### PR TITLE
feat(InviteUserModal): fix modal layout and add dark mode support

### DIFF
--- a/src/components/InviteUserModal/InviteUserModal.stories.tsx
+++ b/src/components/InviteUserModal/InviteUserModal.stories.tsx
@@ -1,21 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useState } from 'react';
-import { InviteUserModal, Role } from './InviteUserModal';
-import { Button } from '../Button/Button';
+import { InviteUserModal } from './InviteUserModal';
 
-const meta: Meta<typeof InviteUserModal> = {
-  title: 'Components/InviteUserModal',
-  component: InviteUserModal,
-  tags: ['autodocs'],
-  parameters: {
-    layout: 'centered',
-  },
-};
-
-export default meta;
-type Story = StoryObj<typeof InviteUserModal>;
-
-const sampleRoles: Role[] = [
+const sampleRoles = [
   {
     id: 'admin',
     name: 'Administrator',
@@ -38,170 +24,117 @@ const sampleRoles: Role[] = [
   },
 ];
 
-// Interactive wrapper component
-function InteractiveDemo({
-  entityName,
-  entityDisplayName,
-  roles = sampleRoles,
-  defaultRoleId,
-}: {
-  entityName?: string;
-  entityDisplayName?: string;
-  roles?: Role[];
-  defaultRoleId?: string;
-}) {
-  const [open, setOpen] = useState(true);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | undefined>();
-  const [success, setSuccess] = useState<string | undefined>();
-
-  const handleSubmit = async (data: {
-    email: string;
-    firstName?: string;
-    lastName?: string;
-    roleId: string;
-    message?: string;
-  }) => {
-    setIsSubmitting(true);
-    setError(undefined);
-    setSuccess(undefined);
-
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-
-    // Simulate success or error
-    if (data.email.includes('error')) {
-      setError('User with this email already exists');
-      setIsSubmitting(false);
-    } else {
-      setSuccess(`Invitation sent to ${data.email}`);
-      setIsSubmitting(false);
-      // Close after showing success briefly
-      setTimeout(() => setOpen(false), 2000);
-    }
-  };
-
-  return (
-    <div>
-      <Button onClick={() => setOpen(true)}>Invite User</Button>
-      <InviteUserModal
-        open={open}
-        onOpenChange={setOpen}
-        onSubmit={handleSubmit}
-        roles={roles}
-        defaultRoleId={defaultRoleId}
-        entityName={entityName}
-        entityDisplayName={entityDisplayName}
-        isSubmitting={isSubmitting}
-        errorMessage={error}
-        successMessage={success}
-      />
-    </div>
-  );
-}
-
-export const Default: Story = {
-  render: () => <InteractiveDemo />,
+const meta: Meta<typeof InviteUserModal> = {
+  title: 'Components/InviteUserModal',
+  component: InviteUserModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      // Container with transform creates a new containing block for position:fixed
+      // This keeps the modal within this container in docs view
+      <div
+        className="flex min-h-[700px] items-center justify-center"
+        style={{ transform: 'translateZ(0)' }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    open: true,
+    roles: sampleRoles,
+  },
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Whether the modal is open',
+    },
+    onOpenChange: { action: 'onOpenChange' },
+    onSubmit: { action: 'onSubmit' },
+    roles: {
+      control: 'object',
+      description: 'Available roles to assign',
+    },
+    defaultRoleId: {
+      control: 'text',
+      description: 'Default role ID',
+    },
+    isSubmitting: {
+      control: 'boolean',
+      description: 'Whether submission is in progress',
+    },
+    entityName: {
+      control: 'text',
+      description: 'Entity name (e.g., "provider" or "organization")',
+    },
+    entityDisplayName: {
+      control: 'text',
+      description: 'Entity display name',
+    },
+    errorMessage: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+    successMessage: {
+      control: 'text',
+      description: 'Success message to display',
+    },
+  },
 };
 
+export default meta;
+type Story = StoryObj<typeof InviteUserModal>;
+
+export const Default: Story = {};
+
 export const WithProvider: Story = {
-  render: () => (
-    <InteractiveDemo
-      entityName="provider"
-      entityDisplayName="MedCare Health Services"
-    />
-  ),
+  args: {
+    entityName: 'provider',
+    entityDisplayName: 'MedCare Health Services',
+  },
 };
 
 export const WithEmployer: Story = {
-  render: () => (
-    <InteractiveDemo
-      entityName="employer"
-      entityDisplayName="Acme Corporation"
-    />
-  ),
+  args: {
+    entityName: 'employer',
+    entityDisplayName: 'Acme Corporation',
+  },
 };
 
 export const WithDefaultRole: Story = {
-  render: () => (
-    <InteractiveDemo
-      entityDisplayName="Healthcare Partners"
-      defaultRoleId="staff"
-    />
-  ),
+  args: {
+    entityDisplayName: 'Healthcare Partners',
+    defaultRoleId: 'staff',
+  },
 };
 
-// Wrapper for WithError story
-function WithErrorWrapper() {
-  const [open, setOpen] = useState(true);
-
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>Show Modal with Error</Button>
-      <InviteUserModal
-        open={open}
-        onOpenChange={setOpen}
-        roles={sampleRoles}
-        errorMessage="User with this email already has an account"
-      />
-    </>
-  );
-}
-
-// Wrapper for WithSuccess story
-function WithSuccessWrapper() {
-  const [open, setOpen] = useState(true);
-
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>Show Modal with Success</Button>
-      <InviteUserModal
-        open={open}
-        onOpenChange={setOpen}
-        roles={sampleRoles}
-        successMessage="Invitation sent to john@example.com"
-      />
-    </>
-  );
-}
-
-// Wrapper for Submitting story
-function SubmittingWrapper() {
-  const [open, setOpen] = useState(true);
-
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>Show Submitting State</Button>
-      <InviteUserModal
-        open={open}
-        onOpenChange={setOpen}
-        roles={sampleRoles}
-        isSubmitting={true}
-      />
-    </>
-  );
-}
-
 export const WithError: Story = {
-  render: () => <WithErrorWrapper />,
+  args: {
+    errorMessage: 'User with this email already has an account',
+  },
 };
 
 export const WithSuccess: Story = {
-  render: () => <WithSuccessWrapper />,
+  args: {
+    successMessage: 'Invitation sent to john@example.com',
+  },
 };
 
 export const Submitting: Story = {
-  render: () => <SubmittingWrapper />,
+  args: {
+    isSubmitting: true,
+  },
 };
 
 export const MinimalRoles: Story = {
-  render: () => (
-    <InteractiveDemo
-      entityDisplayName="Simple Provider"
-      roles={[
-        { id: 'admin', name: 'Admin' },
-        { id: 'user', name: 'User' },
-      ]}
-    />
-  ),
+  args: {
+    entityDisplayName: 'Simple Provider',
+    roles: [
+      { id: 'admin', name: 'Admin' },
+      { id: 'user', name: 'User' },
+    ],
+  },
 };

