### PR TITLE
fix(ClaimProviderForm): add Storybook controls for all props

### DIFF
--- a/src/components/ClaimProviderForm/ClaimProviderForm.stories.tsx
+++ b/src/components/ClaimProviderForm/ClaimProviderForm.stories.tsx
@@ -9,8 +9,47 @@ const meta: Meta<typeof ClaimProviderForm> = {
     layout: 'centered',
   },
   argTypes: {
+    providerName: {
+      control: 'text',
+      description: 'Provider name being claimed',
+    },
+    providerAddress: {
+      control: 'text',
+      description: 'Provider address being claimed',
+    },
+    roleOptions: {
+      control: false,
+      description: 'Available role options',
+    },
+    languageOptions: {
+      control: false,
+      description: 'Available language options',
+    },
+    isSubmitting: {
+      control: 'boolean',
+      description: 'Whether submission is in progress',
+    },
+    errorMessage: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+    termsUrl: {
+      control: 'text',
+      description: 'Terms and conditions link URL',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
     onSubmit: { action: 'onSubmit' },
     onCancel: { action: 'onCancel' },
+  },
+  args: {
+    providerName: '',
+    providerAddress: '',
+    isSubmitting: false,
+    errorMessage: '',
+    termsUrl: '/terms',
   },
   decorators: [
     (Story) => (
@@ -23,6 +62,20 @@ const meta: Meta<typeof ClaimProviderForm> = {
 
 export default meta;
 type Story = StoryObj<typeof ClaimProviderForm>;
+
+/**
+ * Interactive playground with all controls available.
+ * Use the Controls panel to adjust props dynamically.
+ */
+export const Playground: Story = {
+  args: {
+    providerName: 'ABC Medical Center',
+    providerAddress: '123 Healthcare Blvd, Fort Wayne, IN 46802',
+    isSubmitting: false,
+    errorMessage: '',
+    termsUrl: '/terms',
+  },
+};
 
 export const Default: Story = {
   args: {


### PR DESCRIPTION
- Add comprehensive argTypes configuration for all component props
- Add text controls for providerName, providerAddress, errorMessage, termsUrl, className
- Add boolean control for isSubmitting
- Disable controls for roleOptions/languageOptions (complex array props don't work well with default controls)
- Add action handlers for onSubmit and onCancel
- Add default args at meta level for initial control values
- Add Playground story as primary interactive story for testing all controls
- Keep existing stories (Default, WithoutProvider, WithError, Submitting, CustomRoles, WithCancel)

The Playground story now allows dynamic manipulation of all supported props via the Storybook Controls panel.

https://github.com/user-attachments/assets/a703a94c-8250-4f97-81b2-889b96c43a56
