### PR TITLE
feat: move AG Grid to separate entry point (@mieweb/ui/ag-grid)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,16 @@
         "default": "./dist/brands/*.cjs"
       }
     },
+    "./ag-grid": {
+      "import": {
+        "types": "./dist/ag-grid.d.ts",
+        "default": "./dist/ag-grid.js"
+      },
+      "require": {
+        "types": "./dist/ag-grid.d.cts",
+        "default": "./dist/ag-grid.cjs"
+      }
+    },
     "./styles.css": "./dist/styles.css",
     "./styles": "./dist/styles.css"
   },

--- a/src/ag-grid.ts
+++ b/src/ag-grid.ts
@@ -1,0 +1,11 @@
+/**
+ * AG Grid entry point — separate from the main bundle.
+ *
+ * Usage:
+ *   npm install @mieweb/ui ag-grid-community ag-grid-react
+ *   import { AGGrid } from '@mieweb/ui/ag-grid';
+ *
+ * This keeps ag-grid-community and ag-grid-react out of the default
+ * install/bundle so consumers who don't need grids aren't burdened.
+ */
+export * from './components/AGGrid';

--- a/src/components/AGGrid/AGGrid.stories.tsx
+++ b/src/components/AGGrid/AGGrid.stories.tsx
@@ -268,14 +268,30 @@ A themed AG Grid wrapper component that integrates with the MIE Web UI design sy
 - **Full AG Grid API**: Access all AG Grid features through the wrapper
 
 ## Installation
-AG Grid must be installed separately:
+
+AG Grid is **not** included in the default \`@mieweb/ui\` install — it's an opt-in dependency.
+This keeps the base package lightweight for consumers who don't need data grids.
+
+**1. Install AG Grid alongside \`@mieweb/ui\`:**
+
 \`\`\`bash
-npm install ag-grid-community ag-grid-react
+npm install @mieweb/ui ag-grid-community ag-grid-react
 \`\`\`
+
+**2. Import from the \`@mieweb/ui/ag-grid\` sub-path** (not the main entry):
+
+\`\`\`tsx
+import { AGGrid } from '@mieweb/ui/ag-grid';
+\`\`\`
+
+> **Why a separate import?** The main \`@mieweb/ui\` entry never references AG Grid,
+> so bundlers won't try to resolve \`ag-grid-community\` or \`ag-grid-react\` unless
+> you explicitly import from \`@mieweb/ui/ag-grid\`. No AG Grid installed? No problem —
+> everything else works fine.
 
 ## Basic Usage
 \`\`\`tsx
-import { AGGrid } from '@mieweb/ui';
+import { AGGrid } from '@mieweb/ui/ag-grid';
 import 'ag-grid-community/styles/ag-grid.css';
 
 const columnDefs = [
@@ -288,6 +304,18 @@ const rowData = [
 ];
 
 <AGGrid columnDefs={columnDefs} rowData={rowData} />
+\`\`\`
+
+## Cell Renderers
+
+Pre-built cell renderers are also available from the same sub-path:
+
+\`\`\`tsx
+import {
+  AGGrid,
+  MemoizedStatusBadgeRenderer,
+  MemoizedCurrencyRenderer,
+} from '@mieweb/ui/ag-grid';
 \`\`\`
         `,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@
 export * from './components/AddContactModal';
 export * from './components/AdditionalFields';
 export * from './components/Address';
-export * from './components/AGGrid';
+// AG Grid is exported via a separate entry point: @mieweb/ui/ag-grid
+// This avoids forcing ag-grid-community/ag-grid-react on all consumers.
+// See: src/ag-grid.ts
 export * from './components/AI';
 export * from './components/Alert';
 export * from './components/AppHeader';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    'ag-grid': 'src/ag-grid.ts',
     'hooks/index': 'src/hooks/index.ts',
     'utils/index': 'src/utils/index.ts',
     'tailwind-preset': 'src/tailwind-preset.ts',
@@ -50,7 +51,7 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'ag-grid-community', 'ag-grid-react'],
   treeshake: true,
   splitting: true,
   minify: false,


### PR DESCRIPTION
- Remove AGGrid from main barrel export (src/index.ts)
- Add dedicated src/ag-grid.ts entry point
- Add ag-grid entry to tsup config + externalize ag-grid packages
- Add ./ag-grid export map in package.json
- Update AGGrid Storybook docs with new import instructions

Consumers who don't need AG Grid are no longer burdened with it. Import from '@mieweb/ui/ag-grid' to opt in.

<img width="1054" height="1005" alt="image" src="https://github.com/user-attachments/assets/cba5f264-1acb-4284-805a-9facbc280d44" />
