### PR TITLE
fix(RecordButton): Fix temporal dead zone error breaking Dashboard

### DIFF
--- a/src/components/RecordButton/RecordButton.tsx
+++ b/src/components/RecordButton/RecordButton.tsx
@@ -261,6 +261,23 @@ function RecordButton({
     };
   }, []);
 
+  const stopRecording = React.useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+    }
+
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state !== 'inactive'
+    ) {
+      mediaRecorderRef.current.stop();
+    }
+
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+    }
+  }, []);
+
   const startRecording = React.useCallback(async () => {
     if (disabled || isRecording || isProcessing) return;
 
@@ -326,23 +343,6 @@ function RecordButton({
     onError,
     stopRecording,
   ]);
-
-  const stopRecording = React.useCallback(() => {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-    }
-
-    if (
-      mediaRecorderRef.current &&
-      mediaRecorderRef.current.state !== 'inactive'
-    ) {
-      mediaRecorderRef.current.stop();
-    }
-
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => track.stop());
-    }
-  }, []);
 
   const handleClick = React.useCallback(() => {
     if (isRecording) {


### PR DESCRIPTION
Move stopRecording callback definition before startRecording to fix 'Cannot access stopRecording before initialization' ReferenceError.

The issue occurred because startRecording referenced stopRecording in both its function body (for maxDuration auto-stop) and its dependency array, but stopRecording was defined after startRecording. JavaScript's temporal dead zone prevents accessing const/let variables before their declaration, even within useCallback closures.

This bug prevented the Dashboard example page and any component using RecordButton from rendering in Storybook.

<img width="1960" height="1206" alt="image" src="https://github.com/user-attachments/assets/f820e286-8388-4151-a74c-6793159710fb" />
