### PR TITLE
feat(Radio): overhaul stories with working controls and add responsive font sizing

### DIFF
--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -2,7 +2,54 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { RadioGroup, Radio } from './Radio';
 
-const meta: Meta<typeof RadioGroup> = {
+// Wrapper component to handle controlled state for stories
+function RadioGroupWithState(
+  props: Omit<React.ComponentProps<typeof RadioGroup>, 'children'> & {
+    options?: Array<{ value: string; label: string; description?: string; disabled?: boolean }>;
+  }
+) {
+  const {
+    options = [
+      { value: 'option-a', label: 'Option A' },
+      { value: 'option-b', label: 'Option B' },
+      { value: 'option-c', label: 'Option C' },
+    ],
+    defaultValue,
+    ...rest
+  } = props;
+
+  const [value, setValue] = React.useState(defaultValue || '');
+
+  return (
+    <RadioGroup
+      {...rest}
+      value={value}
+      onValueChange={setValue}
+      defaultValue={undefined}
+    >
+      {options.map((opt) => (
+        <Radio
+          key={opt.value}
+          value={opt.value}
+          label={opt.label}
+          description={opt.description}
+          disabled={opt.disabled}
+        />
+      ))}
+    </RadioGroup>
+  );
+}
+
+// Extended args type for wrapper
+type RadioGroupStoryArgs = Omit<
+  React.ComponentProps<typeof RadioGroup>,
+  'children' | 'onValueChange'
+> & {
+  options?: Array<{ value: string; label: string; description?: string; disabled?: boolean }>;
+  onValueChange?: (value: string) => void;
+};
+
+const meta = {
   title: 'Components/Radio',
   component: RadioGroup,
   parameters: {
@@ -10,151 +57,206 @@ const meta: Meta<typeof RadioGroup> = {
   },
   tags: ['autodocs'],
   argTypes: {
+    name: {
+      control: 'text',
+      description: 'Group name (required for native form behavior)',
+    },
+    label: {
+      control: 'text',
+      description: 'Group label displayed above the options',
+    },
+    description: {
+      control: 'text',
+      description: 'Description text below the label',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
+      description: 'Size of all radio buttons',
     },
     orientation: {
       control: 'select',
       options: ['horizontal', 'vertical'],
+      description: 'Layout orientation of radio items',
     },
     disabled: {
       control: 'boolean',
+      description: 'Whether all radios are disabled',
     },
+    defaultValue: {
+      control: 'text',
+      description: 'Default selected value (uncontrolled)',
+    },
+    children: {
+      table: { disable: true },
+    },
+    value: {
+      table: { disable: true },
+    },
+    onValueChange: {
+      table: { disable: true },
+    },
+  },
+  render: (args: RadioGroupStoryArgs) => <RadioGroupWithState {...args} />,
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<RadioGroupStoryArgs>;
+
+export const Default: Story = {
+  args: {
+    name: 'plan',
+    label: 'Select a plan',
+    defaultValue: 'option-a',
+    size: 'md',
+    orientation: 'vertical',
+    disabled: false,
   },
 };
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  render: () => (
-    <RadioGroup name="plan" label="Select a plan" defaultValue="free">
-      <Radio value="free" label="Free" />
-      <Radio value="pro" label="Pro" />
-      <Radio value="enterprise" label="Enterprise" />
-    </RadioGroup>
-  ),
-};
-
 export const Horizontal: Story = {
-  render: () => (
-    <RadioGroup
-      name="size"
-      label="Select size"
-      orientation="horizontal"
-      defaultValue="md"
-    >
-      <Radio value="sm" label="Small" />
-      <Radio value="md" label="Medium" />
-      <Radio value="lg" label="Large" />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'size',
+    label: 'Select size',
+    orientation: 'horizontal',
+    defaultValue: 'option-b',
+    size: 'md',
+    options: [
+      { value: 'sm', label: 'Small' },
+      { value: 'md', label: 'Medium' },
+      { value: 'lg', label: 'Large' },
+    ],
+  },
 };
 
 export const WithDescriptions: Story = {
-  render: () => (
-    <RadioGroup
-      name="subscription"
-      label="Choose your subscription"
-      defaultValue="monthly"
-    >
-      <Radio
-        value="monthly"
-        label="Monthly"
-        description="$9.99 per month, cancel anytime"
-      />
-      <Radio
-        value="yearly"
-        label="Yearly"
-        description="$99.99 per year, save 17%"
-      />
-      <Radio
-        value="lifetime"
-        label="Lifetime"
-        description="$299.99 one-time payment"
-      />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'subscription',
+    label: 'Choose your subscription',
+    defaultValue: 'monthly',
+    options: [
+      { value: 'monthly', label: 'Monthly', description: '$9.99 per month, cancel anytime' },
+      { value: 'yearly', label: 'Yearly', description: '$99.99 per year, save 17%' },
+      { value: 'lifetime', label: 'Lifetime', description: '$299.99 one-time payment' },
+    ],
+  },
 };
 
 export const Small: Story = {
-  render: () => (
-    <RadioGroup name="option" label="Options" size="sm" defaultValue="a">
-      <Radio value="a" label="Option A" />
-      <Radio value="b" label="Option B" />
-      <Radio value="c" label="Option C" />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'option-sm',
+    label: 'Options (Small)',
+    size: 'sm',
+    defaultValue: 'option-a',
+  },
 };
 
 export const Large: Story = {
-  render: () => (
-    <RadioGroup name="option" label="Options" size="lg" defaultValue="a">
-      <Radio value="a" label="Option A" />
-      <Radio value="b" label="Option B" />
-      <Radio value="c" label="Option C" />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'option-lg',
+    label: 'Options (Large)',
+    size: 'lg',
+    defaultValue: 'option-a',
+  },
 };
 
 export const WithDisabledOption: Story = {
-  render: () => (
-    <RadioGroup name="option" label="Options" defaultValue="a">
-      <Radio value="a" label="Option A" />
-      <Radio value="b" label="Option B (disabled)" disabled />
-      <Radio value="c" label="Option C" />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'option-disabled',
+    label: 'Options',
+    defaultValue: 'option-a',
+    options: [
+      { value: 'option-a', label: 'Option A' },
+      { value: 'option-b', label: 'Option B (disabled)', disabled: true },
+      { value: 'option-c', label: 'Option C' },
+    ],
+  },
 };
 
 export const GroupDisabled: Story = {
-  render: () => (
-    <RadioGroup
-      name="option"
-      label="Options (disabled)"
-      disabled
-      defaultValue="a"
-    >
-      <Radio value="a" label="Option A" />
-      <Radio value="b" label="Option B" />
-      <Radio value="c" label="Option C" />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'option-group-disabled',
+    label: 'Options (disabled)',
+    disabled: true,
+    defaultValue: 'option-a',
+  },
 };
 
 export const WithError: Story = {
-  render: () => (
-    <RadioGroup
-      name="required"
-      label="Select an option"
-      error="Please select one of the options"
-    >
-      <Radio value="a" label="Option A" />
-      <Radio value="b" label="Option B" />
-      <Radio value="c" label="Option C" />
-    </RadioGroup>
-  ),
+  args: {
+    name: 'required',
+    label: 'Select an option',
+    error: 'Please select one of the options',
+  },
 };
 
 export const WithGroupDescription: Story = {
+  args: {
+    name: 'notification',
+    label: 'Notification preferences',
+    description: 'Choose how you want to receive notifications',
+    defaultValue: 'email',
+    options: [
+      { value: 'email', label: 'Email', description: 'Get notified via email' },
+      { value: 'sms', label: 'SMS', description: 'Get notified via text message' },
+      { value: 'push', label: 'Push', description: 'Get notified via push notification' },
+    ],
+  },
+};
+
+// Showcase stories with custom render (controls disabled)
+export const AllSizes: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
-    <RadioGroup
-      name="notification"
-      label="Notification preferences"
-      description="Choose how you want to receive notifications"
-      defaultValue="email"
-    >
-      <Radio value="email" label="Email" description="Get notified via email" />
+    <div className="flex flex-col gap-8">
+      <RadioGroup name="size-sm" label="Small" size="sm" defaultValue="a">
+        <Radio value="a" label="Option A" />
+        <Radio value="b" label="Option B" />
+      </RadioGroup>
+      <RadioGroup name="size-md" label="Medium (default)" size="md" defaultValue="a">
+        <Radio value="a" label="Option A" />
+        <Radio value="b" label="Option B" />
+      </RadioGroup>
+      <RadioGroup name="size-lg" label="Large" size="lg" defaultValue="a">
+        <Radio value="a" label="Option A" />
+        <Radio value="b" label="Option B" />
+      </RadioGroup>
+    </div>
+  ),
+};
+
+export const PaymentMethodExample: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <RadioGroup name="payment" label="Payment method" defaultValue="card">
       <Radio
