### PR TITLE
feat: improve Default story with dynamic orientation-based width

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -64,15 +64,29 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    children: 'This is a basic card with default padding.',
+    orientation: 'vertical',
   },
-  decorators: [
-    (Story) => (
-      <div style={{ width: '350px' }}>
-        <Story />
-      </div>
-    ),
-  ],
+  render: (args) => (
+    <div
+      style={{ width: args.orientation === 'horizontal' ? '500px' : '350px' }}
+    >
+      <Card {...args}>
+        <CardHeader>
+          <CardTitle>Card Title</CardTitle>
+          <CardDescription>Card description goes here.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>This is the main content area of the card.</p>
+        </CardContent>
+        <CardFooter className="gap-2">
+          <Button variant="outline" size="sm">
+            Cancel
+          </Button>
+          <Button size="sm">Submit</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  ),
 };
 
 export const WithHeaderAndContent: Story = {


### PR DESCRIPTION
- Update Default story to use render function with meaningful content
- Add CardHeader, CardTitle, CardDescription, CardContent, CardFooter
- Set orientation: 'vertical' as default in args so control works
- Make container width dynamic (500px horizontal, 350px vertical)
- Add gap-2 to CardFooter for proper button spacing

The orientation control was not working because the Default story only had plain text children. Changed to include proper Card subcomponents so switching between vertical/horizontal actually shows a visible layout change in the preview.

<img width="1309" height="1205" alt="image" src="https://github.com/user-attachments/assets/b7c7f1a9-0928-4ecd-b578-d32af6e37169" />
