### PR TITLE
feat(PermissionsEditor): add interactive Storybook controls for Docs page

### DIFF
--- a/src/components/PermissionsEditor/PermissionsEditor.stories.tsx
+++ b/src/components/PermissionsEditor/PermissionsEditor.stories.tsx
@@ -12,13 +12,40 @@ const meta: Meta<typeof PermissionsEditor> = {
   title: 'Components/PermissionsEditor',
   component: PermissionsEditor,
   tags: ['autodocs'],
+  argTypes: {
+    userName: {
+      control: 'text',
+      description: 'User name being edited',
+    },
+    showEmployerAccess: {
+      control: 'boolean',
+      description: 'Whether to show employer access section',
+    },
+    className: {
+      control: 'text',
+      description: 'Custom className',
+    },
+    groups: { control: false },
+    assignedPermissions: { control: false },
+    onPermissionsChange: { control: false },
+    employers: { control: false },
+    selectedEmployers: { control: false },
+    onEmployersChange: { control: false },
+    labels: { control: false },
+  },
   parameters: {
     docs: {
       description: {
         component:
           'A hierarchical permission editor for managing user roles with support for nested permissions, employer access control, and summary display.',
       },
+      story: { inline: true },
     },
+  },
+  args: {
+    userName: 'John Doe',
+    showEmployerAccess: false,
+    className: '',
   },
 };
 
@@ -120,6 +147,34 @@ const sampleEmployers: EmployerAccess[] = [
   },
 ];
 
+export const Default: Story = {
+  args: {
+    userName: 'John Doe',
+    showEmployerAccess: false,
+    className: '',
+  },
+  render: function Render(args) {
+    const [permissions, setPermissions] = React.useState<string[]>([]);
+    const [employers, setEmployers] = React.useState<string[]>([]);
+
+    return (
+      <Card className="max-w-2xl p-6">
+        <PermissionsEditor
+          userName={args.userName}
+          groups={sampleGroups}
+          assignedPermissions={permissions}
+          onPermissionsChange={setPermissions}
+          showEmployerAccess={args.showEmployerAccess}
+          employers={args.showEmployerAccess ? sampleEmployers : undefined}
+          selectedEmployers={employers}
+          onEmployersChange={setEmployers}
+          className={args.className}
+        />
+      </Card>
+    );
+  },
+};
+
 // Interactive demo
 function InteractiveDemo() {
   const [permissions, setPermissions] = React.useState<string[]>([
@@ -151,25 +206,6 @@ function InteractiveDemo() {
 
 export const Interactive: Story = {
   render: () => <InteractiveDemo />,
-};
-
-// Basic usage
-function DefaultDemo() {
-  const [permissions, setPermissions] = React.useState<string[]>([]);
-
-  return (
-    <Card className="max-w-2xl p-6">
-      <PermissionsEditor
-        groups={sampleGroups}
-        assignedPermissions={permissions}
-        onPermissionsChange={setPermissions}
-      />
-    </Card>
-  );
-}
-
-export const Default: Story = {
-  render: () => <DefaultDemo />,
 };
 
 // With pre-assigned permissions


### PR DESCRIPTION


- Add argTypes configuration for userName, showEmployerAccess, and className
- Disable controls for complex props (groups, assignedPermissions, onPermissionsChange, employers, selectedEmployers, onEmployersChange, labels)
- Add default args to meta config for proper control initialization
- Reorder stories to make Default the primary story on Docs page
- Simplify Default story render function to use args directly
- Controls now properly update the inline preview on the Docs page

Props with controls:
- userName (text): User name being edited
- showEmployerAccess (boolean): Toggle employer access section
- className (text): Custom CSS class

Props without controls (complex types):
- groups, assignedPermissions, onPermissionsChange
- employers, selectedEmployers, onEmployersChange, labels

https://github.com/user-attachments/assets/e6e5dde3-b98e-4bff-9d84-119f2639ad9c

