### PR TITLE
feat(QuickAction): overhaul stories with icon dropdown and fix theme …

### DIFF
--- a/src/components/QuickAction/QuickAction.stories.tsx
+++ b/src/components/QuickAction/QuickAction.stories.tsx
@@ -1,5 +1,76 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { QuickAction, QuickActionGroup, QuickActionIcons } from './QuickAction';
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QuickAction, QuickActionGroup } from './QuickAction';
+import {
+  CalendarIcon,
+  ClipboardIcon,
+  UserIcon,
+  FileTextIcon,
+  SearchIcon,
+  BellIcon,
+  SettingsIcon,
+  HelpCircleIcon,
+  HomeIcon,
+  MailIcon,
+  PhoneIcon,
+  MapPinIcon,
+  CreditCardIcon,
+  HeartIcon,
+  StarIcon,
+  BookmarkIcon,
+  FolderIcon,
+  DownloadIcon,
+  UploadIcon,
+  ShareIcon,
+  LinkIcon,
+  ImageIcon,
+  CameraIcon,
+  ChartIcon,
+  ActivityIcon,
+  ZapIcon,
+  GlobeIcon,
+  BuildingIcon,
+  BriefcaseIcon,
+  type LucideIcon,
+} from '../Icons';
+
+// Map of available icons for the dropdown
+const iconMap: Record<string, LucideIcon> = {
+  calendar: CalendarIcon,
+  clipboard: ClipboardIcon,
+  user: UserIcon,
+  fileText: FileTextIcon,
+  search: SearchIcon,
+  bell: BellIcon,
+  settings: SettingsIcon,
+  helpCircle: HelpCircleIcon,
+  home: HomeIcon,
+  mail: MailIcon,
+  phone: PhoneIcon,
+  mapPin: MapPinIcon,
+  creditCard: CreditCardIcon,
+  heart: HeartIcon,
+  star: StarIcon,
+  bookmark: BookmarkIcon,
+  folder: FolderIcon,
+  download: DownloadIcon,
+  upload: UploadIcon,
+  share: ShareIcon,
+  link: LinkIcon,
+  image: ImageIcon,
+  camera: CameraIcon,
+  chart: ChartIcon,
+  activity: ActivityIcon,
+  zap: ZapIcon,
+  globe: GlobeIcon,
+  building: BuildingIcon,
+  briefcase: BriefcaseIcon,
+};
+
+// Extended args type that includes our custom iconName prop
+type QuickActionStoryArgs = Omit<React.ComponentProps<typeof QuickAction>, 'icon'> & {
+  iconName?: keyof typeof iconMap;
+};
 
 const meta: Meta<typeof QuickAction> = {
   title: 'Components/QuickAction',
@@ -9,8 +80,16 @@ const meta: Meta<typeof QuickAction> = {
   },
   tags: ['autodocs'],
   argTypes: {
+    title: {
+      control: 'text',
+      description: 'The main title text',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'The subtitle/description text',
+    },
     color: {
-      control: { type: 'select' },
+      control: 'select',
       options: [
         'primary',
         'green',
@@ -21,26 +100,149 @@ const meta: Meta<typeof QuickAction> = {
         'amber',
         'neutral',
       ],
+      description: 'Color theme for the icon background',
     },
     disabled: {
-      control: { type: 'boolean' },
+      control: 'boolean',
+      description: 'Whether the action is disabled',
     },
+    as: {
+      control: 'select',
+      options: ['button', 'a'],
+      description: 'Render as button or anchor',
+    },
+    href: {
+      control: 'text',
+      description: 'URL when rendered as a link',
+      if: { arg: 'as', eq: 'a' },
+    },
+    icon: {
+      table: { disable: true }, // Hide the raw icon prop
+    },
+    iconName: {
+      control: 'select',
+      options: Object.keys(iconMap),
+      description: 'Select an icon from the Lucide icon library',
+    },
+  } as Meta<QuickActionStoryArgs>['argTypes'],
+  // Convert iconName to actual icon element in render
+  render: ({ iconName = 'calendar', ...args }: QuickActionStoryArgs) => {
+    const IconComponent = iconMap[iconName];
+    return <QuickAction {...args} icon={<IconComponent className="h-5 w-5" />} />;
   },
 };
 
 export default meta;
-type Story = StoryObj<typeof QuickAction>;
+type Story = StoryObj<QuickActionStoryArgs>;
 
 export const Default: Story = {
   args: {
     title: 'Schedule Exam',
     subtitle: 'Find providers nearby',
-    icon: <QuickActionIcons.Calendar />,
+    iconName: 'calendar',
     color: 'primary',
+    disabled: false,
   },
 };
 
+export const Green: Story = {
+  args: {
+    ...Default.args,
+    title: 'My Orders',
+    subtitle: 'View history',
+    iconName: 'clipboard',
+    color: 'green',
+  },
+};
+
+export const Purple: Story = {
+  args: {
+    ...Default.args,
+    title: 'My Profile',
+    subtitle: 'Update your info',
+    iconName: 'user',
+    color: 'purple',
+  },
+};
+
+export const Orange: Story = {
+  args: {
+    ...Default.args,
+    title: 'Documents',
+    subtitle: 'Medical cards & records',
+    iconName: 'fileText',
+    color: 'orange',
+  },
+};
+
+export const Blue: Story = {
+  args: {
+    ...Default.args,
+    title: 'Search',
+    subtitle: 'Find anything',
+    iconName: 'search',
+    color: 'blue',
+  },
+};
+
+export const Red: Story = {
+  args: {
+    ...Default.args,
+    title: 'Alerts',
+    subtitle: 'Critical issues',
+    iconName: 'bell',
+    color: 'red',
+  },
+};
+
+export const Amber: Story = {
+  args: {
+    ...Default.args,
+    title: 'Notifications',
+    subtitle: 'View all',
+    iconName: 'bell',
+    color: 'amber',
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    ...Default.args,
+    title: 'Settings',
+    subtitle: 'Configure options',
+    iconName: 'settings',
+    color: 'neutral',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    title: 'Disabled Action',
+    subtitle: 'This action is disabled',
+    iconName: 'calendar',
+    color: 'primary',
+    disabled: true,
+  },
+};
+
+export const AsLink: Story = {
+  args: {
+    ...Default.args,
+    title: 'Documentation',
+    subtitle: 'View the docs',
+    iconName: 'fileText',
+    color: 'purple',
+    as: 'a',
+    href: '#docs',
+  },
+};
+
+// Showcase stories with custom render
 export const AllColors: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div
       className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
@@ -49,112 +251,84 @@ export const AllColors: Story = {
       <QuickAction
         title="Schedule Exam"
         subtitle="Find providers nearby"
-        icon={<QuickActionIcons.Calendar />}
+        icon={<CalendarIcon className="h-5 w-5" />}
         color="primary"
       />
       <QuickAction
         title="My Orders"
         subtitle="View history"
-        icon={<QuickActionIcons.Clipboard />}
+        icon={<ClipboardIcon className="h-5 w-5" />}
         color="green"
       />
       <QuickAction
         title="My Profile"
         subtitle="Update your info"
-        icon={<QuickActionIcons.User />}
+        icon={<UserIcon className="h-5 w-5" />}
         color="purple"
       />
       <QuickAction
         title="Documents"
         subtitle="Medical cards & records"
-        icon={<QuickActionIcons.Document />}
+        icon={<FileTextIcon className="h-5 w-5" />}
         color="orange"
       />
       <QuickAction
         title="Search"
         subtitle="Find anything"
-        icon={<QuickActionIcons.Search />}
+        icon={<SearchIcon className="h-5 w-5" />}
         color="blue"
       />
       <QuickAction
         title="Alerts"
         subtitle="Critical issues"
-        icon={<QuickActionIcons.Bell />}
+        icon={<BellIcon className="h-5 w-5" />}
         color="red"
       />
       <QuickAction
         title="Notifications"
         subtitle="View all"
-        icon={<QuickActionIcons.Bell />}
+        icon={<BellIcon className="h-5 w-5" />}
         color="amber"
       />
       <QuickAction
         title="Settings"
         subtitle="Configure options"
-        icon={<QuickActionIcons.Settings />}
+        icon={<SettingsIcon className="h-5 w-5" />}
         color="neutral"
       />
     </div>
   ),
 };
 
