### PR TITLE
feat(stories): update PatientSummary with full PatientHeader features

### DIFF
--- a/src/components/Dashboard/DashboardWidgets.stories.tsx
+++ b/src/components/Dashboard/DashboardWidgets.stories.tsx
@@ -8,8 +8,12 @@ import {
 } from '../DashboardWidget';
 import { Badge } from '../Badge';
 import { Avatar } from '../Avatar';
-import { CountBadge } from '../CountBadge';
-import { PatientHeader, type PatientData } from '../PatientHeader';
+import { CountBadge, type CountBadgeItem } from '../CountBadge';
+import {
+  PatientHeader,
+  type PatientData,
+  type PatientOverflowAction,
+} from '../PatientHeader';
 import { Text } from '../Text';
 import {
   UserIcon,
@@ -72,6 +76,49 @@ const sampleMedications = [
   { name: 'Lisinopril' },
   { name: 'Atorvastatin' },
   { name: 'Metformin' },
+];
+
+// -- CountBadge items
+const sampleTasks: CountBadgeItem[] = [
+  { id: 'task-1', label: 'Complete intake questionnaire', status: 'pending' },
+  { id: 'task-2', label: 'Review lab results', status: 'active' },
+  { id: 'task-3', label: 'Follow-up referral', status: 'overdue' },
+];
+
+const sampleEncounters: CountBadgeItem[] = [
+  { id: 'enc-1', label: 'Office visit 12/15', status: 'active' },
+  { id: 'enc-2', label: 'Telehealth 12/10', status: 'active' },
+  { id: 'enc-3', label: 'Lab draw 12/05', status: 'pending' },
+  { id: 'enc-4', label: 'Physical exam 11/20', status: 'completed' },
+  { id: 'enc-5', label: 'Urgent care 11/15', status: 'completed' },
+];
+
+const sampleDueList: CountBadgeItem[] = [
+  { id: 'due-1', label: 'Hemoglobin A1c', status: 'overdue' },
+  { id: 'due-2', label: 'Lipid panel', status: 'pending' },
+  { id: 'due-3', label: 'Annual wellness visit', status: 'pending' },
+  { id: 'due-4', label: 'Pneumonia vaccine', status: 'active' },
+];
+
+const sampleOrders: CountBadgeItem[] = [
+  { id: 'ord-1', label: 'CBC w/ differential', status: 'pending' },
+  { id: 'ord-2', label: 'Comprehensive metabolic panel', status: 'pending' },
+  { id: 'ord-3', label: 'Chest X-ray', status: 'active' },
+  { id: 'ord-4', label: 'PT/INR', status: 'overdue' },
+];
+
+const sampleEsigns: CountBadgeItem[] = [
+  { id: 'esign-1', label: 'Office visit note 12/15', status: 'pending' },
+  {
+    id: 'esign-2',
+    label: 'Referral letter \u2014 Cardiology',
+    status: 'pending',
+  },
+  { id: 'esign-3', label: 'Lab order 12/10', status: 'active' },
+  { id: 'esign-4', label: 'Prescription \u2014 Lisinopril', status: 'pending' },
+  { id: 'esign-5', label: 'Consent \u2014 Telehealth', status: 'completed' },
+  { id: 'esign-6', label: 'Discharge summary 11/15', status: 'overdue' },
+  { id: 'esign-7', label: 'Immunization record update', status: 'active' },
 ];
 
 // -- Stats
@@ -448,11 +495,78 @@ export const PatientSummary: StoryObj = {
         showMedicationBanner
         showDetails
         sticky={false}
+        showOverflowMenu
+        onOverflowAction={(action: PatientOverflowAction) =>
+          console.log('Overflow action:', action)
+        }
+        onAddItem={(
+          entityType: PatientOverflowAction,
+          formData: Record<string, string>
+        ) => console.log('Add item:', entityType, formData)}
+        onEditPatient={(formData: Record<string, string>) =>
+          console.log('Edit patient:', formData)
+        }
         actions={
           <div className="flex flex-wrap gap-2">
-            <CountBadge label="Tasks" count={3} />
-            <CountBadge label="Open Enc" count={5} />
-            <CountBadge label="Due List" count={4} />
+            <CountBadge
+              label="Tasks"
+              count={sampleTasks.length}
+              variant="warning"
+              items={sampleTasks}
+              deleteLabel="task"
+              onView={(item) => console.log('View task', item)}
+              onEdit={(item, formData) =>
+                console.log('Saved task', item, formData)
+              }
+              onDelete={(item) => console.log('Deleted task', item)}
+            />
+            <CountBadge
+              label="Open Enc"
+              count={sampleEncounters.length}
+              variant="info"
+              items={sampleEncounters}
+              deleteLabel="encounter"
+              onView={(item) => console.log('View encounter', item)}
+              onEdit={(item, formData) =>
+                console.log('Saved encounter', item, formData)
+              }
+              onDelete={(item) => console.log('Deleted encounter', item)}
+            />
+            <CountBadge
+              label="Due List"
+              count={sampleDueList.length}
+              variant="alert"
+              items={sampleDueList}
+              deleteLabel="due list item"
+              onView={(item) => console.log('View due item', item)}
+              onEdit={(item, formData) =>
+                console.log('Saved due item', item, formData)
+              }
+              onDelete={(item) => console.log('Deleted due item', item)}
+            />
+            <CountBadge
+              label="Order Req"
+              count={sampleOrders.length}
+              items={sampleOrders}
+              deleteLabel="order"
+              onView={(item) => console.log('View order', item)}
+              onEdit={(item, formData) =>
+                console.log('Saved order', item, formData)
+              }
+              onDelete={(item) => console.log('Deleted order', item)}
+            />
+            <CountBadge
+              label="eSign"
+              count={sampleEsigns.length}
+              variant="warning"
+              items={sampleEsigns}
+              deleteLabel="e-sign request"
+              onView={(item) => console.log('View esign', item)}
+              onEdit={(item, formData) =>
+                console.log('Saved esign', item, formData)
+              }
+              onDelete={(item) => console.log('Deleted esign', item)}
+            />
           </div>
         }
       />


### PR DESCRIPTION
https://github.com/user-attachments/assets/7364740a-27fe-4020-819a-cffe36c52ea9

Update the PatientHeader in the Examples/Dashboard (Widgets) → PatientSummary story to use the latest PatientHeader capabilities:

- Import CountBadgeItem and PatientOverflowAction types
- Add sample data arrays for Tasks (3), Encounters (5), Due List (4), Order Requests (4), and eSign Requests (7) with realistic labels and mixed statuses (pending, active, overdue, completed)
- Replace 3 bare CountBadges with 5 fully-wired CountBadges including variant colors, item lists, hover menus, and CRUD callbacks (onView, onEdit, onDelete)
- Enable overflow menu with showOverflowMenu prop exposing all 15 actions: Quick Actions (Edit Patient, Send Message, Schedule Appointment, Print Summary, Export Record) and Add entities (Task, Encounter, Due List Item, Order Request, eSign Request, Allergy, Medication, Alert, Condition, Vitals)
- Wire onOverflowAction, onAddItem, and onEditPatient callbacks

Only the story file is modified — n
Update the Pource changes.