### PR TITLE
feat(OrderLookupForm): use theme-aware gradient for branding column

### DIFF
--- a/src/components/OrderLookupForm/OrderLookupForm.tsx
+++ b/src/components/OrderLookupForm/OrderLookupForm.tsx
@@ -64,7 +64,13 @@ export function OrderLookupForm({
   return (
     <div className={`flex min-h-screen flex-col md:flex-row ${className}`}>
       {/* Left side - Provider branding */}
-      <div className="flex flex-col items-center justify-center bg-gradient-to-br from-blue-600 to-blue-800 p-8 text-white md:w-1/2 dark:from-blue-800 dark:to-blue-950">
+      <div
+        className="flex flex-col items-center justify-center p-8 text-white md:w-1/2"
+        style={{
+          background:
+            'linear-gradient(to bottom right, var(--mieweb-primary-600, #1f98ca), var(--mieweb-primary-900, #086285))',
+        }}
+      >
         {providerLogo ? (
           <img
             src={providerLogo}


### PR DESCRIPTION
Replace hardcoded blue gradient with CSS custom properties that respect the active brand theme:
- Use --mieweb-primary-600 to --mieweb-primary-900 for gradient
- Gradient now changes with BlueHive (cyan), WebChart (orange), etc.
- Provides consistent brand experience across all themes


https://github.com/user-attachments/assets/0d3a3be1-7570-4e34-917b-244eb4e7481d

