### PR TITLE
fix(Pagination): make onPageChange optional in wrapper component types

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -8,7 +8,9 @@ function PaginationWithState({
   totalPages = 10,
   onPageChange,
   ...props
-}: React.ComponentProps<typeof Pagination>) {
+}: Omit<React.ComponentProps<typeof Pagination>, 'onPageChange'> & {
+  onPageChange?: (page: number) => void;
+}) {
   const [page, setPage] = React.useState(initialPage);
 
   const handlePageChange = (newPage: number) => {
@@ -168,7 +170,9 @@ function SimplePaginationWithState({
   totalPages = 10,
   onPageChange,
   ...props
-}: React.ComponentProps<typeof SimplePagination>) {
+}: Omit<React.ComponentProps<typeof SimplePagination>, 'onPageChange'> & {
+  onPageChange?: (page: number) => void;
+}) {
   const [page, setPage] = React.useState(initialPage);
 
   const handlePageChange = (newPage: number) => {


### PR DESCRIPTION
The PaginationWithState and SimplePaginationWithState wrapper components manage their own internal page state and provide onPageChange to the underlying Pagination component. However, the wrapper's props type was using React.ComponentProps<typeof Pagination> directly, which includes onPageChange as a required prop.

This caused TypeScript errors in the showcase stories (AllVariants, AllSizes) where the wrapper is used without passing onPageChange, since the wrapper handles it internally.

Fix: Change the wrapper props type to:
  Omit<React.ComponentProps<typeof Pagination>, 'onPageChange'> & {
    onPageChange?: (page: number) => void;
  }

This makes onPageChange optional for callers while still allowing them to pass a callback if they want to be notified of page changes.

