### PR TITLE
fix(Text): Fix Default story controls and truncate behavior

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -43,8 +43,21 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    children: 'This is a paragraph of text.',
+    children:
+      'This is a paragraph of text that demonstrates how the Text component works with different options including truncation.',
+    variant: 'default',
+    size: 'base',
+    weight: 'normal',
+    align: 'left',
+    truncate: false,
   },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export const AllVariants: Story = {


### PR DESCRIPTION
- Add explicit default values for all props (variant, size, weight, align, truncate)
- Add 300px width container decorator so truncate control works visibly
- Use longer sample text to demonstrate truncation effect

https://github.com/user-attachments/assets/83cf821d-d2d2-419a-b9cb-5532b4835fde

