### PR TITLE
fix: add dark mode text color for list items on docs pages

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -38,7 +38,8 @@ html, body {
 
 [data-theme="dark"] .sbdocs p,
 [data-theme="dark"] .sbdocs span,
-[data-theme="dark"] .sbdocs label {
+[data-theme="dark"] .sbdocs label,
+[data-theme="dark"] .sbdocs li {
   color: var(--mieweb-muted-foreground, #a1a1aa) !important;
 }
 


### PR DESCRIPTION
The dark mode CSS rules in preview.css targeted p, span, and label elements inside .sbdocs but missed li elements. This caused bullet list items in autodocs pages (e.g., JSDoc descriptions rendered by Storybook) to inherit the default near-black text color, making them nearly unreadable against the dark background.

- Add [data-theme="dark"] .sbdocs li selector alongside existing p, span, and label rules
- Uses the same var(--mieweb-muted-foreground, #a1a1aa) value for consistent text appearance across all prose elements

<img width="1208" height="488" alt="image" src="https://github.com/user-attachments/assets/a9d28124-b258-454d-a88d-eaa301f1f5e1" />