-        value="sms"
-        label="SMS"
-        description="Get notified via text message"
+        value="card"
+        label="Credit/Debit Card"
+        description="Pay with Visa, Mastercard, or American Express"
       />
       <Radio
-        value="push"
-        label="Push"
-        description="Get notified via push notification"
+        value="paypal"
+        label="PayPal"
+        description="Pay with your PayPal account"
+      />
+      <Radio
+        value="bank"
+        label="Bank Transfer"
+        description="Direct bank transfer (3-5 business days)"
+      />
+      <Radio
+        value="crypto"
+        label="Cryptocurrency"
+        description="Pay with Bitcoin, Ethereum, or other cryptocurrencies"
+        disabled
       />
     </RadioGroup>
   ),
@@ -183,33 +285,8 @@ function ControlledRadioDemo() {
 }
 
 export const Controlled: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => <ControlledRadioDemo />,
-};
-
-export const PaymentMethodExample: Story = {
-  render: () => (
-    <RadioGroup name="payment" label="Payment method" defaultValue="card">
-      <Radio
-        value="card"
-        label="Credit/Debit Card"
-        description="Pay with Visa, Mastercard, or American Express"
-      />
-      <Radio
-        value="paypal"
-        label="PayPal"
-        description="Pay with your PayPal account"
-      />
-      <Radio
-        value="bank"
-        label="Bank Transfer"
-        description="Direct bank transfer (3-5 business days)"
-      />
-      <Radio
-        value="crypto"
-        label="Cryptocurrency"
-        description="Pay with Bitcoin, Ethereum, or other cryptocurrencies"
-        disabled
-      />
-    </RadioGroup>
-  ),
 };

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -147,12 +147,27 @@ function RadioGroup({
         }
       >
         {label && (
-          <legend className="text-foreground text-sm font-medium">
+          <legend
+            className={cn(
+              'text-foreground font-medium',
+              size === 'sm' && 'text-xs',
+              size === 'md' && 'text-sm',
+              size === 'lg' && 'text-base'
+            )}
+          >
             {label}
           </legend>
         )}
         {description && (
-          <p id={descriptionId} className="text-muted-foreground text-xs">
+          <p
+            id={descriptionId}
+            className={cn(
+              'text-muted-foreground',
+              size === 'sm' && 'text-[10px]',
+              size === 'md' && 'text-xs',
+              size === 'lg' && 'text-sm'
+            )}
+          >
             {description}
           </p>
         )}
@@ -165,7 +180,16 @@ function RadioGroup({
           {children}
         </div>
         {error && (
-          <p id={errorId} className="text-destructive text-sm" role="alert">
+          <p
+            id={errorId}
+            className={cn(
+              'text-destructive',
+              size === 'sm' && 'text-xs',
+              size === 'md' && 'text-sm',
+              size === 'lg' && 'text-base'
+            )}
+            role="alert"
+          >
             {error}
           </p>
         )}
@@ -266,14 +290,25 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
         <label
           htmlFor={radioId}
           className={cn(
-            'text-foreground cursor-pointer text-sm font-medium select-none',
+            'text-foreground cursor-pointer font-medium select-none',
+            size === 'sm' && 'text-xs',
+            size === 'md' && 'text-sm',
+            size === 'lg' && 'text-base',
             isDisabled && 'cursor-not-allowed opacity-50'
           )}
         >
           {label}
         </label>
         {description && (
-          <p id={descriptionId} className="text-muted-foreground text-xs">
+          <p
+            id={descriptionId}
+            className={cn(
+              'text-muted-foreground',
+              size === 'sm' && 'text-[10px]',
+              size === 'md' && 'text-xs',
+              size === 'lg' && 'text-sm'
+            )}
+          >
             {description}
           </p>
         )}


### PR DESCRIPTION
Stories improvements:
- Replace render functions with args pattern for working Storybook controls
- Add RadioGroupWithState wrapper to handle internal selection state
- Add argTypes for name, label, description, error, size, orientation, disabled
- Hide children, value, onValueChange from controls (handled by wrapper)
- Add showcase stories: AllSizes, PaymentMethodExample, Controlled
- Showcase stories have controls disabled since they're demos

Component improvements:
- Make font sizes scale with size prop (sm/md/lg):
  - sm: text-xs labels, text-[10px] descriptions
  - md: text-sm labels, text-xs descriptions
  - lg: text-base labels, text-sm descriptions
- Apply responsive sizing to group label, group description, error message
- Apply responsive sizing to radio label and description

https://github.com/user-attachments/assets/49734278-1346-403d-a3e0-6506bf7ef9b9
