### PR TITLE
Feature/business hours editor updates

### DIFF
--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
@@ -64,7 +64,6 @@ function BusinessHoursEditorWrapper({
   onChange: _,
   ...restProps
 }: Partial<React.ComponentProps<typeof BusinessHoursEditor>>) {
-
   const [schedule, setSchedule] = useState<DaySchedule[]>(
     initialValue || createDefaultSchedule()
   );
@@ -78,7 +77,11 @@ function BusinessHoursEditorWrapper({
 
   return (
     <div className="max-w-2xl">
-      <BusinessHoursEditor {...restProps} value={schedule} onChange={setSchedule} />
+      <BusinessHoursEditor
+        {...restProps}
+        value={schedule}
+        onChange={setSchedule}
+      />
 
       <div className="mt-6 rounded-lg bg-gray-100 p-4 dark:bg-gray-800">
         <h4 className="mb-2 text-sm font-medium">Current Schedule:</h4>


### PR DESCRIPTION
- Hide 'value', 'onChange', 'className' controls from Storybook docs
  - Clicking 'Set object' on value control caused 'schedule.find is not a function'
    error because Storybook defaults to {} (object) instead of [] (array)
  - These props are managed by the interactive wrapper component

- Hide 'use24Hour' control - prop exists in interface but is not implemented
  - Component uses native <input type='time'> which uses browser locale
  - Prop is destructured as _use24Hour (intentionally unused)
  - Can be implemented in future if 24-hour format support is needed

- Add default args for remaining controls (disabled, showDescription, weekStartsOn, addHoursLabel)
  - Ensures boolean controls start with actual values instead of undefined

- Add useEffect to sync schedule state when props.value changes from Storybook controls

https://github.com/user-attachments/assets/b3afe5fe-f160-45ad-898d-44e2cabbfd55