-export const Disabled: Story = {
-  args: {
-    title: 'Disabled Action',
-    subtitle: 'This action is disabled',
-    icon: <QuickActionIcons.Calendar />,
-    color: 'primary',
-    disabled: true,
-  },
-};
-
-export const WithClickHandler: Story = {
-  args: {
-    title: 'Clickable Action',
-    subtitle: 'Click me!',
-    icon: <QuickActionIcons.Search />,
-    color: 'blue',
-    onClick: () => console.log('QuickAction clicked!'),
-  },
-};
-
-export const AsLink: Story = {
-  args: {
-    title: 'Documentation',
-    subtitle: 'View the docs',
-    icon: <QuickActionIcons.Document />,
-    color: 'purple',
-    as: 'a',
-    href: '#docs',
-  },
-};
-
 export const GroupWithTitle: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div style={{ width: '900px' }}>
       <QuickActionGroup title="Quick Actions">
         <QuickAction
           title="Schedule Exam"
           subtitle="Find providers nearby"
-          icon={<QuickActionIcons.Calendar />}
+          icon={<CalendarIcon className="h-5 w-5" />}
           color="primary"
         />
         <QuickAction
           title="My Orders"
           subtitle="View history"
-          icon={<QuickActionIcons.Clipboard />}
+          icon={<ClipboardIcon className="h-5 w-5" />}
           color="green"
         />
         <QuickAction
           title="My Profile"
           subtitle="Update your info"
