### PR TITLE
feat(WebChartReportViewer): use DateInput component with calendar for custom date range

### DIFF
--- a/src/components/WebChartReportViewer/WebChartReportViewer.stories.tsx
+++ b/src/components/WebChartReportViewer/WebChartReportViewer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 import {
   WebChartReportViewer,
-  ReportDatePicker,
+  ReportTimeRange,
   type SystemReport,
   type ReportResult,
 } from './WebChartReportViewer';
@@ -187,14 +187,14 @@ export const ReportWithError: Story = {
   },
 };
 
-function DatePickerWrapper() {
+function TimeRangeWrapper() {
   const [range, setRange] = useState({
     start: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
     end: new Date(),
   });
 
   return (
-    <ReportDatePicker
+    <ReportTimeRange
       startDate={range.start}
       endDate={range.end}
       onChange={(start, end) => {
@@ -207,8 +207,8 @@ function DatePickerWrapper() {
   );
 }
 
-export const DatePicker: StoryObj<typeof ReportDatePicker> = {
-  render: () => <DatePickerWrapper />,
+export const TimeRange: StoryObj<typeof ReportTimeRange> = {
+  render: () => <TimeRangeWrapper />,
 };
 
 const structuredResult: ReportResult = {

--- a/src/components/WebChartReportViewer/WebChartReportViewer.tsx
+++ b/src/components/WebChartReportViewer/WebChartReportViewer.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { AlertTriangle, Check, Link, RefreshCw } from 'lucide-react';
-import { cn } from '../../utils';
+import { cn, dateToDisplayFormat, displayFormatToDateString, isValidDate } from '../../utils';
 import { Button } from '../Button';
 import { Card, CardContent } from '../Card';
 import { Alert, AlertDescription, AlertTitle } from '../Alert';
@@ -149,22 +149,17 @@ export function WebChartReportViewer({
     onClose?.();
   };
 
-  // Convert Date or ISO string to MM/DD/YYYY format for DateInput
-  const formatDateForInput = (date: Date | string): string => {
-    const d = typeof date === 'string' ? new Date(date) : date;
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    const year = d.getFullYear();
-    return `${month}/${day}/${year}`;
+  // Handle date input change - only propagate when valid
+  const handleStartDateChange = (value: string) => {
+    if (isValidDate(value)) {
+      onDateRangeChange?.(displayFormatToDateString(value), dateRange?.end || new Date());
+    }
   };
 
-  // Convert MM/DD/YYYY format back to ISO string for the callback
-  const formatDateForCallback = (value: string): string => {
-    const [month, day, year] = value.split('/');
-    if (month && day && year && year.length === 4) {
-      return `${year}-${month}-${day}`;
+  const handleEndDateChange = (value: string) => {
+    if (isValidDate(value)) {
+      onDateRangeChange?.(dateRange?.start || new Date(), displayFormatToDateString(value));
     }
-    return value;
   };
 
   return (
@@ -286,20 +281,16 @@ export function WebChartReportViewer({
                 size="sm"
                 showCalendar
                 width="fixed"
-                value={formatDateForInput(dateRange.start)}
-                onChange={(value) =>
-                  onDateRangeChange(formatDateForCallback(value), dateRange.end)
-                }
+                value={dateToDisplayFormat(dateRange.start)}
+                onChange={handleStartDateChange}
               />
               <label className="text-muted-foreground text-sm">{dateTo}:</label>
               <DateInput
                 size="sm"
                 showCalendar
                 width="fixed"
-                value={formatDateForInput(dateRange.end)}
-                onChange={(value) =>
-                  onDateRangeChange(dateRange.start, formatDateForCallback(value))
-                }
+                value={dateToDisplayFormat(dateRange.end)}
+                onChange={handleEndDateChange}
               />
             </div>
           )}
@@ -395,9 +386,9 @@ export function WebChartReportViewer({
   );
 }
 
-/* Date Picker for Reports */
+/* Time Range Selector for Reports */
 
-export interface ReportDatePickerProps {
+export interface ReportTimeRangeProps {
   /** Start date */
   startDate?: Date | string;
   /** End date */
@@ -410,7 +401,7 @@ export interface ReportDatePickerProps {
   className?: string;
 }
 
-export function ReportDatePicker({
+export function ReportTimeRange({
   startDate,
   endDate,
   onChange,
@@ -423,27 +414,8 @@ export function ReportDatePicker({
     { label: 'Custom', value: 'custom' },
   ],
   className,
-}: ReportDatePickerProps) {
+}: ReportTimeRangeProps) {
   const [preset, setPreset] = React.useState('this-month');
-
-  // Convert Date or ISO string to MM/DD/YYYY format for DateInput
-  const formatDateForInput = (date?: Date | string): string => {
-    if (!date) return '';
-    const d = typeof date === 'string' ? new Date(date) : date;
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    const year = d.getFullYear();
-    return `${month}/${day}/${year}`;
-  };
-
-  // Convert MM/DD/YYYY format back to ISO string for the callback
-  const formatDateForCallback = (value: string): string => {
-    const [month, day, year] = value.split('/');
-    if (month && day && year && year.length === 4) {
-      return `${year}-${month}-${day}`;
-    }
-    return value;
-  };
 
   const handlePresetChange = (value: string) => {
     setPreset(value);
@@ -482,6 +454,19 @@ export function ReportDatePicker({
     label: p.label,
   }));
 
+  // Only propagate changes when we have a valid complete date
+  const handleStartChange = (value: string) => {
+    if (isValidDate(value)) {
+      onChange?.(displayFormatToDateString(value), endDate || new Date());
+    }
+  };
+
+  const handleEndChange = (value: string) => {
+    if (isValidDate(value)) {
+      onChange?.(startDate || new Date(), displayFormatToDateString(value));
+    }
+  };
+
   return (
     <div className={cn('flex flex-wrap items-center gap-3', className)}>
       <Select
@@ -497,25 +482,27 @@ export function ReportDatePicker({
             size="sm"
             showCalendar
             width="fixed"
-            value={formatDateForInput(startDate)}
-            onChange={(value) =>
-              onChange?.(formatDateForCallback(value), endDate || new Date())
-            }
+            value={dateToDisplayFormat(startDate || '')}
+            onChange={handleStartChange}
           />
           <span className="text-muted-foreground">to</span>
           <DateInput
             size="sm"
             showCalendar
             width="fixed"
-            value={formatDateForInput(endDate)}
-            onChange={(value) =>
-              onChange?.(startDate || new Date(), formatDateForCallback(value))
-            }
+            value={dateToDisplayFormat(endDate || '')}
+            onChange={handleEndChange}
           />
         </>
       )}
     </div>
   );
 }
+
+/** @deprecated Use ReportTimeRange instead */
+export const ReportDatePicker = ReportTimeRange;
+
+/** @deprecated Use ReportTimeRangeProps instead */
+export type ReportDatePickerProps = ReportTimeRangeProps;
 
 export default WebChartReportViewer;

--- a/src/components/WebChartReportViewer/index.ts
+++ b/src/components/WebChartReportViewer/index.ts
@@ -1,9 +1,11 @@
 export {
   WebChartReportViewer,
+  ReportTimeRange,
   ReportDatePicker,
   type WebChartReportViewerProps,
   type SystemReport,
   type ReportResult,
   type DateRange,
+  type ReportTimeRangeProps,
   type ReportDatePickerProps,
 } from './WebChartReportViewer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,10 +149,12 @@ export * from './components/VisuallyHidden';
 // WebChartReportViewer exports DateRange which conflicts with DateRangePicker
 export {
   WebChartReportViewer,
+  ReportTimeRange,
   ReportDatePicker,
   type WebChartReportViewerProps,
   type SystemReport,
   type ReportResult,
+  type ReportTimeRangeProps,
   type ReportDatePickerProps,
 } from './components/WebChartReportViewer';
 export * from './components/WebsiteInput';

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -108,3 +108,43 @@ export function isDateInFuture(value: string): boolean {
 
   return date.toMillis() > DateTime.now().toMillis();
 }
+
+/**
+ * Converts a Date object or date string to MM/DD/YYYY format for display.
+ * Handles both Date objects and YYYY-MM-DD strings, parsing them in local timezone
+ * to avoid off-by-one day issues from UTC interpretation.
+ */
+export function dateToDisplayFormat(date: Date | string): string {
+  if (!date) return '';
+
+  let dt: DateTime;
+  if (typeof date === 'string') {
+    // Check if it's a YYYY-MM-DD format (ISO date-only)
+    if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      // Parse as local date to avoid UTC offset issues
+      const [year, month, day] = date.split('-').map(Number);
+      dt = DateTime.local(year, month, day);
+    } else {
+      // Try parsing as full ISO or other format
+      dt = DateTime.fromISO(date, { zone: 'local' });
+    }
+  } else {
+    dt = DateTime.fromJSDate(date);
+  }
+
+  if (!dt.isValid) return '';
+
+  return dt.toFormat('MM/dd/yyyy');
+}
+
+/**
+ * Converts MM/DD/YYYY format to YYYY-MM-DD date string.
+ * Returns the original value if not a valid complete date.
+ */
+export function displayFormatToDateString(value: string): string {
+  const [month, day, year] = value.split('/');
+  if (month && day && year && year.length === 4) {
+    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+  }
+  return value;
+}


### PR DESCRIPTION
Updating the WebChartReportViewer to use the date input (date picker) component. Also renaming this particular variant of the WebChartReportViewer from date picker to ReportTimeRange - its more appropriate. 


https://github.com/user-attachments/assets/14a04392-3875-4a70-a8b0-345a408643c9

