### PR TITLE
feat(Sidebar): add interactive Storybook controls for docs page

### DIFF
--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -462,7 +462,13 @@ export const Default: Story = {
 
 export const Collapsible: Story = {
   render: (args) => (
-    <SidebarProvider defaultExpandedGroup="main">
+    <SidebarProvider
+      defaultExpandedGroup={
+        args.defaultExpandedGroup === 'none'
+          ? undefined
+          : args.defaultExpandedGroup
+      }
+    >
       <div className={args.darkMode ? 'dark' : ''}>
         <CollapsibleDemo />
       </div>
@@ -472,11 +478,19 @@ export const Collapsible: Story = {
     showSearch: false,
     showBadges: false,
   },
+  argTypes: {
+    // Hide controls that don't apply to the CollapsibleDemo
+    expandedWidth: { table: { disable: true } },
+    collapsedWidth: { table: { disable: true } },
+    showSearch: { table: { disable: true } },
+    showBadges: { table: { disable: true } },
+    defaultExpandedGroup: { table: { disable: true } },
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'The sidebar can be collapsed to save screen space. Icons remain visible in collapsed state.',
+          'The sidebar can be collapsed to save screen space. Icons remain visible in collapsed state. This demo uses flat navigation without groups to focus on the collapse behavior.',
       },
     },
   },


### PR DESCRIPTION
- Add custom SidebarStoryArgs interface with configurable props:
  - expandedWidth/collapsedWidth: dimension controls
  - showSearch: toggle search input visibility
  - defaultExpandedGroup: select which nav group is expanded
  - showBadges: toggle notification badges on nav items
  - darkMode: toggle dark mode preview

- Create ConfigurableSidebarDemo component that consumes args
- Update all stories (Default, Collapsible, MobileView) to use args
- Wrap stories with SidebarProvider using args.defaultExpandedGroup
- Organize controls into categories: Dimensions, Features, Appearance

Controls were previously not set up - now all toggles and inputs work interactively in the Storybook docs page.


https://github.com/user-attachments/assets/0a367f99-92fb-428e-b5b2-43a521b95b2e

