### PR TITLE
feat: revamp PatientHeader overflow menu layout

### DIFF
--- a/src/components/PatientHeader/PatientHeader.tsx
+++ b/src/components/PatientHeader/PatientHeader.tsx
@@ -421,7 +421,7 @@ function PatientOverflowMenu({
                   Add
                 </span>
               </div>
-              <div className="grid grid-cols-2">
+              <div className="grid grid-cols-2 gap-2">
                 <OverflowMenuItem
                   icon={<ClipboardPlusIcon size={15} />}
                   label="Task"


### PR DESCRIPTION
https://github.com/user-attachments/assets/ec390b3f-3567-4d95-9bac-fcf38948b3fb


- Add Condition (FileHeartIcon) and Vitals (HeartPulseIcon) to the Add section with corresponding PatientOverflowAction types and ADD_ENTITY_LABELS entries
- Display Add items in a 2-column grid to reduce vertical height and improve scannability
- Move Quick Actions column to the left, Add column to the right
- Move Edit Patient into Quick Actions as the first item, removing the separate Edit section header and divider
- Change dropdown max-height from fixed 420px to calc(100vh - 4rem) so all items remain visible without clipping