### PR TITLE
feat(Tabs): Add Playground story with interactive controls

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -2,6 +2,17 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from './Tabs';
 import { Card, CardContent } from '../Card';
+import {
+  UserIcon,
+  SettingsIcon,
+  BellIcon,
+  HomeIcon,
+  ChartIcon,
+  MailIcon,
+  CalendarIcon,
+  FileTextIcon,
+} from '../Icons';
+import { Badge } from '../Badge';
 
 const meta: Meta<typeof Tabs> = {
   title: 'Components/Tabs',
@@ -15,11 +26,231 @@ const meta: Meta<typeof Tabs> = {
       control: 'select',
       options: ['underline', 'pills', 'enclosed'],
     },
+    children: {
+      control: false,
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// Playground Story with Controls
+// ============================================================================
+
+interface PlaygroundArgs {
+  variant: 'underline' | 'pills' | 'enclosed';
+  tabCount: number;
+  showIcons: boolean;
+  showBadges: boolean;
+  disabledTabs: number[];
+  fullWidth: boolean;
+  showContent: boolean;
+  contentStyle: 'plain' | 'card';
+}
+
+const allTabs = [
+  {
+    value: 'dashboard',
+    label: 'Dashboard',
+    icon: HomeIcon,
+    badge: null,
+    content: 'View your dashboard metrics, recent activity, and quick actions.',
+  },
+  {
+    value: 'analytics',
+    label: 'Analytics',
+    icon: ChartIcon,
+    badge: 'New',
+    content:
+      'Explore detailed analytics, charts, and performance metrics for your account.',
+  },
+  {
+    value: 'messages',
+    label: 'Messages',
+    icon: MailIcon,
+    badge: '5',
+    content:
+      'Read and respond to your messages. Manage your inbox and sent items.',
+  },
+  {
+    value: 'calendar',
+    label: 'Calendar',
+    icon: CalendarIcon,
+    badge: null,
+    content: 'View and manage your schedule. Create events and set reminders.',
+  },
+  {
+    value: 'documents',
+    label: 'Documents',
+    icon: FileTextIcon,
+    badge: '12',
+    content: 'Access your files and documents. Upload, download, and organize.',
+  },
+  {
+    value: 'profile',
+    label: 'Profile',
+    icon: UserIcon,
+    badge: null,
+    content: 'Manage your personal information and account settings.',
+  },
+  {
+    value: 'settings',
+    label: 'Settings',
+    icon: SettingsIcon,
+    badge: null,
+    content: 'Configure application settings, preferences, and integrations.',
+  },
+  {
+    value: 'notifications',
+    label: 'Notifications',
+    icon: BellIcon,
+    badge: '3',
+    content: 'Manage your notification preferences and view recent alerts.',
+  },
+];
+
+function PlaygroundTabs({
+  variant,
+  tabCount,
+  showIcons,
+  showBadges,
+  disabledTabs,
+  fullWidth,
+  showContent,
+  contentStyle,
+}: PlaygroundArgs) {
+  const [selectedTab, setSelectedTab] = React.useState(allTabs[0].value);
+  const tabs = allTabs.slice(0, tabCount);
+
+  // Reset to first tab if current tab is removed
+  React.useEffect(() => {
+    if (!tabs.find((t) => t.value === selectedTab)) {
+      setSelectedTab(tabs[0]?.value || '');
+    }
+  }, [tabCount, selectedTab, tabs]);
+
+  return (
+    <div className="w-full max-w-2xl">
+      <Tabs
+        value={selectedTab}
+        onValueChange={setSelectedTab}
+        variant={variant}
+      >
+        <TabsList className={fullWidth ? 'w-full' : ''}>
+          {tabs.map((tab, index) => {
+            const IconComponent = tab.icon;
+            const isDisabled = disabledTabs.includes(index);
+            return (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                disabled={isDisabled}
+                icon={
+                  showIcons ? <IconComponent className="h-4 w-4" /> : undefined
+                }
+                className={fullWidth ? 'flex-1' : ''}
+              >
+                {tab.label}
+                {showBadges && tab.badge && (
+                  <Badge
+                    variant={tab.badge === 'New' ? 'success' : 'secondary'}
+                    size="sm"
+                    className="ml-1.5"
+                  >
+                    {tab.badge}
+                  </Badge>
+                )}
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+        {showContent &&
+          tabs.map((tab) => (
+            <TabsContent key={tab.value} value={tab.value}>
+              {contentStyle === 'card' ? (
+                <Card>
+                  <CardContent className="pt-4">
+                    <h3 className="text-foreground mb-2 font-semibold">
+                      {tab.label}
+                    </h3>
+                    <p className="text-muted-foreground text-sm">
+                      {tab.content}
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : (
+                <div className="py-4">
+                  <h3 className="text-foreground mb-2 font-semibold">
+                    {tab.label}
+                  </h3>
+                  <p className="text-muted-foreground text-sm">{tab.content}</p>
+                </div>
+              )}
+            </TabsContent>
+          ))}
+      </Tabs>
+      <p className="text-muted-foreground mt-4 text-xs">
+        Selected tab:{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono">
+          {selectedTab}
+        </code>
+      </p>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<PlaygroundArgs> = {
+  args: {
+    variant: 'underline',
+    tabCount: 4,
+    showIcons: true,
+    showBadges: true,
+    disabledTabs: [],
+    fullWidth: false,
+    showContent: true,
+    contentStyle: 'card',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['underline', 'pills', 'enclosed'],
+      description: 'Visual style of the tabs',
+    },
+    tabCount: {
+      control: { type: 'range', min: 2, max: 8, step: 1 },
+      description: 'Number of tabs to display (2-8)',
+    },
+    showIcons: {
+      control: 'boolean',
+      description: 'Show icons in tab triggers',
+    },
+    showBadges: {
+      control: 'boolean',
+      description: 'Show badges/counts on applicable tabs',
+    },
+    disabledTabs: {
+      control: 'multi-select',
+      options: [0, 1, 2, 3, 4, 5, 6, 7],
+      description: 'Tab indices to disable (0-indexed)',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch tabs to fill full width',
+    },
+    showContent: {
+      control: 'boolean',
+      description: 'Show tab content panels',
+    },
+    contentStyle: {
+      control: 'select',
+      options: ['plain', 'card'],
+      description: 'Style of the content area',
+    },
+  },
+  render: (args) => <PlaygroundTabs {...args} />,
+};
 
 export const Underline: Story = {
   render: () => (
@@ -130,75 +361,24 @@ export const Enclosed: Story = {
   ),
 };
 
-function UserIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-      <circle cx="12" cy="7" r="4" />
-    </svg>
-  );
-}
-
-function SettingsIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
-  );
-}
-
-function BellIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-    </svg>
-  );
-}
-
 export const WithIcons: Story = {
   render: () => (
     <div className="w-[400px]">
       <Tabs defaultValue="profile" variant="underline">
         <TabsList>
-          <TabsTrigger value="profile" icon={<UserIcon />}>
+          <TabsTrigger value="profile" icon={<UserIcon className="h-4 w-4" />}>
             Profile
           </TabsTrigger>
-          <TabsTrigger value="settings" icon={<SettingsIcon />}>
+          <TabsTrigger
+            value="settings"
+            icon={<SettingsIcon className="h-4 w-4" />}
+          >
             Settings
           </TabsTrigger>
-          <TabsTrigger value="notifications" icon={<BellIcon />}>
+          <TabsTrigger
+            value="notifications"
+            icon={<BellIcon className="h-4 w-4" />}
+          >
             Notifications
           </TabsTrigger>
         </TabsList>


### PR DESCRIPTION
Add 8 controls: variant, tabCount (2-8), showIcons, showBadges, disabledTabs, fullWidth, showContent, contentStyle. Include 8 sample tabs with icons and badges. Replace inline SVGs with Icons imports. Disable children control to fix Storybook error.

https://github.com/user-attachments/assets/cdcd1565-0660-4f76-a7fb-28a5131c9ec4

