### PR TITLE
feat: mobile-responsive overflow menu for PatientHeader

### DIFF
--- a/src/components/PatientHeader/PatientHeader.tsx
+++ b/src/components/PatientHeader/PatientHeader.tsx
@@ -346,9 +346,9 @@ function PatientOverflowMenu({
           aria-label="Patient actions"
           className={cn(
             'absolute top-full right-0 z-50 mt-1',
-            'w-[calc(100vw-2rem)] md:w-auto',
+            'w-[calc(100vw_-_2rem)] md:w-auto',
             'border-border bg-card rounded-xl border py-1 shadow-lg',
-            'max-h-[calc(100vh-3rem)] overflow-y-auto md:max-h-[calc(100vh-4rem)]',
+            'max-h-[calc(100vh_-_3rem)] overflow-y-auto md:max-h-[calc(100vh_-_4rem)]',
             'motion-safe:animate-fade-in'
           )}
         >


### PR DESCRIPTION
https://github.com/user-attachments/assets/bd7d0e4e-5b3c-4589-bc00-fdb98dad9f72

- Menu drops down from 3-dot icon (absolute positioned, not bottom sheet)
- Full viewport width on mobile (calc(100vw - 2rem)), auto width on md+
- Quick Actions and Add sections stack vertically on mobile, side-by-side on md+
- Add grid uses single column on mobile, 2-column on md+
- Max height calc(100vh - 3rem) on mobile for minimal scrolling on tall devices
- All sm: breakpoints updated to md: to match PatientHeader's mobile breakpoint
- Vertical scroll only, no horizontal overflow