### PR TITLE
feat(DashboardWidget): add composable dashboard widget system with 4 variants

### DIFF
--- a/src/components/Dashboard/DashboardWidgets.stories.tsx
+++ b/src/components/Dashboard/DashboardWidgets.stories.tsx
@@ -1,0 +1,703 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  DashboardWidget,
+  DashboardWidgetInfo,
+  DashboardWidgetTable,
+  DashboardWidgetActions,
+  DashboardWidgetDataCards,
+} from '../DashboardWidget';
+import { Badge } from '../Badge';
+import { Avatar } from '../Avatar';
+import { CountBadge } from '../CountBadge';
+import { PatientHeader, type PatientData } from '../PatientHeader';
+import { Text } from '../Text';
+import {
+  UserIcon,
+  CalendarIcon,
+  PencilIcon,
+  TrashIcon,
+  HeartIcon,
+  AlertTriangleIcon,
+  PillIcon,
+  ClipboardListIcon,
+  ZapIcon,
+  StethoscopeIcon,
+  HeartPulseIcon,
+  DollarSignIcon,
+  UsersIcon,
+  ActivityIcon,
+  FileTextIcon,
+  MailIcon,
+  BellIcon,
+} from '../Icons';
+
+// =============================================================================
+// Meta
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Examples/Dashboard (Widgets)',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+// =============================================================================
+// Mock Data
+// =============================================================================
+
+const noop = () => {};
+
+const samplePatient: PatientData = {
+  name: { first: 'William', last: 'Hart', middle: 'S' },
+  mrn: 'MRN-000001',
+  dob: '04-03-1948',
+  age: 77,
+  sex: 'M',
+  status: 'active',
+  email: 'whart@example.com',
+  phone: '555-867-5309',
+  employer: 'Acme Corp.',
+  attendingProvider: 'Dr. Sarah Chen',
+};
+
+const sampleAllergies = [
+  { name: 'Penicillin', severity: 'moderate' as const },
+  { name: 'Sulfa Drugs', severity: 'mild' as const },
+];
+
+const sampleMedications = [
+  { name: 'Lisinopril' },
+  { name: 'Atorvastatin' },
+  { name: 'Metformin' },
+];
+
+// -- Stats
+const statsItems = [
+  { label: 'Total Revenue', value: '$45,231.89' },
+  { label: 'Subscriptions', value: '+2,350' },
+  { label: 'Sales', value: '+12,234' },
+  { label: 'Active Now', value: '+573' },
+];
+
+// -- Orders
+type Order = {
+  id: string;
+  customer: string;
+  status: string;
+  amount: string;
+  date: string;
+};
+
+const orderData: Order[] = [
+  {
+    id: 'ORD-001',
+    customer: 'John Doe',
+    status: 'completed',
+    amount: '$250.00',
+    date: '2024-01-15',
+  },
+  {
+    id: 'ORD-002',
+    customer: 'Jane Smith',
+    status: 'pending',
+    amount: '$150.00',
+    date: '2024-01-14',
+  },
+  {
+    id: 'ORD-003',
+    customer: 'Bob Johnson',
+    status: 'cancelled',
+    amount: '$75.00',
+    date: '2024-01-13',
+  },
+  {
+    id: 'ORD-004',
+    customer: 'Alice Brown',
+    status: 'completed',
+    amount: '$320.00',
+    date: '2024-01-12',
+  },
+  {
+    id: 'ORD-005',
+    customer: 'Charlie Wilson',
+    status: 'processing',
+    amount: '$180.00',
+    date: '2024-01-11',
+  },
+];
+
+const statusVariant = (s: string) =>
+  s === 'completed'
+    ? 'success'
+    : s === 'pending'
+      ? 'warning'
+      : s === 'processing'
+        ? 'secondary'
+        : ('danger' as const);
+
+// -- Activity
+type ActivityItem = { user: string; action: string; time: string };
+
+const activityData: ActivityItem[] = [
+  { user: 'John Doe', action: 'updated profile', time: '2 min ago' },
+  { user: 'Jane Smith', action: 'added new project', time: '1 hour ago' },
+  { user: 'Bob Johnson', action: 'completed task', time: '3 hours ago' },
+  { user: 'Alice Brown', action: 'left a comment', time: '5 hours ago' },
+];
+
+// -- Quick Actions
+const quickActions = [
+  {
+    label: 'Add User',
+    icon: <UsersIcon className="h-3.5 w-3.5" />,
+    color: 'blue' as const,
+    onClick: noop,
+  },
+  {
+    label: 'New Order',
+    icon: <DollarSignIcon className="h-3.5 w-3.5" />,
+    color: 'green' as const,
+    onClick: noop,
+  },
+  {
+    label: 'View Reports',
+    icon: <ActivityIcon className="h-3.5 w-3.5" />,
+    color: 'purple' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Send Email',
+    icon: <MailIcon className="h-3.5 w-3.5" />,
+    color: 'orange' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Notifications',
+    icon: <BellIcon className="h-3.5 w-3.5" />,
+    color: 'amber' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Settings',
+    icon: <FileTextIcon className="h-3.5 w-3.5" />,
+    color: 'neutral' as const,
+    onClick: noop,
+  },
+];
+
+// -- Patient summary (clinical flavor)
+const patientInfo = [
+  { label: 'Name', value: 'Hart, William' },
+  { label: 'DOB', value: '1948-04-03 (77 y/o)' },
+  { label: 'Gender', value: 'male' },
+  { label: 'MRN', value: 'MRN-000001' },
+  { label: 'Phone', value: '555-867-5309' },
+  { label: 'Email', value: 'whart@example.com' },
+  {
+    label: 'Address',
+    value: '123 Main St, Fort Wayne, IN 46802',
+    fullWidth: true,
+  },
+];
+
+type Encounter = {
+  date: string;
+  type: string;
+  provider: string;
+  status: string;
+};
+const encounterData: Encounter[] = [
+  {
+    date: '2025-12-15',
+    type: 'office-visit',
+    provider: 'Dr. Sarah Chen',
+    status: 'completed',
+  },
+  {
+    date: '2025-09-10',
+    type: 'office-visit',
+    provider: 'Dr. Sarah Chen',
+    status: 'completed',
+  },
+  {
+    date: '2025-06-02',
+    type: 'office-visit',
+    provider: 'Dr. Sarah Chen',
+    status: 'completed',
+  },
+];
+
+type Allergy = { allergen: string; reaction: string; severity: string };
+const allergyData: Allergy[] = [
+  { allergen: 'Penicillin', reaction: 'Hives', severity: 'moderate' },
+  { allergen: 'Sulfa Drugs', reaction: 'Rash', severity: 'mild' },
+];
+
+type Medication = { name: string; details: string };
+const medicationData: Medication[] = [
+  { name: 'Lisinopril', details: '10 mg oral, Once daily' },
+  { name: 'Atorvastatin', details: '20 mg oral, Once daily at bedtime' },
+  { name: 'Metformin', details: '500 mg oral, Twice daily' },
+];
+
+type Condition = { name: string; code: string; status: string };
+const conditionData: Condition[] = [
+  { name: 'Essential Hypertension', code: 'I10', status: 'active' },
+  { name: 'Type 2 Diabetes Mellitus', code: 'E11.9', status: 'active' },
+  { name: 'Hyperlipidemia', code: 'E78.5', status: 'active' },
+];
+
+const vitalItems = [
+  { label: 'BP', value: '128/82' },
+  { label: 'Pulse', value: '72' },
+  { label: 'Temp', value: '98.6', unit: '°F' },
+  { label: 'Resp', value: '16' },
+  { label: 'HT', value: '70', unit: '"' },
+  { label: 'WT', value: '195', unit: 'lbs' },
+  { label: 'BMI', value: '28' },
+  { label: 'O₂ Sat', value: '97', unit: '%' },
+];
+
+const clinicalActions = [
+  {
+    label: 'Add Encounter',
+    icon: <CalendarIcon className="h-3.5 w-3.5" />,
+    color: 'primary' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Record Vitals',
+    icon: <HeartPulseIcon className="h-3.5 w-3.5" />,
+    color: 'red' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Add Allergy',
+    icon: <AlertTriangleIcon className="h-3.5 w-3.5" />,
+    color: 'orange' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Add Medication',
+    icon: <PillIcon className="h-3.5 w-3.5" />,
+    color: 'amber' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Add Condition',
+    icon: <StethoscopeIcon className="h-3.5 w-3.5" />,
+    color: 'green' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Print Chart',
+    icon: <FileTextIcon className="h-3.5 w-3.5" />,
+    color: 'neutral' as const,
+    onClick: noop,
+  },
+];
+
+// =============================================================================
+// Story: Business Dashboard
+// =============================================================================
+
+/**
+ * A business-style dashboard with stats, orders table, activity feed,
+ * and quick actions — all composed from DashboardWidget variants.
+ */
+export const BusinessDashboard: StoryObj = {
+  render: () => (
+    <div className="bg-muted/30 min-h-screen p-6">
+      <div className="mx-auto max-w-[1200px] space-y-6">
+        {/* Page heading */}
+        <div>
+          <h1 className="text-foreground text-2xl font-bold">Dashboard</h1>
+          <p className="text-muted-foreground text-sm">Welcome back, John</p>
+        </div>
+
+        {/* Stats row */}
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {statsItems.map((stat) => (
+            <DashboardWidget
+              key={stat.label}
+              title={stat.label}
+              icon={<ActivityIcon className="h-4 w-4" />}
+            >
+              <Text size="3xl" weight="bold">
+                {stat.value}
+              </Text>
+              <Badge variant="success" className="mt-2">
+                +20.1% from last month
+              </Badge>
+            </DashboardWidget>
+          ))}
+        </div>
+
+        {/* Main grid: Orders + Activity */}
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <DashboardWidget
+              title="Recent Orders"
+              icon={<DollarSignIcon className="h-4 w-4" />}
+              count={orderData.length}
+            >
+              <DashboardWidgetTable<Order>
+                showHeader
+                columns={[
+                  {
+                    key: 'id',
+                    header: 'Order ID',
+                    render: (r) => <span className="font-medium">{r.id}</span>,
+                  },
+                  { key: 'customer', header: 'Customer' },
+                  {
+                    key: 'status',
+                    header: 'Status',
+                    render: (r) => (
+                      <Badge variant={statusVariant(r.status)} size="sm">
+                        {r.status}
+                      </Badge>
+                    ),
+                  },
+                  { key: 'amount', header: 'Amount', align: 'right' },
+                ]}
+                data={orderData}
+                actions={[
+                  {
+                    label: 'Edit',
+                    icon: <PencilIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                  {
+                    label: 'Delete',
+                    icon: <TrashIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                ]}
+              />
+            </DashboardWidget>
+          </div>
+
+          <DashboardWidget
+            title="Recent Activity"
+            icon={<ActivityIcon className="h-4 w-4" />}
+            count={activityData.length}
+          >
+            <DashboardWidgetTable<ActivityItem>
+              columns={[
+                {
+                  key: 'user',
+                  render: (row) => (
+                    <div className="flex items-center gap-3">
+                      <Avatar name={row.user} size="sm" />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">
+                          {row.user}
+                        </div>
+                        <div className="text-muted-foreground text-xs">
+                          {row.action}
+                        </div>
+                      </div>
+                    </div>
+                  ),
+                },
+                {
+                  key: 'time',
+                  align: 'right',
+                  className: 'text-xs text-muted-foreground whitespace-nowrap',
+                },
+              ]}
+              data={activityData}
+            />
+          </DashboardWidget>
+        </div>
+
+        {/* Quick Actions */}
+        <DashboardWidget
+          title="Quick Actions"
+          icon={<ZapIcon className="h-4 w-4" />}
+        >
+          <DashboardWidgetActions columns={3} actions={quickActions} />
+        </DashboardWidget>
+      </div>
+    </div>
+  ),
+};
+
+// =============================================================================
+// Story: Patient Summary (Clinical)
+// =============================================================================
+
+/**
+ * A clinical patient summary dashboard matching the reference screenshot —
+ * demographics, encounters, vitals, quick links, allergies, medications,
+ * and medical history.
+ */
+export const PatientSummary: StoryObj = {
+  render: () => (
+    <div className="bg-muted/30 min-h-screen">
+      {/* Patient Header */}
+      <PatientHeader
+        patient={samplePatient}
+        allergies={sampleAllergies}
+        medications={sampleMedications}
+        showAllergyBanner
+        showMedicationBanner
+        showDetails
+        sticky={false}
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <CountBadge label="Tasks" count={3} />
+            <CountBadge label="Open Enc" count={5} />
+            <CountBadge label="Due List" count={4} />
+          </div>
+        }
+      />
+
+      <div className="mx-auto max-w-[1800px] space-y-6 p-6">
+        {/* 3-column grid */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 [&>*]:min-w-0">
+          {/* Column 1 — Demographics */}
+          <div className="space-y-4">
+            <DashboardWidget
+              title="Demographics"
+              icon={<UserIcon className="h-4 w-4" />}
+              headerAction={
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1 transition-colors"
+                  aria-label="Edit demographics"
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </button>
+              }
+            >
+              <DashboardWidgetInfo columns={2} items={patientInfo} />
+            </DashboardWidget>
+          </div>
+
+          {/* Column 2 — Encounters + Vitals */}
+          <div className="space-y-4">
+            <DashboardWidget
+              title="Encounters"
+              icon={<CalendarIcon className="h-4 w-4" />}
+              count={encounterData.length}
+              onAdd={noop}
+            >
+              <DashboardWidgetTable<Encounter>
+                columns={[
+                  {
+                    key: 'date',
+                    render: (row) => (
+                      <div>
+                        <span className="font-medium">{row.date}</span>
+                        <span className="text-muted-foreground">
+                          {' '}
+                          — {row.type}
+                        </span>
+                        <div className="text-muted-foreground text-xs">
+                          ({row.provider})
+                        </div>
+                      </div>
+                    ),
+                  },
+                  {
+                    key: 'status',
+                    align: 'right',
+                    render: (row) => (
+                      <Badge variant="success" size="sm">
+                        {row.status}
+                      </Badge>
+                    ),
+                  },
+                ]}
+                data={encounterData}
+                actions={[
+                  {
+                    label: 'Edit',
+                    icon: <PencilIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                  {
+                    label: 'Delete',
+                    icon: <TrashIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                ]}
+              />
+            </DashboardWidget>
+
+            <DashboardWidget
+              title="Vitals"
+              icon={<HeartIcon className="h-4 w-4" />}
+              count={vitalItems.length}
+              onAdd={noop}
+            >
+              <DashboardWidgetDataCards
+                columns={2}
+                items={vitalItems}
+                footer={
+                  <>
+                    <span>Date: 2025-12-15</span>
+                    <button
+                      type="button"
+                      className="hover:bg-muted rounded p-0.5 transition-colors"
+                      aria-label="Delete"
+                    >
+                      <TrashIcon className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                }
+              />
+            </DashboardWidget>
+          </div>
+
+          {/* Column 3 — Quick Links, Allergies, Medications, Medical History */}
+          <div className="space-y-4">
+            <DashboardWidget
+              title="Quick Links"
+              icon={<ZapIcon className="h-4 w-4" />}
+            >
+              <DashboardWidgetActions columns={2} actions={clinicalActions} />
+            </DashboardWidget>
+
+            <DashboardWidget
+              title="Allergies"
+              icon={<AlertTriangleIcon className="h-4 w-4" />}
+              count={allergyData.length}
+              onAdd={noop}
+            >
+              <DashboardWidgetTable<Allergy>
+                columns={[
+                  {
+                    key: 'allergen',
+                    render: (row) => (
+                      <span>
+                        <span className="font-medium">{row.allergen}</span>
+                        <span className="text-muted-foreground">
+                          {' '}
+                          — {row.reaction}
+                        </span>
+                      </span>
+                    ),
+                  },
+                  {
+                    key: 'severity',
+                    align: 'right',
+                    render: (row) => (
+                      <Badge
+                        variant={
+                          row.severity === 'moderate' ? 'warning' : 'secondary'
+                        }
+                        size="sm"
+                      >
+                        {row.severity}
+                      </Badge>
+                    ),
+                  },
+                ]}
+                data={allergyData}
+                actions={[
+                  {
+                    label: 'Edit',
+                    icon: <PencilIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                  {
+                    label: 'Delete',
+                    icon: <TrashIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                ]}
+              />
+            </DashboardWidget>
+
+            <DashboardWidget
+              title="Medications"
+              icon={<PillIcon className="h-4 w-4" />}
+              count={medicationData.length}
+              onAdd={noop}
+            >
+              <DashboardWidgetTable<Medication>
+                columns={[
+                  {
+                    key: 'name',
+                    render: (row) => (
+                      <span>
+                        <span className="font-medium">{row.name}</span>{' '}
+                        <span className="text-muted-foreground">
+                          {row.details}
+                        </span>
+                      </span>
+                    ),
+                  },
+                ]}
+                data={medicationData}
+                actions={[
+                  {
+                    label: 'Edit',
+                    icon: <PencilIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                  {
+                    label: 'Delete',
+                    icon: <TrashIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                ]}
+              />
+            </DashboardWidget>
+
+            <DashboardWidget
+              title="Medical History"
+              icon={<ClipboardListIcon className="h-4 w-4" />}
+              count={conditionData.length}
+              onAdd={noop}
+            >
+              <DashboardWidgetTable<Condition>
+                columns={[
+                  {
+                    key: 'name',
+                    render: (row) => (
+                      <span>
+                        <span className="font-medium">{row.name}</span>{' '}
+                        <span className="text-muted-foreground">
+                          ({row.code})
+                        </span>
+                      </span>
+                    ),
+                  },
+                  {
+                    key: 'status',
+                    align: 'right',
+                    render: (row) => (
+                      <Badge variant="success" size="sm">
+                        {row.status}
+                      </Badge>
+                    ),
+                  },
+                ]}
+                data={conditionData}
+                actions={[
+                  {
+                    label: 'Edit',
+                    icon: <PencilIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                  {
+                    label: 'Delete',
+                    icon: <TrashIcon className="h-3.5 w-3.5" />,
+                    onClick: noop,
+                  },
+                ]}
+              />
+            </DashboardWidget>
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/DashboardWidget/DashboardWidget.stories.tsx
+++ b/src/components/DashboardWidget/DashboardWidget.stories.tsx
@@ -1,0 +1,925 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  DashboardWidget,
+  DashboardWidgetInfo,
+  DashboardWidgetTable,
+  DashboardWidgetActions,
+  DashboardWidgetDataCards,
+} from './DashboardWidget';
+import { Badge } from '../Badge';
+import {
+  UserIcon,
+  CalendarIcon,
+  PencilIcon,
+  TrashIcon,
+  HeartIcon,
+  AlertTriangleIcon,
+  PillIcon,
+  ClipboardListIcon,
+  ZapIcon,
+  StethoscopeIcon,
+  HeartPulseIcon,
+} from '../Icons';
+import { Printer } from 'lucide-react';
+
+// =============================================================================
+// Meta
+// =============================================================================
+
+const meta: Meta<typeof DashboardWidget> = {
+  title: 'Data Display/DashboardWidget',
+  component: DashboardWidget,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    count: { control: 'number' },
+    loading: { control: 'boolean' },
+    accent: {
+      control: 'select',
+      options: [
+        undefined,
+        'primary',
+        'success',
+        'warning',
+        'destructive',
+        'info',
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DashboardWidget>;
+
+// =============================================================================
+// Helpers — mock data
+// =============================================================================
+
+const noop = () => {};
+
+// -- Demographics
+const demographicItems = [
+  { label: 'Name', value: 'Hart, William' },
+  { label: 'DOB', value: '1948-04-03 (77 y/o)' },
+  { label: 'Gender', value: 'male' },
+  {
+    label: 'MRN',
+    value: (
+      <span className="border-border inline-flex rounded border px-1.5 py-0.5 font-mono text-xs">
+        MRN-000001
+      </span>
+    ),
+  },
+  { label: 'Phone', value: '555-867-5309' },
+  { label: 'Email', value: 'whart@example.com' },
+  {
+    label: 'Address',
+    value: (
+      <>
+        123 Main St
+        <br />
+        Fort Wayne, IN 46802
+      </>
+    ),
+    fullWidth: true,
+  },
+];
+
+// -- Encounters
+type Encounter = {
+  date: string;
+  type: string;
+  provider: string;
+  status: string;
+};
+
+const encounterData: Encounter[] = [
+  {
+    date: '2025-12-15',
+    type: 'office-visit',
+    provider: 'Dr. Sarah Chen',
+    status: 'completed',
+  },
+  {
+    date: '2025-09-10',
+    type: 'office-visit',
+    provider: 'Dr. Sarah Chen',
+    status: 'completed',
+  },
+  {
+    date: '2025-06-02',
+    type: 'office-visit',
+    provider: 'Dr. Sarah Chen',
+    status: 'completed',
+  },
+];
+
+// -- Allergies
+type Allergy = {
+  allergen: string;
+  reaction: string;
+  severity: string;
+};
+
+const allergyData: Allergy[] = [
+  { allergen: 'Penicillin', reaction: 'Hives', severity: 'moderate' },
+  { allergen: 'Sulfa Drugs', reaction: 'Rash', severity: 'mild' },
+];
+
+// -- Medications
+type Medication = {
+  name: string;
+  details: string;
+};
+
+const medicationData: Medication[] = [
+  { name: 'Lisinopril', details: '10 mg oral, Once daily' },
+  { name: 'Atorvastatin', details: '20 mg oral, Once daily at bedtime' },
+  { name: 'Metformin', details: '500 mg oral, Twice daily' },
+];
+
+// -- Medical History
+type Condition = {
+  name: string;
+  code: string;
+  status: string;
+};
+
+const conditionData: Condition[] = [
+  { name: 'Essential Hypertension', code: 'I10', status: 'active' },
+  { name: 'Type 2 Diabetes Mellitus', code: 'E11.9', status: 'active' },
+  { name: 'Hyperlipidemia', code: 'E78.5', status: 'active' },
+];
+
+// -- Vitals
+const vitalItems = [
+  { label: 'BP', value: '128/82' },
+  { label: 'Pulse', value: '72' },
+  { label: 'Temp', value: '98.6', unit: '°F' },
+  { label: 'Resp', value: '16' },
+  { label: 'HT', value: '70', unit: '"' },
+  { label: 'WT', value: '195', unit: 'lbs' },
+  { label: 'BMI', value: '28' },
+  { label: 'O₂ Sat', value: '97', unit: '%' },
+];
+
+// -- Quick Links
+const quickLinkActions = [
+  {
+    label: 'Add Encounter',
+    icon: <CalendarIcon className="h-3.5 w-3.5" />,
+    color: 'primary' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Record Vitals',
+    icon: <HeartPulseIcon className="h-3.5 w-3.5" />,
+    color: 'red' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Add Allergy',
+    icon: <AlertTriangleIcon className="h-3.5 w-3.5" />,
+    color: 'orange' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Add Medication',
+    icon: <PillIcon className="h-3.5 w-3.5" />,
+    color: 'amber' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Add Condition',
+    icon: <StethoscopeIcon className="h-3.5 w-3.5" />,
+    color: 'green' as const,
+    onClick: noop,
+  },
+  {
+    label: 'Print Chart',
+    icon: <Printer className="h-3.5 w-3.5" />,
+    color: 'neutral' as const,
+    onClick: noop,
+  },
+];
+
+// =============================================================================
+// Stories — Playground with variant control
+// =============================================================================
+
+const variantMap = {
+  info: {
+    title: 'Demographics',
+    icon: <UserIcon className="h-4 w-4" />,
+    body: <DashboardWidgetInfo columns={2} items={demographicItems} />,
+  },
+  table: {
+    title: 'Encounters',
+    icon: <CalendarIcon className="h-4 w-4" />,
+    count: encounterData.length,
+    body: (
+      <DashboardWidgetTable<Encounter>
+        columns={[
+          {
+            key: 'date',
+            render: (row: Encounter) => (
+              <div>
+                <span className="font-medium">{row.date}</span>
+                <span className="text-muted-foreground"> — {row.type}</span>
+                <div className="text-muted-foreground text-xs">
+                  ({row.provider})
+                </div>
+              </div>
+            ),
+          },
+          {
+            key: 'status',
+            align: 'right' as const,
+            render: (row: Encounter) => (
+              <Badge variant="success" size="sm">
+                {row.status}
+              </Badge>
+            ),
+          },
+        ]}
+        data={encounterData}
+        actions={[
+          {
+            label: 'Edit',
+            icon: <PencilIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+          {
+            label: 'Delete',
+            icon: <TrashIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+        ]}
+      />
+    ),
+  },
+  actions: {
+    title: 'Quick Links',
+    icon: <ZapIcon className="h-4 w-4" />,
+    body: <DashboardWidgetActions columns={2} actions={quickLinkActions} />,
+  },
+  'data-cards': {
+    title: 'Vitals',
+    icon: <HeartIcon className="h-4 w-4" />,
+    count: vitalItems.length,
+    body: (
+      <DashboardWidgetDataCards
+        columns={2}
+        items={vitalItems}
+        footer={
+          <>
+            <span>Date: 2025-12-15</span>
+            <button
+              type="button"
+              className="hover:bg-muted rounded p-0.5 transition-colors"
+              aria-label="Delete vitals record"
+            >
+              <TrashIcon className="h-3.5 w-3.5" />
+            </button>
+          </>
+        }
+      />
+    ),
+  },
+} as const;
+
+type VariantKey = keyof typeof variantMap;
+
+/**
+ * Interactive playground — use the **variant** control to switch between
+ * `info`, `table`, `actions`, and `data-cards`.
+ */
+export const Playground: Story = {
+  args: {
+    title: 'Widget Title',
+    loading: false,
+    accent: undefined,
+  },
+  argTypes: {
+    // extra arg not on DashboardWidgetProps — we cast below
+    ...({
+      variant: {
+        control: 'select',
+        options: ['info', 'table', 'actions', 'data-cards'],
+        description: 'Which widget body variant to render',
+        defaultValue: 'info',
+      },
+    } as Record<string, unknown>),
+  },
+  render: (args) => {
+    const key = ((args as Record<string, unknown>).variant ??
+      'info') as VariantKey;
+    const preset = variantMap[key];
+
+    return (
+      <DashboardWidget
+        title={args.title ?? preset.title}
+        icon={preset.icon}
+        count={'count' in preset ? preset.count : args.count}
+        loading={args.loading}
+        accent={args.accent}
+        onAdd={key !== 'actions' && key !== 'info' ? noop : undefined}
+      >
+        {preset.body}
+      </DashboardWidget>
+    );
+  },
+};
+
+// =============================================================================
+// Stories — Individual Variants
+// =============================================================================
+
+/**
+ * Info variant — static label/value pairs for demographics-style data.
+ */
+export const Info: Story = {
+  render: () => (
+    <DashboardWidget
+      title="Demographics"
+      icon={<UserIcon className="h-4 w-4" />}
+      headerAction={
+        <button
+          type="button"
+          className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1 transition-colors"
+          aria-label="Edit demographics"
+        >
+          <PencilIcon className="h-4 w-4" />
+        </button>
+      }
+    >
+      <DashboardWidgetInfo columns={2} items={demographicItems} />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Table variant — list of encounters with status badges and row actions.
+ */
+export const TableList: Story = {
+  name: 'Table (Encounters)',
+  render: () => (
+    <DashboardWidget
+      title="Encounters"
+      icon={<CalendarIcon className="h-4 w-4" />}
+      count={encounterData.length}
+      onAdd={noop}
+      addLabel="Add encounter"
+    >
+      <DashboardWidgetTable<Encounter>
+        columns={[
+          {
+            key: 'date',
+            render: (row) => (
+              <div>
+                <span className="font-medium">{row.date}</span>
+                <span className="text-muted-foreground"> — {row.type}</span>
+                <div className="text-muted-foreground text-xs">
+                  ({row.provider})
+                </div>
+              </div>
+            ),
+          },
+          {
+            key: 'status',
+            align: 'right',
+            render: (row) => (
+              <Badge variant="success" size="sm">
+                {row.status}
+              </Badge>
+            ),
+          },
+        ]}
+        data={encounterData}
+        actions={[
+          {
+            label: 'Edit',
+            icon: <PencilIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+          {
+            label: 'Delete',
+            icon: <TrashIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+        ]}
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Table variant — allergies with severity badges.
+ */
+export const AllergyList: Story = {
+  name: 'Table (Allergies)',
+  render: () => (
+    <DashboardWidget
+      title="Allergies"
+      icon={<AlertTriangleIcon className="h-4 w-4" />}
+      count={allergyData.length}
+      onAdd={noop}
+    >
+      <DashboardWidgetTable<Allergy>
+        columns={[
+          {
+            key: 'allergen',
+            render: (row) => (
+              <span>
+                <span className="font-medium">{row.allergen}</span>
+                <span className="text-muted-foreground"> — {row.reaction}</span>
+              </span>
+            ),
+          },
+          {
+            key: 'severity',
+            align: 'right',
+            render: (row) => (
+              <Badge
+                variant={row.severity === 'moderate' ? 'warning' : 'secondary'}
+                size="sm"
+              >
+                {row.severity}
+              </Badge>
+            ),
+          },
+        ]}
+        data={allergyData}
+        actions={[
+          {
+            label: 'Edit',
+            icon: <PencilIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+          {
+            label: 'Delete',
+            icon: <TrashIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+        ]}
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Table variant — medications list.
+ */
+export const MedicationList: Story = {
+  name: 'Table (Medications)',
+  render: () => (
+    <DashboardWidget
+      title="Medications"
+      icon={<PillIcon className="h-4 w-4" />}
+      count={medicationData.length}
+      onAdd={noop}
+    >
+      <DashboardWidgetTable<Medication>
+        columns={[
+          {
+            key: 'name',
+            render: (row) => (
+              <span>
+                <span className="font-medium">{row.name}</span>{' '}
+                <span className="text-muted-foreground">{row.details}</span>
+              </span>
+            ),
+          },
+        ]}
+        data={medicationData}
+        actions={[
+          {
+            label: 'Edit',
+            icon: <PencilIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+          {
+            label: 'Delete',
+            icon: <TrashIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+        ]}
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Table variant — medical history with condition codes and status badges.
+ */
+export const MedicalHistory: Story = {
+  name: 'Table (Medical History)',
+  render: () => (
+    <DashboardWidget
+      title="Medical History"
+      icon={<ClipboardListIcon className="h-4 w-4" />}
+      count={conditionData.length}
+      onAdd={noop}
+    >
+      <DashboardWidgetTable<Condition>
+        columns={[
+          {
+            key: 'name',
+            render: (row) => (
+              <span>
+                <span className="font-medium">{row.name}</span>{' '}
+                <span className="text-muted-foreground">({row.code})</span>
+              </span>
+            ),
+          },
+          {
+            key: 'status',
+            align: 'right',
+            render: (row) => (
+              <Badge variant="success" size="sm">
+                {row.status}
+              </Badge>
+            ),
+          },
+        ]}
+        data={conditionData}
+        actions={[
+          {
+            label: 'Edit',
+            icon: <PencilIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+          {
+            label: 'Delete',
+            icon: <TrashIcon className="h-3.5 w-3.5" />,
+            onClick: noop,
+          },
+        ]}
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Actions variant — grid of quick-link action buttons.
+ */
+export const Actions: Story = {
+  name: 'Actions (Quick Links)',
+  render: () => (
+    <DashboardWidget title="Quick Links" icon={<ZapIcon className="h-4 w-4" />}>
+      <DashboardWidgetActions columns={2} actions={quickLinkActions} />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * DataCards variant — key/value stat blocks for vitals-style data.
+ */
+export const DataCards: Story = {
+  name: 'Data Cards (Vitals)',
+  render: () => (
+    <DashboardWidget
+      title="Vitals"
+      icon={<HeartIcon className="h-4 w-4" />}
+      count={vitalItems.length}
+      onAdd={noop}
+    >
+      <DashboardWidgetDataCards
+        columns={2}
+        items={vitalItems}
+        footer={
+          <>
+            <span>Date: 2025-12-15</span>
+            <button
+              type="button"
+              className="hover:bg-muted rounded p-0.5 transition-colors"
+              aria-label="Delete vitals record"
+            >
+              <TrashIcon className="h-3.5 w-3.5" />
+            </button>
+          </>
+        }
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Loading state — shows the Card loading overlay.
+ */
+export const Loading: Story = {
+  render: () => (
+    <DashboardWidget
+      title="Encounters"
+      icon={<CalendarIcon className="h-4 w-4" />}
+      count={3}
+      loading
+    >
+      <DashboardWidgetTable<Encounter>
+        columns={[{ key: 'date' }, { key: 'status', align: 'right' }]}
+        data={encounterData}
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * Empty state — table with no data.
+ */
+export const Empty: Story = {
+  render: () => (
+    <DashboardWidget
+      title="Allergies"
+      icon={<AlertTriangleIcon className="h-4 w-4" />}
+      count={0}
+      onAdd={noop}
+    >
+      <DashboardWidgetTable
+        columns={[{ key: 'name' }]}
+        data={[]}
+        emptyMessage="No known allergies"
+      />
+    </DashboardWidget>
+  ),
+};
+
+/**
+ * With accent — a widget with a left-side accent color bar.
+ */
+export const WithAccent: Story = {
+  render: () => (
+    <DashboardWidget
+      title="Vitals"
+      icon={<HeartIcon className="h-4 w-4" />}
+      accent="destructive"
+      count={vitalItems.length}
+    >
+      <DashboardWidgetDataCards columns={2} items={vitalItems} />
+    </DashboardWidget>
+  ),
+};
+
+// =============================================================================
+// Full Dashboard Composition
+// =============================================================================
+
+/**
+ * A full patient summary dashboard composed from all widget variants,
+ * matching the layout in the reference screenshot.
+ */
+export const FullDashboard: Story = {
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-[1100px]">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      {/* Column 1 — Demographics */}
+      <div className="space-y-4">
+        <DashboardWidget
+          title="Demographics"
+          icon={<UserIcon className="h-4 w-4" />}
+          headerAction={
+            <button
+              type="button"
+              className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1 transition-colors"
+              aria-label="Edit"
+            >
+              <PencilIcon className="h-4 w-4" />
+            </button>
+          }
+        >
+          <DashboardWidgetInfo columns={2} items={demographicItems} />
+        </DashboardWidget>
+      </div>
+
+      {/* Column 2 — Encounters + Vitals */}
+      <div className="space-y-4">
+        <DashboardWidget
+          title="Encounters"
+          icon={<CalendarIcon className="h-4 w-4" />}
+          count={encounterData.length}
+          onAdd={noop}
+        >
+          <DashboardWidgetTable<Encounter>
+            columns={[
+              {
+                key: 'date',
+                render: (row) => (
+                  <div>
+                    <span className="font-medium">{row.date}</span>
+                    <span className="text-muted-foreground"> — {row.type}</span>
+                    <div className="text-muted-foreground text-xs">
+                      ({row.provider})
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                key: 'status',
+                align: 'right',
+                render: (row) => (
+                  <Badge variant="success" size="sm">
+                    {row.status}
+                  </Badge>
+                ),
+              },
+            ]}
+            data={encounterData}
+            actions={[
+              {
+                label: 'Edit',
+                icon: <PencilIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+              {
+                label: 'Delete',
+                icon: <TrashIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+            ]}
+          />
+        </DashboardWidget>
+
+        <DashboardWidget
+          title="Vitals"
+          icon={<HeartIcon className="h-4 w-4" />}
+          count={vitalItems.length}
+          onAdd={noop}
+        >
+          <DashboardWidgetDataCards
+            columns={2}
+            items={vitalItems}
+            footer={
+              <>
+                <span>Date: 2025-12-15</span>
+                <button
+                  type="button"
+                  className="hover:bg-muted rounded p-0.5 transition-colors"
+                  aria-label="Delete"
+                >
+                  <TrashIcon className="h-3.5 w-3.5" />
+                </button>
+              </>
+            }
+          />
+        </DashboardWidget>
+      </div>
+
+      {/* Column 3 — Quick Links, Allergies, Medications, Medical History */}
+      <div className="space-y-4">
+        <DashboardWidget
+          title="Quick Links"
+          icon={<ZapIcon className="h-4 w-4" />}
+        >
+          <DashboardWidgetActions columns={2} actions={quickLinkActions} />
+        </DashboardWidget>
+
+        <DashboardWidget
+          title="Allergies"
+          icon={<AlertTriangleIcon className="h-4 w-4" />}
+          count={allergyData.length}
+          onAdd={noop}
+        >
+          <DashboardWidgetTable<Allergy>
+            columns={[
+              {
+                key: 'allergen',
+                render: (row) => (
+                  <span>
+                    <span className="font-medium">{row.allergen}</span>
+                    <span className="text-muted-foreground">
+                      {' '}
+                      — {row.reaction}
+                    </span>
+                  </span>
+                ),
+              },
+              {
+                key: 'severity',
+                align: 'right',
+                render: (row) => (
+                  <Badge
+                    variant={
+                      row.severity === 'moderate' ? 'warning' : 'secondary'
+                    }
+                    size="sm"
+                  >
+                    {row.severity}
+                  </Badge>
+                ),
+              },
+            ]}
+            data={allergyData}
+            actions={[
+              {
+                label: 'Edit',
+                icon: <PencilIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+              {
+                label: 'Delete',
+                icon: <TrashIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+            ]}
+          />
+        </DashboardWidget>
+
+        <DashboardWidget
+          title="Medications"
+          icon={<PillIcon className="h-4 w-4" />}
+          count={medicationData.length}
+          onAdd={noop}
+        >
+          <DashboardWidgetTable<Medication>
+            columns={[
+              {
+                key: 'name',
+                render: (row) => (
+                  <span>
+                    <span className="font-medium">{row.name}</span>{' '}
+                    <span className="text-muted-foreground">{row.details}</span>
+                  </span>
+                ),
+              },
+            ]}
+            data={medicationData}
+            actions={[
+              {
+                label: 'Edit',
+                icon: <PencilIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+              {
+                label: 'Delete',
+                icon: <TrashIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+            ]}
+          />
+        </DashboardWidget>
+
+        <DashboardWidget
+          title="Medical History"
+          icon={<ClipboardListIcon className="h-4 w-4" />}
+          count={conditionData.length}
+          onAdd={noop}
+        >
+          <DashboardWidgetTable<Condition>
+            columns={[
+              {
+                key: 'name',
+                render: (row) => (
+                  <span>
+                    <span className="font-medium">{row.name}</span>{' '}
+                    <span className="text-muted-foreground">({row.code})</span>
+                  </span>
+                ),
+              },
+              {
+                key: 'status',
+                align: 'right',
+                render: (row) => (
+                  <Badge variant="success" size="sm">
+                    {row.status}
+                  </Badge>
+                ),
+              },
+            ]}
+            data={conditionData}
+            actions={[
+              {
+                label: 'Edit',
+                icon: <PencilIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+              {
+                label: 'Delete',
+                icon: <TrashIcon className="h-3.5 w-3.5" />,
+                onClick: noop,
+              },
+            ]}
+          />
+        </DashboardWidget>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/DashboardWidget/DashboardWidget.tsx
+++ b/src/components/DashboardWidget/DashboardWidget.tsx
@@ -1,0 +1,660 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../utils/cn';
+import { Card, CardContent, CardHeader } from '../Card';
+import { Button } from '../Button';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '../Table';
+
+// =============================================================================
+// DashboardWidget — shared wrapper
+// =============================================================================
+
+const widgetVariants = cva('', {
+  variants: {
+    size: {
+      sm: '',
+      md: '',
+      lg: '',
+      full: '',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+export interface DashboardWidgetProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof widgetVariants> {
+  /** Widget title displayed in the header */
+  title: string;
+  /** Optional icon rendered before the title */
+  icon?: React.ReactNode;
+  /** Count badge next to the title (e.g. number of items) */
+  count?: number;
+  /** Callback when the "+" add button is clicked — omit to hide the button */
+  onAdd?: () => void;
+  /** Label for the add button (accessible) */
+  addLabel?: string;
+  /** Optional header-right element (replaces the default "+" button) */
+  headerAction?: React.ReactNode;
+  /** Show a loading skeleton state */
+  loading?: boolean;
+  /** Card accent color bar */
+  accent?: 'primary' | 'success' | 'warning' | 'destructive' | 'info';
+  /** Optional footer content beneath the widget body */
+  footer?: React.ReactNode;
+}
+
+/**
+ * A composable dashboard widget container.
+ *
+ * Provides a consistent card wrapper with a title bar, optional count badge,
+ * and an add/action button. Pair with the variant sub-components
+ * (`DashboardWidgetInfo`, `DashboardWidgetTable`, `DashboardWidgetActions`,
+ * `DashboardWidgetDataCards`) to build dashboard layouts.
+ *
+ * @example
+ * ```tsx
+ * <DashboardWidget title="Demographics" icon={<UserIcon className="h-4 w-4" />}>
+ *   <DashboardWidgetInfo items={[{ label: 'Name', value: 'Hart, William' }]} />
+ * </DashboardWidget>
+ * ```
+ */
+const DashboardWidget = React.forwardRef<HTMLDivElement, DashboardWidgetProps>(
+  (
+    {
+      className,
+      size,
+      title,
+      icon,
+      count,
+      onAdd,
+      addLabel = 'Add',
+      headerAction,
+      loading,
+      accent,
+      footer,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Card
+        ref={ref}
+        padding="none"
+        loading={loading}
+        accent={accent}
+        className={cn(widgetVariants({ size }), className)}
+        {...props}
+      >
+        {/* Header */}
+        <CardHeader
+          className={cn(
+            'border-border flex flex-row items-center justify-between gap-2 border-b px-4 py-3 pb-3',
+            accent && 'pl-6'
+          )}
+        >
+          <div className="flex items-center gap-2">
+            {icon && (
+              <span className="text-muted-foreground shrink-0">{icon}</span>
+            )}
+            <h3 className="text-foreground text-sm font-semibold tracking-wide uppercase">
+              {title}
+            </h3>
+            {count !== undefined && (
+              <span className="bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300 inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-semibold">
+                {count}
+              </span>
+            )}
+          </div>
+          {headerAction
+            ? headerAction
+            : onAdd && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={onAdd}
+                  aria-label={addLabel}
+                >
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 4v16m8-8H4"
+                    />
+                  </svg>
+                </Button>
+              )}
+        </CardHeader>
+
+        {/* Body */}
+        <CardContent className={cn('px-4 py-3', accent && 'pl-6')}>
+          {children}
+        </CardContent>
+
+        {/* Footer */}
+        {footer && (
+          <div
+            className={cn('border-border border-t px-4 py-2', accent && 'pl-6')}
+          >
+            {footer}
+          </div>
+        )}
+      </Card>
+    );
+  }
+);
+
+DashboardWidget.displayName = 'DashboardWidget';
+
+// =============================================================================
+// DashboardWidgetInfo — static label/value pairs (e.g. Demographics)
+// =============================================================================
+
+export interface InfoItem {
+  /** Field label (e.g. "NAME", "DOB") */
+  label: string;
+  /** Field value — string or ReactNode for rich content */
+  value: React.ReactNode;
+  /** Span full width of the grid row */
+  fullWidth?: boolean;
+  /** Custom className for this item */
+  className?: string;
+}
+
+export interface DashboardWidgetInfoProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Array of label/value items to display */
+  items: InfoItem[];
+  /** Number of columns in the grid */
+  columns?: 1 | 2 | 3 | 4;
+  /** Whether labels should be rendered above values (stacked) or inline */
+  layout?: 'stacked' | 'inline';
+}
+
+/**
+ * A label/value grid for displaying static information fields.
+ *
+ * @example
+ * ```tsx
+ * <DashboardWidgetInfo
+ *   columns={2}
+ *   items={[
+ *     { label: 'Name', value: 'Hart, William' },
+ *     { label: 'DOB', value: '1948-04-03 (77 y/o)' },
+ *     { label: 'Address', value: '123 Main St\nFort Wayne, IN 46802', fullWidth: true },
+ *   ]}
+ * />
+ * ```
+ */
+const DashboardWidgetInfo = React.forwardRef<
+  HTMLDivElement,
+  DashboardWidgetInfoProps
+>(({ className, items, columns = 2, layout = 'stacked', ...props }, ref) => {
+  const gridCols = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-2',
+    3: 'grid-cols-3',
+    4: 'grid-cols-4',
+  };
+
+  return (
+    <div
+      ref={ref}
+      className={cn('grid gap-x-6 gap-y-3', gridCols[columns], className)}
+      {...props}
+    >
+      {items.map((item, i) => (
+        <div
+          key={`${item.label}-${i}`}
+          className={cn(
+            item.fullWidth && 'col-span-full',
+            layout === 'inline' && 'flex items-baseline gap-2',
+            item.className
+          )}
+        >
+          <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            {item.label}
+          </dt>
+          <dd
+            className={cn(
+              'text-foreground text-sm',
+              layout === 'stacked' && 'mt-0.5'
+            )}
+          >
+            {item.value}
+          </dd>
+        </div>
+      ))}
+    </div>
+  );
+});
+
+DashboardWidgetInfo.displayName = 'DashboardWidgetInfo';
+
+// =============================================================================
+// DashboardWidgetTable — rows with columns, badges, actions
+// (Encounters, Allergies, Medications, Medical History)
+// =============================================================================
+
+export interface WidgetTableColumn<T = Record<string, unknown>> {
+  /** Unique column key */
+  key: string;
+  /** Header label — omit for a headerless table */
+  header?: string;
+  /** Custom cell renderer */
+  render?: (row: T, index: number) => React.ReactNode;
+  /** Alignment */
+  align?: 'left' | 'center' | 'right';
+  /** Header & cell className */
+  className?: string;
+}
+
+export interface WidgetTableAction<T = Record<string, unknown>> {
+  /** Accessible label */
+  label: string;
+  /** Icon to render */
+  icon: React.ReactNode;
+  /** Click handler */
+  onClick: (row: T, index: number) => void;
+  /** Conditionally hide per row */
+  hidden?: (row: T, index: number) => boolean;
+}
+
+export interface DashboardWidgetTableProps<
+  T = Record<string, unknown>,
+> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  /** Column definitions */
+  columns: WidgetTableColumn<T>[];
+  /** Row data */
+  data: T[];
+  /** Row-level actions (edit, delete, etc.) rendered at the end of each row */
+  actions?: WidgetTableAction<T>[];
+  /** Show column headers */
+  showHeader?: boolean;
+  /** Callback when a row is clicked */
+  onRowClick?: (row: T, index: number) => void;
+  /** Message when data is empty */
+  emptyMessage?: string;
+  /** Key extractor for stable row keys */
+  rowKey?: (row: T, index: number) => string;
+}
+
+/**
+ * A lightweight table view for list-style widget content.
+ *
+ * Uses the existing `Table` primitives under the hood.
+ *
+ * @example
+ * ```tsx
+ * <DashboardWidgetTable
+ *   columns={[
+ *     { key: 'date', header: 'Date' },
+ *     { key: 'type', header: 'Type' },
+ *     { key: 'status', render: (row) => <Badge>{row.status}</Badge> },
+ *   ]}
+ *   data={encounters}
+ *   actions={[
+ *     { label: 'Edit', icon: <EditIcon />, onClick: handleEdit },
+ *     { label: 'Delete', icon: <TrashIcon />, onClick: handleDelete },
+ *   ]}
+ * />
+ * ```
+ */
+function DashboardWidgetTableInner<T extends Record<string, unknown>>(
+  {
+    className,
+    columns,
+    data,
+    actions,
+    showHeader = false,
+    onRowClick,
+    emptyMessage = 'No items',
+    rowKey,
+    ...props
+  }: DashboardWidgetTableProps<T>,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
+  if (data.length === 0) {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'text-muted-foreground flex items-center justify-center py-6 text-sm',
+          className
+        )}
+        {...props}
+      >
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className={cn('-mx-4', className)} {...props}>
+      <Table responsive>
+        {showHeader && (
+          <TableHeader>
+            <TableRow>
+              {columns.map((col) => (
+                <TableHead
+                  key={col.key}
+                  className={cn(
+                    'px-4 text-xs',
+                    col.align === 'right' && 'text-right',
+                    col.align === 'center' && 'text-center',
+                    col.className
+                  )}
+                >
+                  {col.header}
+                </TableHead>
+              ))}
+              {actions && actions.length > 0 && (
+                <TableHead className="w-0 px-4" />
+              )}
+            </TableRow>
+          </TableHeader>
+        )}
+        <TableBody>
+          {data.map((row, rowIndex) => (
+            <TableRow
+              key={rowKey ? rowKey(row, rowIndex) : rowIndex}
+              className={cn(
+                onRowClick &&
+                  'hover:bg-muted/50 cursor-pointer transition-colors'
+              )}
+              onClick={onRowClick ? () => onRowClick(row, rowIndex) : undefined}
+            >
+              {columns.map((col) => (
+                <TableCell
+                  key={col.key}
+                  className={cn(
+                    'px-4 py-2 text-sm',
+                    col.align === 'right' && 'text-right',
+                    col.align === 'center' && 'text-center',
+                    col.className
+                  )}
+                >
+                  {col.render
+                    ? col.render(row, rowIndex)
+                    : (row[col.key] as React.ReactNode)}
+                </TableCell>
+              ))}
+              {actions && actions.length > 0 && (
+                <TableCell className="px-2 py-2 text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    {actions.map(
+                      (action, actionIndex) =>
+                        !action.hidden?.(row, rowIndex) && (
+                          <button
+                            key={actionIndex}
+                            type="button"
+                            className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1 transition-colors"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              action.onClick(row, rowIndex);
+                            }}
+                            aria-label={action.label}
+                          >
+                            {action.icon}
+                          </button>
+                        )
+                    )}
+                  </div>
+                </TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+const DashboardWidgetTable = React.forwardRef(DashboardWidgetTableInner) as <
+  T extends Record<string, unknown>,
+>(
+  props: DashboardWidgetTableProps<T> & {
+    ref?: React.ForwardedRef<HTMLDivElement>;
+  }
+) => React.ReactElement | null;
+
+// =============================================================================
+// DashboardWidgetActions — grid of action buttons (Quick Links)
+// =============================================================================
+
+export interface WidgetAction {
+  /** Action label */
+  label: string;
+  /** Icon rendered before the label */
+  icon?: React.ReactNode;
+  /** Click handler */
+  onClick?: () => void;
+  /** Render as a link instead of a button */
+  href?: string;
+  /** Color accent for the icon */
+  color?:
+    | 'primary'
+    | 'green'
+    | 'red'
+    | 'orange'
+    | 'blue'
+    | 'purple'
+    | 'amber'
+    | 'neutral';
+  /** Disabled state */
+  disabled?: boolean;
+}
+
+const actionColorMap: Record<string, string> = {
+  primary:
+    'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300',
+  green:
+    'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  red: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  orange:
+    'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
+  blue: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
+  purple:
+    'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  amber: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  neutral:
+    'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
+};
+
+export interface DashboardWidgetActionsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Array of actions to render */
+  actions: WidgetAction[];
+  /** Grid columns */
+  columns?: 1 | 2 | 3;
+}
+
+/**
+ * A grid of action buttons for quick navigation / shortcuts.
+ *
+ * @example
+ * ```tsx
+ * <DashboardWidgetActions
+ *   columns={2}
+ *   actions={[
+ *     { label: 'Add Encounter', icon: <CalendarIcon />, color: 'primary', onClick: handleAdd },
+ *     { label: 'Record Vitals', icon: <HeartIcon />, color: 'red', onClick: handleVitals },
+ *   ]}
+ * />
+ * ```
+ */
+const DashboardWidgetActions = React.forwardRef<
+  HTMLDivElement,
+  DashboardWidgetActionsProps
+>(({ className, actions, columns = 2, ...props }, ref) => {
+  const gridCols = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-2',
+    3: 'grid-cols-3',
+  };
+
+  return (
+    <div
+      ref={ref}
+      className={cn('grid gap-2', gridCols[columns], className)}
+      {...props}
+    >
+      {actions.map((action, i) => {
+        const colorClasses = actionColorMap[action.color ?? 'primary'];
+
+        const content = (
+          <>
+            {action.icon && (
+              <span
+                className={cn(
+                  'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md',
+                  colorClasses
+                )}
+              >
+                {action.icon}
+              </span>
+            )}
+            <span className="text-sm font-medium">{action.label}</span>
+          </>
+        );
+
+        const sharedClasses = cn(
+          'flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-left transition-colors',
+          'hover:bg-muted/60 hover:border-primary-200 dark:hover:border-primary-800',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2',
+          action.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
+        );
+
+        if (action.href) {
+          return (
+            <a key={i} href={action.href} className={sharedClasses}>
+              {content}
+            </a>
+          );
+        }
+
+        return (
+          <button
+            key={i}
+            type="button"
+            className={sharedClasses}
+            onClick={action.onClick}
+            disabled={action.disabled}
+          >
+            {content}
+          </button>
+        );
+      })}
+    </div>
+  );
+});
+
+DashboardWidgetActions.displayName = 'DashboardWidgetActions';
+
+// =============================================================================
+// DashboardWidgetDataCards — key/value stat blocks (Vitals)
+// =============================================================================
+
+export interface DataCardItem {
+  /** Short label (e.g. "BP", "PULSE") */
+  label: string;
+  /** Display value */
+  value: React.ReactNode;
+  /** Optional unit suffix (e.g. "lbs", "°F") */
+  unit?: string;
+  /** Custom className for this card */
+  className?: string;
+}
+
+export interface DashboardWidgetDataCardsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Array of data card items */
+  items: DataCardItem[];
+  /** Grid columns */
+  columns?: 2 | 3 | 4;
+  /** Optional footer content below the grid (e.g. a date + delete button) */
+  footer?: React.ReactNode;
+}
+
+/**
+ * A grid of key/value stat blocks for displaying metrics at a glance.
+ *
+ * @example
+ * ```tsx
+ * <DashboardWidgetDataCards
+ *   columns={2}
+ *   items={[
+ *     { label: 'BP', value: '128/82' },
+ *     { label: 'Pulse', value: '72' },
+ *     { label: 'Temp', value: '98.6', unit: '°F' },
+ *   ]}
+ * />
+ * ```
+ */
+const DashboardWidgetDataCards = React.forwardRef<
+  HTMLDivElement,
+  DashboardWidgetDataCardsProps
+>(({ className, items, columns = 2, footer, ...props }, ref) => {
+  const gridCols = {
+    2: 'grid-cols-2',
+    3: 'grid-cols-3',
+    4: 'grid-cols-4',
+  };
+
+  return (
+    <div ref={ref} className={cn('space-y-3', className)} {...props}>
+      <div className={cn('grid gap-x-6 gap-y-3', gridCols[columns])}>
+        {items.map((item, i) => (
+          <div key={`${item.label}-${i}`} className={cn('', item.className)}>
+            <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+              {item.label}
+            </dt>
+            <dd className="text-foreground mt-0.5 text-sm font-semibold">
+              {item.value}
+              {item.unit && (
+                <span className="text-muted-foreground ml-0.5 text-xs font-normal">
+                  {item.unit}
+                </span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </div>
+      {footer && (
+        <div className="border-border text-muted-foreground flex items-center gap-2 border-t pt-2 text-xs">
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+});
+
+DashboardWidgetDataCards.displayName = 'DashboardWidgetDataCards';
+
+// =============================================================================
+// Exports
+// =============================================================================
+
+export {
+  DashboardWidget,
+  DashboardWidgetInfo,
+  DashboardWidgetTable,
+  DashboardWidgetActions,
+  DashboardWidgetDataCards,
+  widgetVariants,
+};

--- a/src/components/DashboardWidget/index.ts
+++ b/src/components/DashboardWidget/index.ts
@@ -1,0 +1,21 @@
+export {
+  DashboardWidget,
+  DashboardWidgetInfo,
+  DashboardWidgetTable,
+  DashboardWidgetActions,
+  DashboardWidgetDataCards,
+  widgetVariants,
+} from './DashboardWidget';
+
+export type {
+  DashboardWidgetProps,
+  InfoItem,
+  DashboardWidgetInfoProps,
+  WidgetTableColumn,
+  WidgetTableAction,
+  DashboardWidgetTableProps,
+  WidgetAction,
+  DashboardWidgetActionsProps,
+  DataCardItem,
+  DashboardWidgetDataCardsProps,
+} from './DashboardWidget';

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export * from './components/ConnectionStatus';
 export * from './components/CountBadge';
 export * from './components/CookieConsent';
 export * from './components/CSVColumnMapper';
+export * from './components/DashboardWidget';
 export * from './components/DateInput';
 export * from './components/DateRangePicker';
 export * from './components/DocumentScanner';


### PR DESCRIPTION
Add a new DashboardWidget component system for building dashboard layouts with a consistent card-based UI. The system consists of 5 composable sub-components:

- DashboardWidget: Shared wrapper card with title bar, icon, count badge, add button, loading state, accent color bar, and footer slot
- DashboardWidgetInfo: Label/value grid for static data (e.g. demographics) with configurable columns and stacked/inline layout
- DashboardWidgetTable: Generic typed table using existing Table primitives, supporting column definitions, custom cell renderers, row actions (edit/delete), empty state messages, and row click handlers
- DashboardWidgetActions: Color-coded action button grid for quick links, supporting both onClick and href, with 8 color options
- DashboardWidgetDataCards: Key/value stat blocks for metrics (e.g. vitals) with optional unit suffixes and footer content

Stories and Documentation:
- Playground story with variant selector control (info, table, actions, data-cards) for autodocs
- Individual stories for each variant plus Loading, Empty, WithAccent, and FullDashboard composition
- DashboardWidgets.stories.tsx under Examples/Dashboard (Widgets) with BusinessDashboard and PatientSummary full-page compositions
- PatientSummary includes PatientHeader with allergy/medication banners, 3-column grid (max-w-1800px) with demographics, encounters, vitals, quick links, allergies, medications, and medical history

All components use forwardRef, CVA for variants, cn() utility, and reuse existing primitives (Card, Button, Table, Badge, Avatar, etc.). Barrel-exported via index.ts and added to main src/index.ts entry point.

https://github.com/user-attachments/assets/51d8f971-bb70-4b39-a7f3-42281350b039
