### PR TITLE
fix(Button): handle invalid React children for icon props and add Lucid icon picker

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import React from 'react';
 import { Button } from './Button';
 import {
   Plus,
@@ -52,8 +51,8 @@ import {
 } from 'lucide-react';
 
 // Icon registry for Storybook controls
-const iconRegistry: Record<string, LucideIcon> = {
-  None: undefined as unknown as LucideIcon,
+const iconRegistry: Record<string, LucideIcon | undefined> = {
+  None: undefined,
   Plus,
   Minus,
   Check,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -78,10 +78,10 @@ export interface ButtonProps
   extends
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  /** Optional icon to render before the button text */
-  leftIcon?: React.ReactNode;
-  /** Optional icon to render after the button text */
-  rightIcon?: React.ReactNode;
+  /** Optional icon element to render before the button text */
+  leftIcon?: React.ReactElement | null;
+  /** Optional icon element to render after the button text */
+  rightIcon?: React.ReactElement | null;
   /** Shows a loading spinner and disables the button */
   isLoading?: boolean;
   /** Accessible label for the loading state */


### PR DESCRIPTION
Added lucid icon options to the button, and dropdowns to preview them on the component

https://github.com/user-attachments/assets/fe42d1e2-fa0f-4bc5-b489-97c6271ee4b1

