### PR TITLE
feat(DateInput): Add calendar picker with width/size props and dark mode fixes

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -42,6 +42,13 @@ html, body {
   color: var(--mieweb-muted-foreground, #a1a1aa) !important;
 }
 
+/* Exception: Allow destructive (error) color to override the muted foreground */
+[data-theme="dark"] .sbdocs p.text-destructive,
+[data-theme="dark"] .sbdocs span.text-destructive,
+[data-theme="dark"] .sbdocs .text-destructive {
+  color: var(--mieweb-destructive) !important;
+}
+
 /* Story preview containers */
 [data-theme="dark"] .docs-story,
 [data-theme="dark"] .sb-story,

--- a/src/components/DateInput/DateInput.stories.tsx
+++ b/src/components/DateInput/DateInput.stories.tsx
@@ -14,10 +14,22 @@ const meta: Meta<typeof DateInput> = {
       control: 'select',
       options: ['default', 'dob', 'expiration', 'past', 'future'],
     },
+    width: {
+      control: 'select',
+      options: ['full', 'fit', 'fixed'],
+      description: 'Width behavior of the input',
+    },
+    showCalendar: {
+      control: 'boolean',
+      description: 'Show calendar picker button',
+    },
+    validateOnBlur: {
+      control: 'boolean',
+    },
   },
   decorators: [
     (Story) => (
-      <div style={{ width: '300px' }}>
+      <div style={{ width: '400px' }}>
         <Story />
       </div>
     ),
@@ -33,6 +45,23 @@ export const Default: Story = {
   },
 };
 
