### PR TITLE
fix: resolve TypeScript errors in Storybook preview config

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import type { Preview, Decorator } from '@storybook/react-vite';
 import { useEffect, useMemo } from 'react';
 import { addons } from 'storybook/preview-api';
@@ -202,7 +203,6 @@ const preview: Preview = {
           { value: 'waggleline', title: '🍯 Waggleline' },
           { value: 'webchart', title: '🟠 WebChart' },
         ],
-        showName: true,
         dynamicTitle: true,
       },
     },
@@ -216,7 +216,6 @@ const preview: Preview = {
           { value: 'light', icon: 'sun', title: 'Light' },
           { value: 'dark', icon: 'moon', title: 'Dark' },
         ],
-        showName: true,
         dynamicTitle: true,
       },
     },


### PR DESCRIPTION
- Add /// <reference types="vite/client" /> for import.meta.hot HMR API (Property 'hot' does not exist on type 'ImportMeta')
- Remove deprecated 'showName' from brand and theme toolbar configs (Storybook 10 dropped showName from ToolbarConfig; dynamicTitle handles it)