### PR TITLE
feat: add icon selector dropdowns to Button stories and stricter icon types

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,5 +1,114 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from './Button';
+import {
+  Plus,
+  Minus,
+  Check,
+  X,
+  ChevronRight,
+  ChevronLeft,
+  ChevronDown,
+  ChevronUp,
+  ArrowRight,
+  ArrowLeft,
+  Search,
+  Settings,
+  User,
+  Users,
+  Mail,
+  Phone,
+  Calendar,
+  Clock,
+  Heart,
+  Star,
+  Trash2,
+  Edit,
+  Copy,
+  Download,
+  Upload,
+  Share,
+  Send,
+  Save,
+  Loader2,
+  RefreshCw,
+  ExternalLink,
+  Link as LinkIcon,
+  Eye,
+  EyeOff,
+  Lock,
+  Unlock,
+  Bell,
+  BellOff,
+  Home,
+  Menu,
+  MoreHorizontal,
+  MoreVertical,
+  Filter,
+  SortAsc,
+  SortDesc,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react';
+
+// Icon registry for Storybook controls
+const iconRegistry: Record<string, LucideIcon | undefined> = {
+  None: undefined,
+  Plus,
+  Minus,
+  Check,
+  X,
+  ChevronRight,
+  ChevronLeft,
+  ChevronDown,
+  ChevronUp,
+  ArrowRight,
+  ArrowLeft,
+  Search,
+  Settings,
+  User,
+  Users,
+  Mail,
+  Phone,
+  Calendar,
+  Clock,
+  Heart,
+  Star,
+  Trash2,
+  Edit,
+  Copy,
+  Download,
+  Upload,
+  Share,
+  Send,
+  Save,
+  Loader2,
+  RefreshCw,
+  ExternalLink,
+  Link: LinkIcon,
+  Eye,
+  EyeOff,
+  Lock,
+  Unlock,
+  Bell,
+  BellOff,
+  Home,
+  Menu,
+  MoreHorizontal,
+  MoreVertical,
+  Filter,
+  SortAsc,
+  SortDesc,
+  Zap,
+};
+
+const iconOptions = Object.keys(iconRegistry);
+
+// Helper to render icon from name
+const renderIcon = (iconName: string | undefined) => {
+  if (!iconName || iconName === 'None') return undefined;
+  const IconComponent = iconRegistry[iconName];
+  return IconComponent ? <IconComponent size={16} /> : undefined;
+};
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
@@ -25,6 +134,22 @@ const meta: Meta<typeof Button> = {
     },
     disabled: {
       control: 'boolean',
+    },
+    leftIcon: {
+      control: 'select',
+      options: iconOptions,
+      description: 'Icon to display before the button text',
+      mapping: Object.fromEntries(
+        iconOptions.map((name) => [name, renderIcon(name)])
+      ),
+    },
+    rightIcon: {
+      control: 'select',
+      options: iconOptions,
+      description: 'Icon to display after the button text',
+      mapping: Object.fromEntries(
+        iconOptions.map((name) => [name, renderIcon(name)])
+      ),
     },
   },
 };
@@ -119,23 +244,23 @@ export const FullWidth: Story = {
 
 export const WithIcons: Story = {
   args: {
-    children: 'With Icon',
-    leftIcon: (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M5 12h14" />
-        <path d="M12 5v14" />
-      </svg>
-    ),
+    children: 'Add Item',
+    leftIcon: <Plus size={16} />,
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    children: 'Continue',
+    rightIcon: <ChevronRight size={16} />,
+  },
+};
+
+export const WithBothIcons: Story = {
+  args: {
+    children: 'Settings',
+    leftIcon: <Settings size={16} />,
+    rightIcon: <ChevronDown size={16} />,
   },
 };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -78,10 +78,10 @@ export interface ButtonProps
   extends
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  /** Optional icon to render before the button text */
-  leftIcon?: React.ReactNode;
-  /** Optional icon to render after the button text */
-  rightIcon?: React.ReactNode;
+  /** Optional icon element to render before the button text */
+  leftIcon?: React.ReactElement | null;
+  /** Optional icon element to render after the button text */
+  rightIcon?: React.ReactElement | null;
   /** Shows a loading spinner and disables the button */
   isLoading?: boolean;
   /** Accessible label for the loading state */
@@ -120,7 +120,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(buttonVariants({ variant, size, fullWidth }), className)}
         ref={ref}
         disabled={disabled || isLoading}
-        aria-busy={isLoading ? 'true' : 'false'}
+        aria-busy={isLoading}
         {...props}
       >
         {isLoading ? (
@@ -130,9 +130,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           </>
         ) : (
           <>
-            {leftIcon && <span className="shrink-0">{leftIcon}</span>}
+            {React.isValidElement(leftIcon) && (
+              <span className="shrink-0">{leftIcon}</span>
+            )}
             {children}
-            {rightIcon && <span className="shrink-0">{rightIcon}</span>}
+            {React.isValidElement(rightIcon) && (
+              <span className="shrink-0">{rightIcon}</span>
+            )}
           </>
         )}
       </button>
@@ -152,8 +156,7 @@ function LoadingSpinner() {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
-      role="img"
-      aria-label="Loading"
+      aria-hidden="true"
     >
       <circle
         className="opacity-25"


### PR DESCRIPTION
Button.stories.tsx:
- Add Lucide icon imports (~50 icons)
- Create iconRegistry for Storybook dropdown controls
- Add leftIcon/rightIcon argTypes with icon selector dropdowns
- Replace inline SVG with Lucide components
- Add WithRightIcon and WithBothIcons stories

Button.tsx:
- Change leftIcon/rightIcon type from ReactNode to ReactElement | null
- Add React.isValidElement() checks for icon rendering
- Simplify aria-busy attribute

Improves DX with interactive icon selection in Storybook controls.

https://github.com/user-attachments/assets/fe42d1e2-fa0f-4bc5-b489-97c6271ee4b1