--- a/src/components/InviteUserModal/InviteUserModal.tsx
+++ b/src/components/InviteUserModal/InviteUserModal.tsx
@@ -103,10 +103,10 @@ export function InviteUserModal({
 
         <ModalBody className="space-y-4">
           {entityDisplayName && (
-            <div className="rounded-lg bg-muted p-3">
-              <p className="text-sm text-muted-foreground">
+            <div className="bg-muted rounded-lg p-3">
+              <p className="text-muted-foreground text-sm">
                 Inviting user to:{' '}
-                <span className="font-medium text-foreground">
+                <span className="text-foreground font-medium">
                   {entityDisplayName}
                 </span>
               </p>
@@ -208,13 +208,13 @@ export function InviteUserModal({
           <div>
             <label
               htmlFor="invite-message"
-              className="mb-1 block text-sm font-medium text-foreground"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               Personal Message (optional)
             </label>
             <textarea
               id="invite-message"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-foreground shadow-sm focus:ring-2 focus:ring-primary focus:outline-none"
+              className="border-input bg-background text-foreground focus:ring-primary w-full rounded-md border px-3 py-2 shadow-sm focus:ring-2 focus:outline-none"
               rows={3}
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -223,7 +223,7 @@ export function InviteUserModal({
           </div>
 
           {/* Info text */}
-          <p className="text-xs text-muted-foreground">
+          <p className="text-muted-foreground text-xs">
             An email invitation will be sent to this address. If the user
             doesn&apos;t have an account, they&apos;ll be prompted to create
             one.


### PR DESCRIPTION
Modal Structure:
- Import and use ModalBody component for proper padding/spacing
- Content now properly wrapped: ModalHeader → ModalBody → ModalFooter

Dark Mode Support:
- Replace bg-gray-50/dark:bg-gray-800 with bg-muted token
- Replace text-gray-*/dark:text-gray-* with text-foreground/text-muted-foreground
- Textarea uses border-input, bg-background, text-foreground
- Focus ring uses focus:ring-primary instead of hardcoded blue

https://github.com/user-attachments/assets/ce1f7586-eeaa-4954-8416-50e76dd6797d

