### PR TITLE
fix(EmployerServiceModal): Fix docs page layout and theming

### DIFF
--- a/src/components/EmployerServiceModal/EmployerServiceModal.stories.tsx
+++ b/src/components/EmployerServiceModal/EmployerServiceModal.stories.tsx
@@ -6,11 +6,56 @@ const meta: Meta<typeof EmployerServiceModal> = {
   title: 'Components/EmployerServiceModal',
   tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
+    layout: 'fullscreen',
   },
+  decorators: [
+    (Story) => (
+      // Container with transform creates a new containing block for position:fixed
+      // This keeps the modal within this container in docs view
+      <div
+        className="relative flex items-center justify-center"
+        style={{
+          transform: 'translateZ(0)',
+          minHeight: '900px',
+          padding: '100px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Whether the modal is open',
+    },
+    isSubmitting: {
+      control: 'boolean',
+      description: 'Whether submission is in progress',
+    },
+    errorMessage: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+    employer: {
+      control: false,
+      description: 'Employer information',
+    },
+    service: {
+      control: false,
+      description: 'Service being configured',
+    },
+    existingConfig: {
+      control: false,
+      description: 'Existing configuration (for editing)',
+    },
     onOpenChange: { action: 'onOpenChange' },
     onSave: { action: 'onSave' },
+  },
+  args: {
+    open: true,
+    isSubmitting: false,
+    errorMessage: '',
   },
 };
 

--- a/src/components/EmployerServiceModal/EmployerServiceModal.tsx
+++ b/src/components/EmployerServiceModal/EmployerServiceModal.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { Modal, ModalHeader, ModalTitle, ModalFooter } from '../Modal/Modal';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalBody,
+  ModalFooter,
+} from '../Modal/Modal';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 import { Switch } from '../Switch/Switch';
@@ -102,23 +108,19 @@ export function EmployerServiceModal({
           </ModalTitle>
         </ModalHeader>
 
-        <div className="space-y-4">
+        <ModalBody className="space-y-4">
           {/* Error message */}
           {errorMessage && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-              <p className="text-sm text-red-600 dark:text-red-400">
-                {errorMessage}
-              </p>
+            <div className="border-destructive/30 bg-destructive/10 rounded-lg border p-3">
+              <p className="text-destructive text-sm">{errorMessage}</p>
             </div>
           )}
 
           {/* Service info */}
           {service && (
-            <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-900/20">
-              <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                {service.name}
-              </p>
-              <p className="text-xs text-blue-600 dark:text-blue-400">
+            <div className="border-primary/30 bg-primary/10 rounded-lg border p-3">
+              <p className="text-primary text-sm font-medium">{service.name}</p>
+              <p className="text-primary/80 text-xs">
                 Base price: ${service.basePrice.toFixed(2)}
               </p>
             </div>
@@ -126,16 +128,12 @@ export function EmployerServiceModal({
 
           {/* Pricing section */}
           <div className="space-y-3">
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Pricing
-            </p>
+            <p className="text-foreground text-sm font-medium">Pricing</p>
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-900 dark:text-white">
-                  Use Base Price
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-foreground text-sm">Use Base Price</p>
+                <p className="text-muted-foreground text-xs">
                   Use the service&apos;s default pricing
                 </p>
               </div>
@@ -152,15 +150,15 @@ export function EmployerServiceModal({
             </div>
 
             {!config.useBasePrice && (
-              <div className="ml-4 border-l-2 border-gray-200 pl-4 dark:border-gray-700">
+              <div className="border-border ml-4 border-l-2 pl-4">
                 <label
                   htmlFor="custom-price"
-                  className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  className="text-foreground mb-1 block text-sm font-medium"
                 >
                   Custom Price
                 </label>
                 <div className="relative w-40">
-                  <span className="absolute top-1/2 left-3 -translate-y-1/2 text-gray-500">
+                  <span className="text-muted-foreground absolute top-1/2 left-3 -translate-y-1/2">
                     $
                   </span>
                   <input
@@ -168,7 +166,7 @@ export function EmployerServiceModal({
                     type="number"
                     min="0"
                     step="0.01"
-                    className="w-full rounded-md border border-gray-300 py-2 pr-4 pl-7 shadow-sm focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border py-2 pr-4 pl-7 shadow-sm focus:ring-2 focus:outline-none"
                     value={config.customPrice ?? ''}
                     onChange={(e) =>
                       setConfig((prev) => ({
@@ -195,16 +193,14 @@ export function EmployerServiceModal({
 
           {/* Order handling */}
           <div className="space-y-3">
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            <p className="text-foreground text-sm font-medium">
               Order Handling
             </p>
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-900 dark:text-white">
-                  Auto-Accept Orders
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-foreground text-sm">Auto-Accept Orders</p>
+                <p className="text-muted-foreground text-xs">
                   Automatically accept orders from this employer
                 </p>
               </div>
@@ -218,10 +214,8 @@ export function EmployerServiceModal({
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-900 dark:text-white">
-                  Requires Approval
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-foreground text-sm">Requires Approval</p>
+                <p className="text-muted-foreground text-xs">
                   Orders need manual approval before processing
                 </p>
               </div>
@@ -236,16 +230,12 @@ export function EmployerServiceModal({
 
           {/* Notifications */}
           <div className="space-y-3">
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Notifications
-            </p>
+            <p className="text-foreground text-sm font-medium">Notifications</p>
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-900 dark:text-white">
-                  Notify on New Orders
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-foreground text-sm">Notify on New Orders</p>
+                <p className="text-muted-foreground text-xs">
                   Send email when orders are placed
                 </p>
               </div>
@@ -258,7 +248,7 @@ export function EmployerServiceModal({
             </div>
 
             {config.notifyOnOrder && (
-              <div className="ml-4 border-l-2 border-gray-200 pl-4 dark:border-gray-700">
+              <div className="border-border ml-4 border-l-2 pl-4">
                 <Input
                   label="Notification Email"
                   type="email"
@@ -279,13 +269,13 @@ export function EmployerServiceModal({
           <div>
             <label
               htmlFor="employer-service-notes"
-              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               Internal Notes
             </label>
             <textarea
               id="employer-service-notes"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 shadow-sm focus:ring-2 focus:outline-none"
               rows={3}
               value={config.notes || ''}
               onChange={(e) =>
@@ -294,7 +284,7 @@ export function EmployerServiceModal({
               placeholder="Notes about this employer's service configuration..."
             />
           </div>
-        </div>
+        </ModalBody>
 
         <ModalFooter>
           <Button


### PR DESCRIPTION
Stories changes:
- Add decorator with transform:translateZ(0) to contain position:fixed modal
- Set layout to fullscreen with 900px min-height and 100px padding
- Add argTypes with descriptions for open, isSubmitting, errorMessage, employer, service, and existingConfig props
- Add default args for better Storybook controls experience

Component theming fixes:
- Replace hardcoded colors with design tokens for dark/light mode support
- Error messages: border-red-200/bg-red-50 → border-destructive/30 bg-destructive/10
- Service info: border-blue-200/bg-blue-50 → border-primary/30 bg-primary/10
- Text colors: text-gray-* → text-foreground/text-muted-foreground
- Borders: border-gray-* → border-border/border-input
- Inputs: Add bg-background text-foreground for proper theming
- Focus rings: focus:ring-blue-500 → focus:ring-ring

https://github.com/user-attachments/assets/20d5a328-01e5-410b-a9bd-af3b6feae89d

