### PR TITLE
feat(RecurringServiceCard): redesign UI to match CSVColumnMapper patterns

### DIFF
--- a/src/components/RecurringServiceCard/RecurringServiceCard.stories.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.stories.tsx
@@ -7,12 +7,33 @@ import {
   RecurringServiceGrid,
   type RecurringService,
   type RecurringServiceFormData,
+  type RecurringServiceCardState,
 } from './RecurringServiceCard';
 
 const meta: Meta<typeof RecurringServiceCard> = {
   title: 'Components/RecurringServiceCard',
   component: RecurringServiceCard,
   tags: ['autodocs'],
+  argTypes: {
+    state: {
+      control: 'select',
+      options: [
+        undefined,
+        'default',
+        'success',
+        'primary',
+        'warning',
+        'error',
+        'disabled',
+      ] as (RecurringServiceCardState | undefined)[],
+      description:
+        'Card state - controls border color and status icon. If not set, uses neutral gray styling.',
+    },
+    showProvider: {
+      control: 'boolean',
+      description: 'Whether to show the provider name',
+    },
+  },
 };
 
 export default meta;
@@ -57,6 +78,47 @@ export const Default: Story = {
   args: {
     service: sampleService,
     showProvider: true,
+  },
+};
+
+// State variants
+export const SuccessState: Story = {
+  args: {
+    service: sampleService,
+    showProvider: true,
+    state: 'success',
+  },
+};
+
+export const PrimaryState: Story = {
+  args: {
+    service: sampleService,
+    showProvider: true,
+    state: 'primary',
+  },
+};
+
+export const WarningState: Story = {
+  args: {
+    service: sampleService,
+    showProvider: true,
+    state: 'warning',
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    service: sampleService,
+    showProvider: true,
+    state: 'error',
+  },
+};
+
+export const DisabledState: Story = {
+  args: {
+    service: sampleService,
+    showProvider: true,
+    state: 'disabled',
   },
 };
 

--- a/src/components/RecurringServiceCard/index.ts
+++ b/src/components/RecurringServiceCard/index.ts
@@ -4,6 +4,7 @@ export {
   RecurringServiceSetupModal,
   RecurringServiceGrid,
   type RecurringServiceCardProps,
+  type RecurringServiceCardState,
   type RecurringService,
   type RecurringServiceAddCardProps,
   type RecurringServiceSetupModalProps,


### PR DESCRIPTION


## UI Redesign
- Updated card styling to match CSVColumnMapper design system
- Added rounded-xl border-2 shadow-sm card styling
- Labels now use uppercase tracking-wider font styling
- Values displayed in bg-muted rounded-md boxes
- Delete button styled as subtle centered link

## State System
- Added RecurringServiceCardState type with 6 variants:
  - default: Gray border, no icon (neutral state)
  - success: Green border + checkmark icon
  - primary: Blue border + info circle icon
  - warning: Orange border + dot icon, shows consent note
  - error: Red border + X icon, shows consent note
  - disabled: Gray border, faded opacity, no interactions
- State can be explicitly set via prop or defaults to 'default'
- Each state has distinct border color, icon, and showNote behavior

## Stories Updates
- Added state control to Storybook argTypes with all 6 options
- Added individual stories for each state variant: SuccessState, PrimaryState, WarningState, ErrorState, DisabledState
- Removed invalid showDeleteButton argType (not a component prop)

## Bug Fixes
- Added early return guard for undefined service prop
- Added optional chaining for service.overrideConsent access
- Prevents TypeError in Grid stories when service is undefined

## Exports
- Added RecurringServiceCardState type export to index.ts


https://github.com/user-attachments/assets/907d1c89-d45c-4fc2-b288-c987745d1675