-          icon={<QuickActionIcons.User />}
+          icon={<UserIcon className="h-5 w-5" />}
           color="purple"
         />
         <QuickAction
           title="Documents"
           subtitle="Medical cards & records"
-          icon={<QuickActionIcons.Document />}
+          icon={<FileTextIcon className="h-5 w-5" />}
           color="orange"
         />
       </QuickActionGroup>
@@ -163,19 +337,22 @@ export const GroupWithTitle: Story = {
 };
 
 export const GroupTwoColumns: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div style={{ width: '600px' }}>
       <QuickActionGroup title="Settings" columns={{ sm: 2, lg: 2 }}>
         <QuickAction
           title="Settings"
           subtitle="Configure options"
-          icon={<QuickActionIcons.Settings />}
+          icon={<SettingsIcon className="h-5 w-5" />}
           color="neutral"
         />
         <QuickAction
           title="Help"
           subtitle="Get support"
-          icon={<QuickActionIcons.Help />}
+          icon={<HelpCircleIcon className="h-5 w-5" />}
           color="blue"
         />
       </QuickActionGroup>
@@ -184,31 +361,34 @@ export const GroupTwoColumns: Story = {
 };
 
 export const DashboardExample: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div style={{ width: '900px' }} className="space-y-8">
       <QuickActionGroup title="Quick Actions">
         <QuickAction
           title="Schedule Exam"
           subtitle="Find providers nearby"
-          icon={<QuickActionIcons.Calendar />}
+          icon={<CalendarIcon className="h-5 w-5" />}
           color="primary"
         />
         <QuickAction
           title="My Orders"
           subtitle="3 pending"
-          icon={<QuickActionIcons.Clipboard />}
+          icon={<ClipboardIcon className="h-5 w-5" />}
           color="green"
         />
         <QuickAction
           title="My Profile"
           subtitle="Update your info"
-          icon={<QuickActionIcons.User />}
+          icon={<UserIcon className="h-5 w-5" />}
           color="purple"
         />
         <QuickAction
           title="Documents"
           subtitle="Medical cards & records"
-          icon={<QuickActionIcons.Document />}
+          icon={<FileTextIcon className="h-5 w-5" />}
           color="orange"
         />
       </QuickActionGroup>

--- a/src/components/QuickAction/QuickAction.tsx
+++ b/src/components/QuickAction/QuickAction.tsx
@@ -10,13 +10,13 @@ const quickActionIconVariants = cva(
         primary:
           'bg-primary-100 text-primary-600 dark:bg-primary-900/50 dark:text-primary-400',
         green:
-          'bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400',
+          'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/50 dark:text-emerald-400',
         purple:
-          'bg-secondary-100 text-secondary-600 dark:bg-secondary-900/50 dark:text-secondary-400',
+          'bg-violet-100 text-violet-600 dark:bg-violet-900/50 dark:text-violet-400',
         orange:
           'bg-orange-100 text-orange-600 dark:bg-orange-900/50 dark:text-orange-400',
-        blue: 'bg-primary-100 text-primary-600 dark:bg-primary-900/50 dark:text-primary-400',
-        red: 'bg-red-100 text-red-600 dark:bg-red-900/50 dark:text-red-400',
+        blue: 'bg-sky-100 text-sky-600 dark:bg-sky-900/50 dark:text-sky-400',
+        red: 'bg-rose-100 text-rose-600 dark:bg-rose-900/50 dark:text-rose-400',
         amber:
           'bg-amber-100 text-amber-600 dark:bg-amber-900/50 dark:text-amber-400',
         neutral:


### PR DESCRIPTION
…colors

- Replace JSON editor for icon prop with Lucide icon dropdown selector
- Add 29 icons from the Icons module for easy selection in Storybook
- Use args pattern for all stories to enable working controls on docs page
- Fix purple color: change from undefined 'secondary-*' to 'violet-*'
- Update color variants to use proper Tailwind palette colors:
  - green: emerald (richer green)
  - blue: sky (distinct from primary)
  - red: rose (softer red)
- Keep primary, orange, amber, neutral unchanged
- Add showcase stories for AllColors, GroupWithTitle, DashboardExample

https://github.com/user-attachments/assets/d2a4829c-8098-4439-939b-f85db8695ea0
