### PR TITLE
feat(Table): add interactive Playground story with column controls

### DIFF
--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   Skeleton,
@@ -6,15 +7,279 @@ import {
   SkeletonTable,
 } from './Skeleton';
 
-const meta: Meta<typeof Skeleton> = {
+// =============================================================================
+// Example Types
+// =============================================================================
+
+type ExampleType =
+  | 'custom'
+  | 'default'
+  | 'text'
+  | 'title'
+  | 'avatar'
+  | 'button'
+  | 'image'
+  | 'textBlock'
+  | 'card'
+  | 'cardWithoutImage'
+  | 'cardMinimal'
+  | 'table'
+  | 'profileCard'
+  | 'listItems';
+
+// =============================================================================
+// Wrapper Component
+// =============================================================================
+
+interface SkeletonExampleProps {
+  example: ExampleType;
+  /** Custom width (CSS value like '100%' or '200px') */
+  customWidth?: string;
+  /** Custom height in pixels */
+  customHeight?: number;
+  /** Custom variant */
+  customVariant?:
+    | 'default'
+    | 'text'
+    | 'title'
+    | 'avatar'
+    | 'button'
+    | 'card'
+    | 'image';
+  /** Custom border radius */
+  customRounded?: 'none' | 'sm' | 'md' | 'lg' | 'full';
+  /** Avatar size in pixels */
+  avatarSize?: number;
+  /** Number of text lines (for textBlock) */
+  textLines?: number;
+  /** Last line width (for textBlock) */
+  lastLineWidth?: string;
+  /** Text gap size (for textBlock) */
+  textGap?: 'sm' | 'md' | 'lg';
+  /** Show image in card */
+  cardShowImage?: boolean;
+  /** Show avatar in card */
+  cardShowAvatar?: boolean;
+  /** Number of text lines in card */
+  cardTextLines?: number;
+  /** Number of table rows */
+  tableRows?: number;
+  /** Number of table columns */
+  tableColumns?: number;
+  /** Number of list items */
+  listItemCount?: number;
+}
+
+function SkeletonExample({
+  example,
+  customWidth = '100%',
+  customHeight = 40,
+  customVariant = 'default',
+  customRounded = 'md',
+  avatarSize = 48,
+  textLines = 4,
+  lastLineWidth = '70%',
+  textGap = 'sm',
+  cardShowImage = true,
+  cardShowAvatar = true,
+  cardTextLines = 2,
+  tableRows = 5,
+  tableColumns = 4,
+  listItemCount = 4,
+}: SkeletonExampleProps) {
+  const roundedClasses = {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    full: 'rounded-full',
+  };
+
+  switch (example) {
+    case 'custom':
+      return (
+        <div className="w-80">
+          <Skeleton
+            variant={customVariant}
+            width={customWidth}
+            height={customHeight}
+            className={roundedClasses[customRounded]}
+          />
+        </div>
+      );
+
+    case 'default':
+      return (
+        <div className="w-80">
+          <Skeleton width="100%" height={40} />
+        </div>
+      );
+
+    case 'text':
+      return (
+        <div className="w-80">
+          <Skeleton variant="text" />
+        </div>
+      );
+
+    case 'title':
+      return (
+        <div className="w-80">
+          <Skeleton variant="title" width="60%" />
+        </div>
+      );
+
+    case 'avatar':
+      return (
+        <div className="flex items-center justify-center">
+          <Skeleton circle width={avatarSize} height={avatarSize} />
+        </div>
+      );
+
+    case 'button':
+      return (
+        <div className="flex gap-2">
+          <Skeleton variant="button" />
+        </div>
+      );
+
+    case 'image':
+      return (
+        <div className="w-80">
+          <Skeleton variant="image" className="rounded-lg" />
+        </div>
+      );
+
+    case 'textBlock':
+      return (
+        <div className="w-80">
+          <SkeletonText
+            lines={textLines}
+            lastLineWidth={lastLineWidth}
+            gap={textGap}
+          />
+        </div>
+      );
+
+    case 'card':
+      return (
+        <div className="w-80">
+          <SkeletonCard
+            showImage={cardShowImage}
+            showAvatar={cardShowAvatar}
+            textLines={cardTextLines}
+          />
+        </div>
+      );
+
+    case 'cardWithoutImage':
+      return (
+        <div className="w-80">
+          <SkeletonCard
+            showImage={false}
+            showAvatar={cardShowAvatar}
+            textLines={cardTextLines}
+          />
+        </div>
+      );
+
+    case 'cardMinimal':
+      return (
+        <div className="w-80">
+          <SkeletonCard
+            showImage={false}
+            showAvatar={false}
+            textLines={cardTextLines}
+          />
+        </div>
+      );
+
+    case 'table':
+      return (
+        <div className="w-full max-w-2xl">
+          <SkeletonTable rows={tableRows} columns={tableColumns} />
+        </div>
+      );
+
+    case 'profileCard':
+      return (
+        <div className="border-border bg-card w-80 rounded-xl border p-4">
+          <div className="mb-4 flex items-center gap-4">
+            <Skeleton circle width={64} height={64} />
+            <div className="flex-1 space-y-2">
+              <Skeleton variant="title" width="70%" />
+              <Skeleton variant="text" width="50%" />
+            </div>
+          </div>
+          <SkeletonText lines={3} gap="md" />
+          <div className="mt-4 flex gap-2">
+            <Skeleton variant="button" className="flex-1" />
+            <Skeleton variant="button" className="flex-1" />
+          </div>
+        </div>
+      );
+
+    case 'listItems':
+      return (
+        <div className="w-80 space-y-4">
+          {Array.from({ length: listItemCount }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton circle width={40} height={40} />
+              <div className="flex-1 space-y-2">
+                <Skeleton variant="text" width="80%" />
+                <Skeleton variant="text" width="60%" />
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}
+
+// =============================================================================
+// Meta Configuration
+// =============================================================================
+
+const meta = {
   title: 'Components/Skeleton',
-  component: Skeleton,
+  component: SkeletonExample,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   argTypes: {
-    variant: {
+    example: {
+      control: 'select',
+      options: [
+        'custom',
+        'default',
+        'text',
+        'title',
+        'avatar',
+        'button',
+        'image',
+        'textBlock',
+        'card',
+        'cardWithoutImage',
+        'cardMinimal',
+        'table',
+        'profileCard',
+        'listItems',
+      ],
+      description: 'Type of skeleton example to display',
+    },
+    customWidth: {
+      control: 'text',
+      description: 'Width (CSS value like "100%" or "200px")',
+    },
+    customHeight: {
+      control: { type: 'number', min: 8, max: 400 },
+      description: 'Height in pixels',
+    },
+    customVariant: {
       control: 'select',
       options: [
         'default',
@@ -25,160 +290,261 @@ const meta: Meta<typeof Skeleton> = {
         'card',
         'image',
       ],
-      description: 'The visual style variant of the skeleton',
-      table: {
-        defaultValue: { summary: 'default' },
-      },
+      description: 'Variant type',
     },
-    width: {
+    customRounded: {
+      control: 'select',
+      options: ['none', 'sm', 'md', 'lg', 'full'],
+      description: 'Border radius',
+    },
+    avatarSize: {
+      control: { type: 'number', min: 24, max: 128 },
+      description: 'Avatar size in pixels',
+      if: { arg: 'example', eq: 'avatar' },
+    },
+    textLines: {
+      control: { type: 'number', min: 1, max: 10 },
+      description: 'Number of text lines',
+      if: { arg: 'example', eq: 'textBlock' },
+    },
+    lastLineWidth: {
       control: 'text',
-      description:
-        'Width of the skeleton (number for px or string for CSS value)',
+      description: 'Width of the last line',
+      if: { arg: 'example', eq: 'textBlock' },
     },
-    height: {
-      control: 'text',
-      description:
-        'Height of the skeleton (number for px or string for CSS value)',
+    textGap: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Gap between text lines',
+      if: { arg: 'example', eq: 'textBlock' },
     },
-    circle: {
+    cardShowImage: {
       control: 'boolean',
-      description: 'Whether to render as a circle (rounded-full)',
+      description: 'Show image in card',
+      if: { arg: 'example', eq: 'card' },
     },
-    className: {
-      control: 'text',
-      description: 'Additional CSS classes',
+    cardShowAvatar: {
+      control: 'boolean',
+      description: 'Show avatar in card',
+      if: { arg: 'example', eq: 'card' },
+    },
+    cardTextLines: {
+      control: { type: 'number', min: 0, max: 10 },
+      description: 'Number of text lines in card',
+      if: { arg: 'example', eq: 'card' },
+    },
+    tableRows: {
+      control: { type: 'number', min: 1, max: 20 },
+      description: 'Number of table rows',
+      if: { arg: 'example', eq: 'table' },
+    },
+    tableColumns: {
+      control: { type: 'number', min: 1, max: 10 },
+      description: 'Number of table columns',
+      if: { arg: 'example', eq: 'table' },
+    },
+    listItemCount: {
+      control: { type: 'number', min: 1, max: 10 },
+      description: 'Number of list items',
+      if: { arg: 'example', eq: 'listItems' },
     },
   },
-};
+} satisfies Meta<typeof SkeletonExample>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// =============================================================================
+// Stories with Args (Controls Work)
+// =============================================================================
+
 export const Default: Story = {
-  render: () => (
-    <div className="w-80">
-      <Skeleton width="100%" height={40} />
-    </div>
-  ),
+  args: {
+    example: 'custom',
+    customWidth: '200px',
+    customHeight: 40,
+    customVariant: 'default',
+    customRounded: 'md',
+  },
 };
 
 export const Text: Story = {
-  render: () => (
-    <div className="w-80">
-      <Skeleton variant="text" />
-    </div>
-  ),
+  args: {
+    example: 'text',
+  },
 };
 
 export const Title: Story = {
-  render: () => (
-    <div className="w-80">
-      <Skeleton variant="title" width="60%" />
-    </div>
-  ),
+  args: {
+    example: 'title',
+  },
 };
 
 export const Avatar: Story = {
+  args: {
+    example: 'avatar',
+    avatarSize: 48,
+  },
+};
+
+export const Button: Story = {
+  args: {
+    example: 'button',
+  },
+};
+
+export const Image: Story = {
+  args: {
+    example: 'image',
+  },
+};
+
+export const TextBlock: Story = {
+  args: {
+    example: 'textBlock',
+    textLines: 4,
+    lastLineWidth: '70%',
+    textGap: 'sm',
+  },
+};
+
+export const Card: Story = {
+  args: {
+    example: 'card',
+    cardShowImage: true,
+    cardShowAvatar: true,
+    cardTextLines: 2,
+  },
+};
+
+export const CardWithoutImage: Story = {
+  args: {
+    example: 'cardWithoutImage',
+    cardShowAvatar: true,
+    cardTextLines: 3,
+  },
+};
+
+export const CardMinimal: Story = {
+  args: {
+    example: 'cardMinimal',
+    cardTextLines: 2,
+  },
+};
+
+export const Table: Story = {
+  args: {
+    example: 'table',
+    tableRows: 5,
+    tableColumns: 4,
+  },
+};
+
+export const ProfileCard: Story = {
+  args: {
+    example: 'profileCard',
+  },
+};
+
+export const ListItems: Story = {
+  args: {
+    example: 'listItems',
+    listItemCount: 4,
+  },
+};
+
+// =============================================================================
+// Showcase Stories (Controls Disabled)
+// =============================================================================
+
+export const AvatarSizes: Story = {
+  args: {
+    example: 'avatar',
+  },
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div className="flex items-center gap-3">
+      <Skeleton circle width={32} height={32} />
       <Skeleton circle width={40} height={40} />
       <Skeleton circle width={48} height={48} />
       <Skeleton circle width={56} height={56} />
+      <Skeleton circle width={64} height={64} />
     </div>
   ),
 };
 
-export const Button: Story = {
+export const ButtonVariations: Story = {
+  args: {
+    example: 'button',
+  },
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div className="flex gap-2">
-      <Skeleton variant="button" />
+      <Skeleton variant="button" width={80} />
       <Skeleton variant="button" width={100} />
+      <Skeleton variant="button" width={120} />
       <Skeleton variant="button" width={150} />
     </div>
   ),
 };
 
-export const Image: Story = {
-  render: () => (
-    <div className="w-80">
-      <Skeleton variant="image" className="rounded-lg" />
-    </div>
-  ),
-};
-
-export const TextBlock: Story = {
-  render: () => (
-    <div className="w-80">
-      <SkeletonText lines={4} lastLineWidth="70%" />
-    </div>
-  ),
-};
-
-export const Card: Story = {
-  render: () => (
-    <div className="w-80">
-      <SkeletonCard showImage showAvatar textLines={2} />
-    </div>
-  ),
-};
-
-export const CardWithoutImage: Story = {
-  render: () => (
-    <div className="w-80">
-      <SkeletonCard showImage={false} showAvatar textLines={3} />
-    </div>
-  ),
-};
-
-export const Table: Story = {
-  render: () => (
-    <div className="w-full max-w-2xl">
-      <SkeletonTable rows={5} columns={4} />
-    </div>
-  ),
-};
-
-export const ProfileCard: Story = {
-  render: () => (
-    <div className="border-border bg-card w-80 rounded-xl border p-4">
-      <div className="mb-4 flex items-center gap-4">
-        <Skeleton circle width={64} height={64} />
-        <div className="flex-1 space-y-2">
-          <Skeleton variant="title" width="70%" />
-          <Skeleton variant="text" width="50%" />
-        </div>
-      </div>
-      <SkeletonText lines={3} gap="md" />
-      <div className="mt-4 flex gap-2">
-        <Skeleton variant="button" className="flex-1" />
-        <Skeleton variant="button" className="flex-1" />
-      </div>
-    </div>
-  ),
-};
-
-export const ListItems: Story = {
-  render: () => (
-    <div className="w-80 space-y-4">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-3">
-          <Skeleton circle width={40} height={40} />
-          <div className="flex-1 space-y-2">
-            <Skeleton variant="text" width="80%" />
-            <Skeleton variant="text" width="60%" />
-          </div>
-        </div>
-      ))}
-    </div>
-  ),
-};
-
 export const Grid: Story = {
+  args: {
+    example: 'card',
+  },
+  parameters: {
+    controls: { disable: true },
+  },
   render: () => (
     <div className="grid w-full max-w-2xl grid-cols-3 gap-4">
       {Array.from({ length: 6 }).map((_, i) => (
         <SkeletonCard key={i} showAvatar={false} textLines={1} />
       ))}
+    </div>
+  ),
+};
+
+export const AllVariants: Story = {
+  args: {
+    example: 'default',
+  },
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="w-80 space-y-6">
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Default</p>
+        <Skeleton width="100%" height={40} />
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Text</p>
+        <Skeleton variant="text" />
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Title</p>
+        <Skeleton variant="title" width="60%" />
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Avatar</p>
+        <Skeleton variant="avatar" circle width={48} height={48} />
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Button</p>
+        <Skeleton variant="button" />
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Card</p>
+        <Skeleton variant="card" />
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-2 text-sm">Image</p>
+        <Skeleton variant="image" className="rounded-lg" />
+      </div>
     </div>
   ),
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -12,6 +12,21 @@ import {
 } from './Table';
 import { Badge } from '../Badge';
 import { Checkbox } from '../Checkbox';
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownLabel,
+} from '../Dropdown';
+import {
+  FilterIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  EyeOffIcon,
+  LockIcon,
+  XIcon,
+} from '../Icons';
 
 const meta: Meta<typeof Table> = {
   title: 'Components/Table',
@@ -38,6 +53,552 @@ const meta: Meta<typeof Table> = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// Playground Story with Controls
+// ============================================================================
+
+interface PlaygroundArgs {
+  columnCount: number;
+  showFooter: boolean;
+  pinnedColumns: number;
+  selectable: boolean;
+  showColumnMenus: boolean;
+}
+
+const allColumns = [
+  { key: 'name', label: 'Name', footerValue: 'Total', filterable: true },
+  { key: 'email', label: 'Email', footerValue: '', filterable: true },
+  { key: 'role', label: 'Role', footerValue: '', filterable: true },
+  { key: 'status', label: 'Status', footerValue: '', filterable: true },
+  { key: 'department', label: 'Department', footerValue: '', filterable: true },
+  { key: 'location', label: 'Location', footerValue: '', filterable: true },
+  { key: 'phone', label: 'Phone', footerValue: '', filterable: false },
+  { key: 'startDate', label: 'Start Date', footerValue: '', filterable: true },
+  { key: 'salary', label: 'Salary', footerValue: '$485,000', filterable: true },
+  { key: 'manager', label: 'Manager', footerValue: '', filterable: true },
+  { key: 'team', label: 'Team', footerValue: '', filterable: true },
+  { key: 'projects', label: 'Projects', footerValue: '23', filterable: false },
+];
+
+const playgroundData = [
+  {
+    id: 1,
+    name: 'John Doe',
+    email: 'john@example.com',
+    role: 'Admin',
+    status: 'Active',
+    department: 'Engineering',
+    location: 'New York',
+    phone: '(555) 123-4567',
+    startDate: '2021-03-15',
+    salary: '$120,000',
+    manager: 'Sarah Wilson',
+    team: 'Platform',
+    projects: '5',
+  },
+  {
+    id: 2,
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    role: 'User',
+    status: 'Active',
+    department: 'Design',
+    location: 'San Francisco',
+    phone: '(555) 234-5678',
+    startDate: '2020-07-22',
+    salary: '$95,000',
+    manager: 'Mike Chen',
+    team: 'Product',
+    projects: '3',
+  },
+  {
+    id: 3,
+    name: 'Bob Johnson',
+    email: 'bob@example.com',
+    role: 'User',
+    status: 'Inactive',
+    department: 'Marketing',
+    location: 'Chicago',
+    phone: '(555) 345-6789',
+    startDate: '2019-11-08',
+    salary: '$85,000',
+    manager: 'Lisa Park',
+    team: 'Growth',
+    projects: '2',
+  },
+  {
+    id: 4,
+    name: 'Alice Brown',
+    email: 'alice@example.com',
+    role: 'Moderator',
+    status: 'Active',
+    department: 'Support',
+    location: 'Austin',
+    phone: '(555) 456-7890',
+    startDate: '2022-01-10',
+    salary: '$75,000',
+    manager: 'Tom Davis',
+    team: 'Customer Success',
+    projects: '8',
+  },
+  {
+    id: 5,
+    name: 'Charlie Wilson',
+    email: 'charlie@example.com',
+    role: 'User',
+    status: 'Pending',
+    department: 'Sales',
+    location: 'Seattle',
+    phone: '(555) 567-8901',
+    startDate: '2023-06-01',
+    salary: '$110,000',
+    manager: 'Rachel Green',
+    team: 'Enterprise',
+    projects: '5',
+  },
+];
+
+function PlaygroundTable({
+  columnCount,
+  showFooter,
+  pinnedColumns,
+  selectable,
+  showColumnMenus,
+}: PlaygroundArgs) {
+  const [selectedIds, setSelectedIds] = React.useState<Set<number>>(new Set());
+  const [sortConfig, setSortConfig] = React.useState<{
+    key: string;
+    direction: 'asc' | 'desc';
+  } | null>(null);
+  const [hiddenColumns, setHiddenColumns] = React.useState<Set<string>>(
+    new Set()
+  );
+  const [pinnedColumnKeys, setPinnedColumnKeys] = React.useState<Set<string>>(
+    new Set()
+  );
+  const [filterValues, setFilterValues] = React.useState<
+    Record<string, string>
+  >({});
+
+  const visibleColumns = allColumns
+    .slice(0, columnCount)
+    .filter((col) => !hiddenColumns.has(col.key));
+  const allSelected = selectedIds.size === playgroundData.length;
+  const someSelected = selectedIds.size > 0 && !allSelected;
+
+  // Sort and filter data
+  const filteredData = React.useMemo(() => {
+    let data = [...playgroundData];
+
+    // Apply filters
+    Object.entries(filterValues).forEach(([key, value]) => {
+      if (value) {
+        data = data.filter((row) =>
+          String(row[key as keyof typeof row])
+            .toLowerCase()
+            .includes(value.toLowerCase())
+        );
+      }
+    });
+
+    // Apply sorting
+    if (sortConfig) {
+      data.sort((a, b) => {
+        const aVal = String(a[sortConfig.key as keyof typeof a]);
+        const bVal = String(b[sortConfig.key as keyof typeof b]);
+        const direction = sortConfig.direction === 'asc' ? 1 : -1;
+        return aVal.localeCompare(bVal) * direction;
+      });
+    }
+
+    return data;
+  }, [filterValues, sortConfig]);
+
+  const handleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(playgroundData.map((d) => d.id)));
+    }
+  };
+
+  const handleSelectRow = (id: number) => {
+    const newSelected = new Set(selectedIds);
+    if (newSelected.has(id)) {
+      newSelected.delete(id);
+    } else {
+      newSelected.add(id);
+    }
+    setSelectedIds(newSelected);
+  };
+
+  const handleSort = (key: string, direction: 'asc' | 'desc') => {
+    setSortConfig({ key, direction });
+  };
+
+  const handleHideColumn = (key: string) => {
+    setHiddenColumns((prev) => new Set([...prev, key]));
+  };
+
+  const handleTogglePinColumn = (key: string) => {
+    setPinnedColumnKeys((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(key)) {
+        newSet.delete(key);
+      } else {
+        newSet.add(key);
+      }
+      return newSet;
+    });
+  };
+
+  const handleClearFilter = (key: string) => {
+    setFilterValues((prev) => {
+      const newFilters = { ...prev };
+      delete newFilters[key];
+      return newFilters;
+    });
+  };
+
+  const getPinnedStyle = (
+    index: number,
+    colKey: string
+  ): React.CSSProperties => {
+    const isPinned = index < pinnedColumns || pinnedColumnKeys.has(colKey);
+    if (isPinned) {
+      const checkboxOffset = selectable ? 48 : 0;
+      // Calculate offset based on pinned columns before this one
+      let leftOffset = checkboxOffset;
+      for (let i = 0; i < index; i++) {
+        const prevCol = visibleColumns[i];
+        if (i < pinnedColumns || pinnedColumnKeys.has(prevCol.key)) {
+          leftOffset += 140;
+        }
+      }
+      return {
+        position: 'sticky',
+        left: leftOffset,
+        zIndex: 10,
+      };
+    }
+    return {};
+  };
+
+  const getCheckboxPinnedStyle = (): React.CSSProperties => {
+    if (pinnedColumns > 0 || selectable) {
+      return {
+        position: 'sticky',
+        left: 0,
+        zIndex: 10,
+      };
+    }
+    return {};
+  };
+
+  // Column header with menu
+  const ColumnHeader = ({
+    col,
+    index,
+  }: {
+    col: (typeof allColumns)[0];
+    index: number;
+  }) => {
+    const isPinned = index < pinnedColumns || pinnedColumnKeys.has(col.key);
+    const isSorted = sortConfig?.key === col.key;
+    const hasFilter = filterValues[col.key];
+
+    if (!showColumnMenus) {
+      return (
+        <TableHead
+          key={col.key}
+          className={isPinned ? 'bg-background min-w-[140px]' : 'min-w-[140px]'}
+          style={getPinnedStyle(index, col.key)}
+        >
+          {col.label}
+        </TableHead>
+      );
+    }
+
+    return (
+      <TableHead
+        key={col.key}
+        className={`${isPinned ? 'bg-background' : ''} min-w-[140px]`}
+        style={getPinnedStyle(index, col.key)}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex items-center gap-1">
+            {col.label}
+            {isSorted && (
+              <span className="text-muted-foreground">
+                {sortConfig.direction === 'asc' ? (
+                  <ChevronUpIcon className="h-3 w-3" />
+                ) : (
+                  <ChevronDownIcon className="h-3 w-3" />
+                )}
+              </span>
+            )}
+            {hasFilter && <FilterIcon className="text-primary h-3 w-3" />}
+          </span>
+          <Dropdown
+            placement="bottom-end"
+            className="z-[100]"
+            trigger={
+              <button
+                className="hover:bg-muted rounded p-0.5 transition-colors"
+                aria-label={`Options for ${col.label}`}
+              >
+                <ChevronDownIcon className="text-muted-foreground h-4 w-4" />
+              </button>
+            }
+          >
+            <DropdownContent>
+              <DropdownLabel>Sort</DropdownLabel>
+              <DropdownItem
+                icon={<ChevronUpIcon className="h-4 w-4" />}
+                onClick={() => handleSort(col.key, 'asc')}
+              >
+                Sort Ascending
+              </DropdownItem>
+              <DropdownItem
+                icon={<ChevronDownIcon className="h-4 w-4" />}
+                onClick={() => handleSort(col.key, 'desc')}
+              >
+                Sort Descending
+              </DropdownItem>
+
+              {col.filterable && (
+                <>
+                  <DropdownSeparator />
+                  <DropdownLabel>Filter</DropdownLabel>
+                  <div className="px-2 py-1">
+                    <input
+                      type="text"
+                      placeholder={`Filter ${col.label}...`}
+                      value={filterValues[col.key] || ''}
+                      onChange={(e) =>
+                        setFilterValues((prev) => ({
+                          ...prev,
+                          [col.key]: e.target.value,
+                        }))
+                      }
+                      className="border-input bg-background text-foreground placeholder:text-muted-foreground w-full rounded-md border px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </div>
+                  {hasFilter && (
+                    <DropdownItem
+                      icon={<XIcon className="h-4 w-4" />}
+                      onClick={() => handleClearFilter(col.key)}
+                    >
+                      Clear Filter
+                    </DropdownItem>
+                  )}
+                </>
+              )}
+
+              <DropdownSeparator />
+              <DropdownLabel>Column</DropdownLabel>
+              <DropdownItem
+                icon={<LockIcon className="h-4 w-4" />}
+                onClick={() => handleTogglePinColumn(col.key)}
+              >
+                {isPinned ? 'Unpin Column' : 'Pin Column'}
+              </DropdownItem>
+              <DropdownItem
+                icon={<EyeOffIcon className="h-4 w-4" />}
+                onClick={() => handleHideColumn(col.key)}
+              >
+                Hide Column
+              </DropdownItem>
+            </DropdownContent>
+          </Dropdown>
+        </div>
+      </TableHead>
+    );
+  };
+
+  return (
+    <div className="w-full max-w-5xl">
+      {/* Show hidden columns restore UI */}
+      {hiddenColumns.size > 0 && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          <span className="text-muted-foreground text-sm">Hidden columns:</span>
+          {Array.from(hiddenColumns).map((key) => {
+            const col = allColumns.find((c) => c.key === key);
+            return (
+              <button
+                key={key}
+                onClick={() =>
+                  setHiddenColumns((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.delete(key);
+                    return newSet;
+                  })
+                }
+                className="bg-muted hover:bg-muted/80 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs transition-colors"
+              >
+                {col?.label}
+                <XIcon className="h-3 w-3" />
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {selectable && (
+              <TableHead
+                className="bg-background w-12"
+                style={getCheckboxPinnedStyle()}
+              >
+                <Checkbox
+                  checked={allSelected}
+                  indeterminate={someSelected}
+                  onChange={handleSelectAll}
+                  aria-label="Select all"
+                />
+              </TableHead>
+            )}
+            {visibleColumns.map((col, index) => (
+              <ColumnHeader key={col.key} col={col} index={index} />
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredData.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={visibleColumns.length + (selectable ? 1 : 0)}
+                className="text-muted-foreground h-24 text-center"
+              >
+                No results found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            filteredData.map((row) => (
+              <TableRow
+                key={row.id}
+                selected={selectable && selectedIds.has(row.id)}
+              >
+                {selectable && (
+                  <TableCell
+                    className="bg-background"
+                    style={getCheckboxPinnedStyle()}
+                  >
+                    <Checkbox
+                      checked={selectedIds.has(row.id)}
+                      onChange={() => handleSelectRow(row.id)}
+                      aria-label={`Select ${row.name}`}
+                    />
+                  </TableCell>
+                )}
+                {visibleColumns.map((col, index) => {
+                  const isPinned =
+                    index < pinnedColumns || pinnedColumnKeys.has(col.key);
+                  return (
+                    <TableCell
+                      key={col.key}
+                      className={`${index === 0 ? 'font-medium' : ''} ${
+                        isPinned
+                          ? 'bg-background min-w-[140px]'
+                          : 'min-w-[140px]'
+                      }`}
+                      style={getPinnedStyle(index, col.key)}
+                    >
+                      {col.key === 'status' ? (
+                        <Badge
+                          variant={
+                            row.status === 'Active'
+                              ? 'success'
+                              : row.status === 'Inactive'
+                                ? 'secondary'
+                                : 'warning'
+                          }
+                          size="sm"
+                        >
+                          {row.status}
+                        </Badge>
+                      ) : (
+                        row[col.key as keyof typeof row]
+                      )}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+        {showFooter && (
+          <TableFooter>
+            <TableRow>
+              {selectable && (
+                <TableCell
+                  className="bg-muted/50"
+                  style={getCheckboxPinnedStyle()}
+                />
+              )}
+              {visibleColumns.map((col, index) => {
+                const isPinned =
+                  index < pinnedColumns || pinnedColumnKeys.has(col.key);
+                return (
+                  <TableCell
+                    key={col.key}
+                    className={`${col.footerValue ? 'font-bold' : ''} ${
+                      isPinned ? 'bg-muted/50 min-w-[140px]' : ''
+                    }`}
+                    style={getPinnedStyle(index, col.key)}
+                  >
+                    {col.footerValue}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          </TableFooter>
+        )}
+      </Table>
+      {selectable && (
+        <p className="text-muted-foreground mt-4 text-sm">
+          {selectedIds.size} of {filteredData.length} row(s) selected.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const Playground: StoryObj<PlaygroundArgs> = {
+  args: {
+    columnCount: 6,
+    showFooter: false,
+    pinnedColumns: 0,
+    selectable: false,
+    showColumnMenus: true,
+  },
+  argTypes: {
+    columnCount: {
+      control: { type: 'range', min: 1, max: 12, step: 1 },
+      description: 'Number of columns to display (1-12)',
+    },
+    showFooter: {
+      control: 'boolean',
+      description: 'Show or hide the table footer',
+    },
+    pinnedColumns: {
+      control: { type: 'range', min: 0, max: 4, step: 1 },
+      description: 'Number of columns to pin to the left (0-4)',
+    },
+    selectable: {
+      control: 'boolean',
+      description: 'Enable row selection with checkboxes',
+    },
+    showColumnMenus: {
+      control: 'boolean',
+      description: 'Show column header menus with sort, filter, and options',
+    },
+  },
+  render: (args) => <PlaygroundTable {...args} />,
+};
 
 const users = [
   {


### PR DESCRIPTION
- Add column count slider (1-12 columns)
- Add show/hide footer toggle
- Add pin columns control (0-4 sticky columns)
- Add row selection with checkboxes and select-all
- Add column header dropdown menus with sort, filter, pin, hide
- Add hidden column restore chips
- Fix z-index on dropdown menus to render above badges

https://github.com/user-attachments/assets/44ed2d05-724e-4c29-a9cb-d6159c230787

