### PR TITLE
fix(Address): Disable icon control in Storybook

### DIFF
--- a/src/components/Address/Address.stories.tsx
+++ b/src/components/Address/Address.stories.tsx
@@ -30,6 +30,7 @@ const meta: Meta<typeof Address> = {
     showIcon: { control: 'boolean' },
     hideStreet: { control: 'boolean' },
     hidePostalCode: { control: 'boolean' },
+    icon: { control: false }, // ReactNode can't be controlled via Storybook
   },
 };
 


### PR DESCRIPTION
ReactNode props cannot be controlled via Storybook UI controls. Setting control: false removes the broken icon control from the docs page controls panel.