### PR TITLE
fix(AuthDialog): resolve TypeScript error by moving demo component be…

### DIFF
--- a/src/components/AuthDialog/AuthDialog.stories.tsx
+++ b/src/components/AuthDialog/AuthDialog.stories.tsx
@@ -1,10 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
-import {
-  AuthDialog,
-  AuthMode,
-  DEFAULT_SOCIAL_PROVIDERS,
-} from './AuthDialog';
+import { AuthDialog, AuthMode, DEFAULT_SOCIAL_PROVIDERS } from './AuthDialog';
 
 // Demo-only controls interface
 interface DemoControls {


### PR DESCRIPTION
…fore meta definition

- Move AuthDialogDemo component definition before meta to fix reference error
- Remove duplicate AuthDialogDemo function
- Remove disabled argTypes for component props (not needed with DemoControls type)
- Remove unused AuthDialogProps import