### PR TITLE
fix(DocumentScanner): disable unreliable acceptedFileTypes control

### DIFF
--- a/src/components/DocumentScanner/DocumentScanner.stories.tsx
+++ b/src/components/DocumentScanner/DocumentScanner.stories.tsx
@@ -81,7 +81,7 @@ function MyForm() {
     },
     acceptedFileTypes: {
       description: 'Accepted MIME types',
-      control: 'object',
+      control: false,
       table: {
         defaultValue: {
           summary:


### PR DESCRIPTION
- Change acceptedFileTypes control from 'object' to false
- Object controls don't work reliably for string array props in Storybook
- The ImagesOnly and WithValidationCallback stories demonstrate different file type configurations as working examples
- This is consistent with how other components handle complex array props


https://github.com/user-attachments/assets/57bb7294-83de-4e67-a85b-f9412e8b2b1b