+export const WithCalendar: Story = {
+  args: {
+    label: 'Select Date',
+    showCalendar: true,
+    width: 'fixed',
+  },
+};
+
+export const WithCalendarPreFilled: Story = {
+  args: {
+    label: 'Appointment Date',
+    showCalendar: true,
+    width: 'fixed',
+    value: '06/15/2026',
+  },
+};
+
 export const DateOfBirth: Story = {
   args: {
     label: 'Date of Birth',
@@ -43,10 +72,31 @@ export const DateOfBirth: Story = {
   },
 };
 
+export const DateOfBirthWithCalendar: Story = {
+  args: {
+    label: 'Date of Birth',
+    mode: 'dob',
+    showCalendar: true,
+    validateOnBlur: true,
+    minAge: 18,
+    helperText: 'Must be 18 years or older',
+  },
+};
+
 export const ExpirationDate: Story = {
   args: {
     label: 'License Expiration',
     mode: 'expiration',
+    validateOnBlur: true,
+    helperText: 'Must be a future date',
+  },
+};
+
+export const ExpirationWithCalendar: Story = {
+  args: {
+    label: 'License Expiration',
+    mode: 'expiration',
+    showCalendar: true,
     validateOnBlur: true,
     helperText: 'Must be a future date',
   },

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -8,6 +8,7 @@ import {
   calculateAge,
 } from '../../utils/date';
 import { Input, type InputProps } from '../Input';
+import { Calendar } from 'lucide-react';
 
 export type DateInputMode =
   | 'default'
@@ -15,6 +16,20 @@ export type DateInputMode =
   | 'expiration'
   | 'past'
   | 'future';
+
+export type DateInputWidth = 'full' | 'fit' | 'fixed';
+
+const widthClasses: Record<DateInputWidth, string> = {
+  full: 'w-full',
+  fit: 'w-fit',
+  fixed: 'w-44', // ~176px - enough for MM/DD/YYYY + calendar icon
+};
+
+const sizeClasses = {
+  sm: 'h-8 text-sm',
+  md: 'h-10 text-base',
+  lg: 'h-12 text-lg',
+} as const;
 
 export interface DateInputProps extends Omit<
   InputProps,
@@ -32,6 +47,10 @@ export interface DateInputProps extends Omit<
   maxAge?: number;
   /** Whether to validate on blur */
   validateOnBlur?: boolean;
+  /** Whether to show a calendar picker button */
+  showCalendar?: boolean;
+  /** Width behavior of the input */
+  width?: DateInputWidth;
 }
 
 function getValidationError(
@@ -97,6 +116,12 @@ function getValidationError(
  *   validateOnBlur
  * />
  *
+ * // With calendar picker
+ * <DateInput
+ *   label="Select Date"
+ *   showCalendar
+ * />
+ *
  * // Expiration date
  * <DateInput
  *   label="License Expiration"
@@ -114,6 +139,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       minAge,
       maxAge,
       validateOnBlur,
+      showCalendar = false,
+      width = 'full',
       className,
       onBlur,
       hasError,
@@ -161,6 +188,386 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const autoComplete =
       mode === 'dob' ? 'bday' : mode === 'expiration' ? 'cc-exp' : undefined;
 
+    // Generate stable ID for accessibility
+    const generatedId = React.useId();
+
+    // Calendar picker state
+    const [isCalendarOpen, setIsCalendarOpen] = React.useState(false);
+    const calendarRef = React.useRef<HTMLDivElement>(null);
+    const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+    // Parse current value into date parts for calendar
+    const parsedDate = React.useMemo(() => {
+      if (!displayValue || !isValidDate(displayValue)) {
+        return {
+          month: new Date().getMonth(),
+          year: new Date().getFullYear(),
+          day: null,
+        };
+      }
+      const [month, day, year] = displayValue.split('/').map(Number);
+      return { month: month - 1, year, day };
+    }, [displayValue]);
+
+    const [calendarMonth, setCalendarMonth] = React.useState(parsedDate.month);
+    const [calendarYear, setCalendarYear] = React.useState(parsedDate.year);
+
+    // Update calendar view when value changes
+    React.useEffect(() => {
+      if (displayValue && isValidDate(displayValue)) {
+        const [month, , year] = displayValue.split('/').map(Number);
+        setCalendarMonth(month - 1);
+        setCalendarYear(year);
+      }
+    }, [displayValue]);
+
+    // Close calendar on click outside
+    React.useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (
+          calendarRef.current &&
+          !calendarRef.current.contains(event.target as HTMLElement) &&
+          buttonRef.current &&
+          !buttonRef.current.contains(event.target as HTMLElement)
+        ) {
+          setIsCalendarOpen(false);
+        }
+      };
+
+      if (isCalendarOpen) {
+        document.addEventListener('mousedown', handleClickOutside);
+        return () =>
+          document.removeEventListener('mousedown', handleClickOutside);
+      }
+    }, [isCalendarOpen]);
+
+    // Close on Escape key
+    React.useEffect(() => {
+      const handleEscape = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          setIsCalendarOpen(false);
+          buttonRef.current?.focus();
+        }
+      };
+
+      if (isCalendarOpen) {
+        document.addEventListener('keydown', handleEscape);
+        return () => document.removeEventListener('keydown', handleEscape);
+      }
+    }, [isCalendarOpen]);
+
+    const handleDateSelect = (day: number) => {
+      const month = String(calendarMonth + 1).padStart(2, '0');
+      const dayStr = String(day).padStart(2, '0');
+      const year = String(calendarYear);
+      const formatted = `${month}/${dayStr}/${year}`;
+      setDisplayValue(formatted);
+      onChange?.(formatted);
+      setIsCalendarOpen(false);
+
+      // Validate if needed
+      if (validateOnBlur) {
+        const validationError = getValidationError(
+          formatted,
+          mode,
+          minAge,
+          maxAge
+        );
+        setLocalError(validationError);
+      }
+    };
+
+    const getDaysInMonth = (month: number, year: number) => {
+      return new Date(year, month + 1, 0).getDate();
+    };
+
+    const getFirstDayOfMonth = (month: number, year: number) => {
+      return new Date(year, month, 1).getDay();
+    };
+
+    const renderCalendar = () => {
+      const daysInMonth = getDaysInMonth(calendarMonth, calendarYear);
+      const firstDay = getFirstDayOfMonth(calendarMonth, calendarYear);
+      const days: (number | null)[] = [];
+
+      // Add empty cells for days before the first day of the month
+      for (let i = 0; i < firstDay; i++) {
+        days.push(null);
+      }
+
+      // Add the days of the month
+      for (let i = 1; i <= daysInMonth; i++) {
+        days.push(i);
+      }
+
+      const monthNames = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ];
+
+      const isSelectedDay = (day: number) => {
+        return (
+          parsedDate.day === day &&
+          parsedDate.month === calendarMonth &&
+          parsedDate.year === calendarYear
+        );
+      };
+
+      const isToday = (day: number) => {
+        const today = new Date();
+        return (
+          day === today.getDate() &&
+          calendarMonth === today.getMonth() &&
+          calendarYear === today.getFullYear()
+        );
+      };
+
+      return (
+        <div
+          ref={calendarRef}
+          className={cn(
+            'absolute top-full left-0 z-50 mt-1',
+            'bg-background border-border rounded-lg border shadow-lg',
+            'w-72 p-3'
+          )}
+          role="dialog"
+          aria-label="Choose date"
+        >
+          {/* Header with month/year navigation */}
+          <div className="mb-3 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => {
+                if (calendarMonth === 0) {
+                  setCalendarMonth(11);
+                  setCalendarYear(calendarYear - 1);
+                } else {
+                  setCalendarMonth(calendarMonth - 1);
+                }
+              }}
+              className="hover:bg-muted rounded-md p-1 transition-colors"
+              aria-label="Previous month"
+            >
+              <ChevronLeftIcon />
+            </button>
+            <div className="flex items-center gap-2">
+              <select
+                value={calendarMonth}
+                onChange={(e) => setCalendarMonth(Number(e.target.value))}
+                className="bg-background border-border rounded border px-2 py-1 text-sm"
+                aria-label="Select month"
+              >
+                {monthNames.map((name, i) => (
+                  <option key={name} value={i}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={calendarYear}
+                onChange={(e) => setCalendarYear(Number(e.target.value))}
+                className="bg-background border-border rounded border px-2 py-1 text-sm"
+                aria-label="Select year"
+              >
+                {Array.from(
+                  { length: 150 },
+                  (_, i) => new Date().getFullYear() - 100 + i
+                ).map((year) => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                if (calendarMonth === 11) {
+                  setCalendarMonth(0);
+                  setCalendarYear(calendarYear + 1);
+                } else {
+                  setCalendarMonth(calendarMonth + 1);
+                }
+              }}
+              className="hover:bg-muted rounded-md p-1 transition-colors"
+              aria-label="Next month"
+            >
+              <ChevronRightIcon />
+            </button>
+          </div>
+
+          {/* Day headers */}
+          <div className="mb-1 grid grid-cols-7 gap-1">
+            {['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].map((day) => (
+              <div
+                key={day}
+                className="text-muted-foreground py-1 text-center text-xs font-medium"
+              >
+                {day}
+              </div>
+            ))}
+          </div>
+
+          {/* Calendar grid */}
+          <div className="grid grid-cols-7 gap-1">
+            {days.map((day, index) => (
+              <button
+                key={index}
+                type="button"
+                disabled={day === null}
+                onClick={() => day && handleDateSelect(day)}
+                className={cn(
+                  'h-8 w-8 rounded-md text-sm transition-colors',
+                  'focus:ring-ring focus:ring-2 focus:outline-none',
+                  day === null && 'invisible',
+                  day !== null && 'hover:bg-muted',
+                  isSelectedDay(day!) &&
+                    'bg-primary-800 hover:bg-primary-700 text-white',
+                  isToday(day!) &&
+                    !isSelectedDay(day!) &&
+                    'border-primary-800 text-primary-800 border'
+                )}
+              >
+                {day}
+              </button>
+            ))}
+          </div>
+
+          {/* Today button */}
+          <div className="border-border mt-3 border-t pt-3">
+            <button
+              type="button"
+              onClick={() => {
+                const today = new Date();
+                setCalendarMonth(today.getMonth());
+                setCalendarYear(today.getFullYear());
+                handleDateSelect(today.getDate());
+              }}
+              className="text-primary-800 w-full text-sm hover:underline"
+            >
+              Today
+            </button>
+          </div>
+        </div>
+      );
+    };
+
+    if (showCalendar) {
+      // Extract label/error/helper and component-specific props to handle positioning correctly
+      // Filter out Input component props that aren't valid HTML input attributes
+      const { label, helperText, hideLabel, required, size, ...inputProps } =
+        props;
+      // Ensure size has a valid value (fallback to 'md' if null/undefined)
+      const resolvedSize = size ?? 'md';
+      const inputId = inputProps.id || generatedId;
+      const errorId = `${inputId}-error`;
+      const helperId = `${inputId}-helper`;
+      const showError = hasError || !!localError;
+      const errorMessage = error || localError;
+
+      return (
+        <div className={cn('flex flex-col gap-1.5', widthClasses[width])}>
+          {label && (
+            <label
+              htmlFor={inputId}
+              className={cn(
+                'text-foreground text-sm font-medium',
+                hideLabel && 'sr-only'
+              )}
+            >
+              {label}
+              {required && (
+                <span
+                  className="ml-1"
+                  style={{ color: '#ef4444' }}
+                  aria-hidden="true"
+                >
+                  *
+                </span>
+              )}
+            </label>
+          )}
+          <div className="relative">
+            <input
+              ref={ref}
+              id={inputId}
+              type="text"
+              inputMode="numeric"
+              autoComplete={autoComplete}
+              placeholder={placeholder}
+              value={displayValue}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              aria-invalid={showError}
+              aria-describedby={
+                [errorMessage ? errorId : null, helperText ? helperId : null]
+                  .filter(Boolean)
+                  .join(' ') || undefined
+              }
+              className={cn(
+                'w-full px-3 py-2',
+                'rounded-lg border',
+                'bg-background text-foreground',
+                'placeholder:text-muted-foreground',
+                'transition-colors duration-200',
+                'focus:ring-ring focus:border-transparent focus:ring-2 focus:outline-none',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                sizeClasses[resolvedSize],
+                showError
+                  ? 'border-destructive focus:ring-destructive'
+                  : 'border-input',
+                'pr-10',
+                className
+              )}
+              {...inputProps}
+            />
+            <button
+              ref={buttonRef}
+              type="button"
+              onClick={() => setIsCalendarOpen(!isCalendarOpen)}
+              className={cn(
+                'absolute top-1/2 right-3 -translate-y-1/2',
+                'text-muted-foreground hover:text-foreground',
+                'focus:text-foreground focus:outline-none',
+                'transition-colors'
+              )}
+              aria-label="Open calendar"
+              aria-expanded={isCalendarOpen}
+              aria-haspopup="dialog"
+            >
+              <Calendar size={18} />
+            </button>
+            {isCalendarOpen && renderCalendar()}
+          </div>
+          {errorMessage && (
+            <p
+              id={errorId}
+              className="text-sm"
+              style={{ color: '#ef4444' }}
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          )}
+          {helperText && !errorMessage && (
+            <p id={helperId} className="text-muted-foreground text-sm">
+              {helperText}
+            </p>
+          )}
+        </div>
+      );
+    }
+
     return (
       <Input
         ref={ref}
@@ -173,7 +580,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         onBlur={handleBlur}
         hasError={hasError || !!localError}
         error={error || localError}
-        className={cn(className)}
+        className={cn(widthClasses[width], className)}
         {...props}
       />
     );
@@ -181,5 +588,40 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 );
 
 DateInput.displayName = 'DateInput';
+
+// Simple icon components
+function ChevronLeftIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
 
 export { DateInput };


### PR DESCRIPTION
Features:
- Add showCalendar prop to display a calendar icon button
- Calendar picker with month/year dropdown navigation
- Click outside and Escape key to close calendar
- Today button for quick date selection
- Pre-filled dates highlight selected day

Props:
- Add width prop with 'full', 'fit', 'fixed' options
- Support size variants (sm, md, lg) for calendar version
- Properly handle required asterisk and error states

Styling:
- Calendar popup with proper dark mode support
- Selected day and today highlighting
- Responsive positioning relative to input

Fixes:
- Fix calendar icon positioning with label/error/helper text
- Fix size prop type handling (null/undefined fallback to 'md')
- Use inline styles for error/required colors to avoid CSS specificity issues

Storybook:
- Add width control dropdown
- Add calendar-specific stories (WithCalendar, WithCalendarPreFilled, etc.)
- Fix text-destructive color override in docs dark mode"


https://github.com/user-attachments/assets/4609dcb5-7cd1-48be-98aa-a2f80b863a2c


