### PR TITLE
fix: add controls to ServiceAccordion Storybook docs page

### DIFF
--- a/src/components/ServiceAccordion/ServiceAccordion.stories.tsx
+++ b/src/components/ServiceAccordion/ServiceAccordion.stories.tsx
@@ -77,18 +77,38 @@ const meta: Meta<typeof ServiceAccordion> = {
   parameters: {
     layout: 'padded',
   },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'bordered', 'cards'],
+      description: 'Visual style variant',
+    },
+    allowMultiple: {
+      control: 'boolean',
+      description: 'Allow multiple categories to be expanded at once',
+    },
+    basePath: {
+      control: 'text',
+      description: 'Base path for service links',
+    },
+    categories: { table: { disable: true } },
+    expandedCategories: { table: { disable: true } },
+    onExpandedChange: { table: { disable: true } },
+    onServiceClick: { action: 'service-clicked' },
+  },
+  args: {
+    categories: mockCategories,
+    variant: 'default',
+    allowMultiple: true,
+    basePath: '/service',
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof ServiceAccordion>;
 
 // Default accordion
-export const Default: Story = {
-  args: {
-    categories: mockCategories,
-    onServiceClick: (service) => console.log('Clicked:', service.slug),
-  },
-};
+export const Default: Story = {};
 
 // All variants comparison
 export const AllVariants: Story = {


### PR DESCRIPTION
- Add argTypes for variant (select: default/bordered/cards), allowMultiple (boolean), and basePath (text input)
- Disable expandedCategories control to prevent crash from 'Set object' button assigning {} to a string[] prop (breaks .includes())
- Disable complex object props (categories, onExpandedChange)
- Add onServiceClick as action handler
- Move categories to shared meta args and simplify Default story

https://github.com/user-attachments/assets/db3cbcae-abe5-400f-bdf9-86776473e2d2

