### PR TITLE
fix: update Dashboard example link in Introduction.mdx

### DIFF
--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -32,7 +32,7 @@ A **themeable, accessible React component library** built with Tailwind CSS 4. D
     </span>
   </div>
   <a 
-    href="/?path=/story/product-feature-modules-dashboard--dashboard"
+    href="?path=/story/product-feature-modules-dashboard--dashboard"
     style={{ 
       display: 'inline-block',
       padding: '10px 20px', 


### PR DESCRIPTION
Fixed the "View Dashboard Example" button link on the Introduction docs page.

Changed from `?path=/story/examples-dashboard--dashboard` to `/?path=/story/product-feature-modules-dashboard--dashboard` to match the updated Storybook route.