### PR TITLE
feat(condensed): add condensed view support for Provider components

### DIFF
--- a/src/components/ProviderCard/ProviderCard.tsx
+++ b/src/components/ProviderCard/ProviderCard.tsx
@@ -310,10 +310,10 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
         tabIndex={interactive ? 0 : undefined}
         role={interactive ? 'button' : undefined}
         aria-label={`View ${provider.name}`}
+        {...props}
         data-slot="provider-card"
         data-variant={variant}
         data-testid="provider-card"
-        {...props}
       >
         {/* Logo Section */}
         {(variant === 'compact' || variant === 'featured') && (

--- a/src/components/ProviderCard/ProviderCard.tsx
+++ b/src/components/ProviderCard/ProviderCard.tsx
@@ -96,7 +96,10 @@ const ProviderLogo: React.FC<{
 
   if (!logoURL || hasError) {
     return (
-      <div className={cn(logoContainerVariants({ variant }))}>
+      <div
+        data-slot="provider-card-logo"
+        className={cn(logoContainerVariants({ variant }))}
+      >
         <div className="bg-primary-100 dark:bg-primary-900 flex h-12 w-12 items-center justify-center rounded-full">
           <span className="text-primary-800 dark:text-primary-300 text-lg font-bold">
             {name.charAt(0).toUpperCase()}
@@ -107,7 +110,10 @@ const ProviderLogo: React.FC<{
   }
 
   return (
-    <div className={cn(logoContainerVariants({ variant }))}>
+    <div
+      data-slot="provider-card-logo"
+      className={cn(logoContainerVariants({ variant }))}
+    >
       <img
         src={logoURL}
         alt={`${name}'s logo`}
@@ -298,6 +304,8 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
         tabIndex={interactive ? 0 : undefined}
         role={interactive ? 'button' : undefined}
         aria-label={`View ${provider.name}`}
+        data-slot="provider-card"
+        data-variant={variant}
         data-testid="provider-card"
         {...props}
       >
@@ -319,6 +327,7 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
 
         {/* Content Section */}
         <div
+          data-slot="provider-card-content"
           className={cn(
             'flex flex-1 flex-col',
             variant === 'compact' && 'p-4',
@@ -327,7 +336,10 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
           )}
         >
           {/* Header: Name + Verified */}
-          <div className="mb-1 flex items-start justify-between gap-2">
+          <div
+            data-slot="provider-card-header"
+            className="mb-1 flex items-start justify-between gap-2"
+          >
             <h3
               className={cn(
                 'text-primary-800 dark:text-primary-300 line-clamp-2 font-semibold',
@@ -343,6 +355,7 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
 
           {/* Address */}
           <p
+            data-slot="provider-card-address"
             className={cn(
               'text-muted-foreground',
               variant === 'featured' ? 'text-sm' : 'text-xs'
@@ -370,6 +383,7 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
           {provider.workNumber && (
             <a
               href={`tel:${provider.workNumber}`}
+              data-slot="provider-card-phone"
               data-phone-link
               onClick={handlePhoneClick}
               className={cn(
@@ -385,7 +399,10 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
 
           {/* Services Badges */}
           {displayServices && displayServices.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-1.5">
+            <div
+              data-slot="provider-card-services"
+              className="mt-3 flex flex-wrap gap-1.5"
+            >
               {displayServices.map((service) => (
                 <Badge
                   key={service._id}
@@ -408,7 +425,10 @@ export const ProviderCard = React.forwardRef<HTMLDivElement, ProviderCardProps>(
           <div className="flex-1" />
 
           {/* Footer: Distance + Actions */}
-          <div className="mt-3 flex items-center justify-between">
+          <div
+            data-slot="provider-card-footer"
+            className="mt-3 flex items-center justify-between"
+          >
             <div className="flex items-center gap-2">
               {provider.safeFromWildfires && <SafeFromWildfiresNotice />}
               {!provider.safeFromWildfires && (
@@ -468,6 +488,7 @@ export const ProviderCardGrid: React.FC<ProviderCardGridProps> = ({
   if (loading) {
     return (
       <div
+        data-slot="provider-card-grid"
         className={cn(
           'grid gap-4',
           variant === 'compact' && 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
@@ -484,7 +505,10 @@ export const ProviderCardGrid: React.FC<ProviderCardGridProps> = ({
 
   if (providers.length === 0) {
     return (
-      <div className={cn('py-12 text-center', className)}>
+      <div
+        data-slot="provider-card-grid"
+        className={cn('py-12 text-center', className)}
+      >
         {emptyState || (
           <div className="text-muted-foreground">
             <svg
@@ -512,6 +536,7 @@ export const ProviderCardGrid: React.FC<ProviderCardGridProps> = ({
 
   return (
     <div
+      data-slot="provider-card-grid"
       className={cn(
         'grid gap-4',
         variant === 'compact' && 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',

--- a/src/components/ProviderCard/ProviderCard.tsx
+++ b/src/components/ProviderCard/ProviderCard.tsx
@@ -155,7 +155,10 @@ const DistanceBadge: React.FC<{ distance?: number }> = ({ distance }) => {
 
 const SafeFromWildfiresNotice: React.FC = () => (
   <Tooltip content="BlueHive has confirmed that this provider is operational and not impacted by the January 2025 wildfires.">
-    <div className="inline-flex items-center gap-1.5 rounded-md bg-green-100 px-2 py-1 text-xs text-green-700 dark:bg-green-900/30 dark:text-green-300">
+    <div
+      data-slot="provider-card-safe-notice"
+      className="inline-flex items-center gap-1.5 rounded-md bg-green-100 px-2 py-1 text-xs text-green-700 dark:bg-green-900/30 dark:text-green-300"
+    >
       <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
         <path
           fillRule="evenodd"
@@ -170,7 +173,10 @@ const SafeFromWildfiresNotice: React.FC = () => (
 
 const VerifiedBadge: React.FC = () => (
   <Tooltip content="This provider's information has been verified">
-    <span className="inline-flex items-center gap-1 text-xs text-green-700 dark:text-green-300">
+    <span
+      data-slot="provider-card-verified"
+      className="inline-flex items-center gap-1 text-xs text-green-700 dark:text-green-300"
+    >
       <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20">
         <path
           fillRule="evenodd"

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -149,6 +149,7 @@ export function ActionButtonsBar({
 
   return (
     <div
+      data-slot="provider-detail-actions"
       className={cn(
         'flex justify-center border-b border-gray-200 dark:border-gray-700',
         className
@@ -200,7 +201,11 @@ export interface BreadcrumbProps {
 
 export function Breadcrumb({ items, className }: BreadcrumbProps) {
   return (
-    <nav aria-label="Breadcrumb" className={cn('py-2', className)}>
+    <nav
+      aria-label="Breadcrumb"
+      data-slot="provider-detail-breadcrumb"
+      className={cn('py-2', className)}
+    >
       <ol className="flex flex-wrap items-center gap-1 text-sm">
         {items.map((item, index) => (
           <li key={item.href} className="flex items-center">
@@ -242,7 +247,10 @@ export function MobileBackButton({
   className,
 }: MobileBackButtonProps) {
   return (
-    <div className={cn('py-2 sm:hidden', className)}>
+    <div
+      data-slot="provider-detail-back"
+      className={cn('py-2 sm:hidden', className)}
+    >
       <a
         href={href}
         className="bg-primary-700 hover:bg-primary-800 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
@@ -289,6 +297,7 @@ export function ProviderLogo({
   if (!src || hasError) {
     return (
       <div
+        data-slot="provider-detail-logo"
         className={cn(
           logoSizeClasses[size],
           'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 flex items-center justify-center rounded-lg font-bold',
@@ -308,6 +317,7 @@ export function ProviderLogo({
     <img
       src={src}
       alt={`${name} logo`}
+      data-slot="provider-detail-logo"
       className={cn(
         logoSizeClasses[size],
         'rounded-lg object-contain',
@@ -388,7 +398,10 @@ export function SocialMediaLinks({
   }
 
   return (
-    <div className={cn('flex flex-wrap items-center gap-3', className)}>
+    <div
+      data-slot="provider-detail-social"
+      className={cn('flex flex-wrap items-center gap-3', className)}
+    >
       {socialLinks.map((link) => (
         <a
           key={link.key}
@@ -438,6 +451,7 @@ export function VerifiedBadge({
 
   return (
     <div
+      data-slot="provider-detail-verified"
       className={cn(
         'flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400',
         className
@@ -704,6 +718,7 @@ export function ProviderDetailHeader({
 
   return (
     <div
+      data-slot="provider-detail-header"
       className={cn(
         headerVariants({ variant: variant ?? 'default' }),
         className
@@ -720,7 +735,10 @@ export function ProviderDetailHeader({
       )}
 
       {/* Main Header Content */}
-      <div className="container mx-auto px-4 py-6">
+      <div
+        data-slot="provider-detail-content"
+        className="container mx-auto px-4 py-6"
+      >
         {/* Breadcrumb (Desktop) */}
         {showBreadcrumb && (
           <Breadcrumb
@@ -741,7 +759,10 @@ export function ProviderDetailHeader({
 
           {/* Details */}
           <div className="flex-1">
-            <h1 className="mb-2 text-2xl font-bold text-gray-900 sm:text-3xl dark:text-white">
+            <h1
+              data-slot="provider-detail-name"
+              className="mb-2 text-2xl font-bold text-gray-900 sm:text-3xl dark:text-white"
+            >
               {provider.name}
             </h1>
 
@@ -806,6 +827,7 @@ export function CompactProviderHeader({
 }: CompactProviderHeaderProps) {
   return (
     <div
+      data-slot="provider-detail-compact"
       className={cn(
         'rounded-lg bg-white p-4 shadow-sm dark:bg-gray-900',
         className

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -193,9 +193,12 @@ export function ProviderOverview({
   }
 
   return (
-    <div className={`space-y-6 ${className}`}>
+    <div data-slot="provider-overview" className={`space-y-6 ${className}`}>
       {/* Header */}
-      <div className="flex items-center gap-4">
+      <div
+        data-slot="provider-overview-header"
+        className="flex items-center gap-4"
+      >
         {logoUrl ? (
           <img
             src={logoUrl}
@@ -220,7 +223,10 @@ export function ProviderOverview({
       </div>
 
       {/* Stats Grid */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <div
+        data-slot="provider-overview-stats"
+        className="grid grid-cols-2 gap-4 lg:grid-cols-4"
+      >
         <StatCard
           label="Pending Orders"
           value={stats.pendingOrders}
@@ -309,7 +315,7 @@ export function ProviderOverview({
 
       {/* Quick Actions */}
       {quickActions.length > 0 && (
-        <Card>
+        <Card data-slot="provider-overview-actions">
           <CardHeader>
             <CardTitle>Quick Actions</CardTitle>
           </CardHeader>
@@ -353,7 +359,7 @@ export function ProviderOverview({
 
       {/* Recent Activity */}
       {recentActivity.length > 0 && (
-        <Card>
+        <Card data-slot="provider-overview-activity">
           <CardHeader>
             <CardTitle>Recent Activity</CardTitle>
           </CardHeader>
@@ -432,6 +438,7 @@ function StatCard({ label, value, icon, color, onClick }: StatCardProps) {
 
   return (
     <div
+      data-slot="provider-overview-stat"
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       onClick={onClick}

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { cn } from '../../utils/cn';
 import { Card, CardHeader, CardTitle, CardContent } from '../Card/Card';
 import { Badge } from '../Badge/Badge';
 
@@ -173,7 +174,7 @@ export function ProviderOverview({
 
   if (isLoading) {
     return (
-      <div data-slot="provider-overview" className={`space-y-6 ${className}`}>
+      <div data-slot="provider-overview" className={cn('space-y-6', className)}>
         {/* Header skeleton */}
         <div
           data-slot="provider-overview-header"
@@ -199,7 +200,7 @@ export function ProviderOverview({
   }
 
   return (
-    <div data-slot="provider-overview" className={`space-y-6 ${className}`}>
+    <div data-slot="provider-overview" className={cn('space-y-6', className)}>
       {/* Header */}
       <div
         data-slot="provider-overview-header"

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -183,7 +183,10 @@ export function ProviderOverview({
           <div className="h-6 w-48 rounded bg-gray-200 dark:bg-gray-700" />
         </div>
         {/* Stats skeleton */}
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <div
+          data-slot="provider-overview-stats"
+          className="grid grid-cols-2 gap-4 lg:grid-cols-4"
+        >
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -321,103 +321,107 @@ export function ProviderOverview({
 
       {/* Quick Actions */}
       {quickActions.length > 0 && (
-        <Card data-slot="provider-overview-actions">
-          <CardHeader>
-            <CardTitle>Quick Actions</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-              {quickActions.map((action) => (
-                <button
-                  key={action.id}
-                  onClick={() => {
-                    action.onClick?.();
-                    onQuickActionClick?.(action);
-                  }}
-                  className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-                >
-                  <span className="text-gray-500 dark:text-gray-400">
-                    {action.icon || (
-                      <svg
-                        className="h-5 w-5"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                    )}
-                  </span>
-                  <span className="text-center text-xs font-medium text-gray-700 dark:text-gray-300">
-                    {action.label}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <div data-slot="provider-overview-actions">
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick Actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {quickActions.map((action) => (
+                  <button
+                    key={action.id}
+                    onClick={() => {
+                      action.onClick?.();
+                      onQuickActionClick?.(action);
+                    }}
+                    className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+                  >
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {action.icon || (
+                        <svg
+                          className="h-5 w-5"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                      )}
+                    </span>
+                    <span className="text-center text-xs font-medium text-gray-700 dark:text-gray-300">
+                      {action.label}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       )}
 
       {/* Recent Activity */}
       {recentActivity.length > 0 && (
-        <Card data-slot="provider-overview-activity">
-          <CardHeader>
-            <CardTitle>Recent Activity</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {recentActivity.map((activity) => (
-                <div
-                  key={activity.id}
-                  role={onActivityClick ? 'button' : undefined}
-                  tabIndex={onActivityClick ? 0 : undefined}
-                  onClick={() => onActivityClick?.(activity)}
-                  onKeyDown={(e) =>
-                    e.key === 'Enter' && onActivityClick?.(activity)
-                  }
-                  className={`flex items-start gap-3 rounded-lg p-2 ${onActivityClick ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800' : ''} `}
-                >
-                  <div className="rounded-full bg-gray-100 p-2 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                    {getActivityIcon(activity.type)}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <p className="truncate font-medium text-gray-900 dark:text-white">
-                        {activity.title}
-                      </p>
-                      {activity.status && (
-                        <Badge
-                          variant={
-                            activity.status === 'completed'
-                              ? 'success'
-                              : activity.status === 'cancelled'
-                                ? 'danger'
-                                : 'warning'
-                          }
-                        >
-                          {activity.status}
-                        </Badge>
-                      )}
+        <div data-slot="provider-overview-activity">
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent Activity</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {recentActivity.map((activity) => (
+                  <div
+                    key={activity.id}
+                    role={onActivityClick ? 'button' : undefined}
+                    tabIndex={onActivityClick ? 0 : undefined}
+                    onClick={() => onActivityClick?.(activity)}
+                    onKeyDown={(e) =>
+                      e.key === 'Enter' && onActivityClick?.(activity)
+                    }
+                    className={`flex items-start gap-3 rounded-lg p-2 ${onActivityClick ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800' : ''} `}
+                  >
+                    <div className="rounded-full bg-gray-100 p-2 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                      {getActivityIcon(activity.type)}
                     </div>
-                    {activity.description && (
-                      <p className="truncate text-sm text-gray-500 dark:text-gray-400">
-                        {activity.description}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate font-medium text-gray-900 dark:text-white">
+                          {activity.title}
+                        </p>
+                        {activity.status && (
+                          <Badge
+                            variant={
+                              activity.status === 'completed'
+                                ? 'success'
+                                : activity.status === 'cancelled'
+                                  ? 'danger'
+                                  : 'warning'
+                            }
+                          >
+                            {activity.status}
+                          </Badge>
+                        )}
+                      </div>
+                      {activity.description && (
+                        <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+                          {activity.description}
+                        </p>
+                      )}
+                      <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        {formatTime(activity.timestamp)}
                       </p>
-                    )}
-                    <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                      {formatTime(activity.timestamp)}
-                    </p>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       )}
     </div>
   );

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -173,9 +173,12 @@ export function ProviderOverview({
 
   if (isLoading) {
     return (
-      <div className={`space-y-6 ${className}`}>
+      <div data-slot="provider-overview" className={`space-y-6 ${className}`}>
         {/* Header skeleton */}
-        <div className="flex animate-pulse items-center gap-4">
+        <div
+          data-slot="provider-overview-header"
+          className="flex animate-pulse items-center gap-4"
+        >
           <div className="h-12 w-12 rounded-lg bg-gray-200 dark:bg-gray-700" />
           <div className="h-6 w-48 rounded bg-gray-200 dark:bg-gray-700" />
         </div>

--- a/src/components/ProviderSearchBar/ProviderSearchBar.tsx
+++ b/src/components/ProviderSearchBar/ProviderSearchBar.tsx
@@ -415,6 +415,7 @@ export const ProviderSearchBar = React.forwardRef<
 
     return (
       <div
+        data-slot="provider-search"
         className={cn(
           'w-full',
           searchBarVariants({ size, variant }),
@@ -430,6 +431,7 @@ export const ProviderSearchBar = React.forwardRef<
           {...props}
         >
           <div
+            data-slot="provider-search-input"
             className={cn(
               'bg-background flex items-center gap-1 rounded-lg border',
               'focus-within:ring-primary-500 focus-within:ring-2 focus-within:ring-offset-2',
@@ -499,7 +501,7 @@ export const ProviderSearchBar = React.forwardRef<
 
         {/* Results Message */}
         {showResults && (results || resultsLoading) && (
-          <div className="mt-3">
+          <div data-slot="provider-search-results" className="mt-3">
             <SearchResultsMessage
               results={results}
               loading={resultsLoading}
@@ -535,9 +537,15 @@ export const HeroSearchBar: React.FC<HeroSearchBarProps> = ({
   ...props
 }) => {
   return (
-    <div className={cn('text-center', className)}>
+    <div
+      data-slot="provider-search-hero"
+      className={cn('text-center', className)}
+    >
       {title && (
-        <h1 className="text-foreground mb-2 text-3xl font-bold md:text-4xl lg:text-5xl">
+        <h1
+          data-slot="provider-search-hero-title"
+          className="text-foreground mb-2 text-3xl font-bold md:text-4xl lg:text-5xl"
+        >
           {title}
         </h1>
       )}

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -386,7 +386,11 @@ export function ServiceMultiSelect({
   }
 
   return (
-    <div ref={containerRef} className="relative">
+    <div
+      ref={containerRef}
+      className="relative"
+      data-slot="provider-service-select"
+    >
       {label && <label className={labelVariants()}>{label}</label>}
 
       {/* Selected tags display */}
@@ -613,6 +617,7 @@ export function ProviderSearchFilters({
     <FormWrapper
       {...formProps}
       className={cn(containerVariants({ layout }), className)}
+      data-slot="provider-search-filters"
     >
       {/* Provider Name Search */}
       {showNameSearch && (
@@ -737,6 +742,7 @@ export function CompactFilterBar({
         'dark:border-neutral-700 dark:bg-neutral-800',
         className
       )}
+      data-slot="provider-compact-filter"
     >
       {/* Search Input */}
       <div className="min-w-[150px] flex-1">
@@ -929,7 +935,10 @@ export function ActiveFilters({
   }
 
   return (
-    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+    <div
+      className={cn('flex flex-wrap items-center gap-2', className)}
+      data-slot="provider-active-filters"
+    >
       <span className="text-sm text-neutral-500 dark:text-neutral-400">
         Active filters:
       </span>

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -265,6 +265,7 @@ interface ServiceTagProps {
 function ServiceTag({ service, onRemove }: ServiceTagProps) {
   return (
     <span
+      data-slot="provider-service-tag"
       className={cn(
         'inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm',
         'bg-primary-100 text-primary-800',

--- a/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/src/components/ProviderSettings/ProviderSettings.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { cn } from '../../utils/cn';
 import { Button } from '../Button/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../Card/Card';
 import { Input } from '../Input/Input';
@@ -156,7 +157,7 @@ export function ProviderSettings({
     return (
       <div
         data-slot="provider-settings"
-        className={`animate-pulse space-y-4 ${className}`}
+        className={cn('animate-pulse space-y-4', className)}
       >
         <div className="h-12 rounded-lg bg-gray-200 dark:bg-gray-700" />
         <div className="h-64 rounded-lg bg-gray-200 dark:bg-gray-700" />
@@ -165,7 +166,7 @@ export function ProviderSettings({
   }
 
   return (
-    <div data-slot="provider-settings" className={`space-y-6 ${className}`}>
+    <div data-slot="provider-settings" className={cn('space-y-6', className)}>
       {/* Header */}
       <div
         data-slot="provider-settings-header"
@@ -406,359 +407,359 @@ export function ProviderSettings({
         </TabsContent>
 
         {/* Notifications Tab */}
-        <TabsContent
-          value="notifications"
-          data-slot="provider-settings-notifications"
-        >
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">
-                Notification Preferences
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div>
-                <h3 className="mb-4 font-medium text-gray-900 dark:text-white">
-                  Email Notifications
-                </h3>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium text-gray-700 dark:text-gray-300">
-                        New Orders
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Receive email when a new order is placed
-                      </p>
+        <TabsContent value="notifications">
+          <div data-slot="provider-settings-notifications">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">
+                  Notification Preferences
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div>
+                  <h3 className="mb-4 font-medium text-gray-900 dark:text-white">
+                    Email Notifications
+                  </h3>
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-700 dark:text-gray-300">
+                          New Orders
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Receive email when a new order is placed
+                        </p>
+                      </div>
+                      <Switch
+                        checked={settings.notifications.emailNewOrders}
+                        onCheckedChange={(checked) =>
+                          updateNotifications('emailNewOrders', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.notifications.emailNewOrders}
-                      onCheckedChange={(checked) =>
-                        updateNotifications('emailNewOrders', checked)
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium text-gray-700 dark:text-gray-300">
-                        Order Updates
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Receive email when an order status changes
-                      </p>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-700 dark:text-gray-300">
+                          Order Updates
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Receive email when an order status changes
+                        </p>
+                      </div>
+                      <Switch
+                        checked={settings.notifications.emailOrderUpdates}
+                        onCheckedChange={(checked) =>
+                          updateNotifications('emailOrderUpdates', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.notifications.emailOrderUpdates}
-                      onCheckedChange={(checked) =>
-                        updateNotifications('emailOrderUpdates', checked)
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium text-gray-700 dark:text-gray-300">
-                        Invoice Notifications
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Receive email for invoice activity
-                      </p>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-700 dark:text-gray-300">
+                          Invoice Notifications
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Receive email for invoice activity
+                        </p>
+                      </div>
+                      <Switch
+                        checked={settings.notifications.emailInvoices}
+                        onCheckedChange={(checked) =>
+                          updateNotifications('emailInvoices', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.notifications.emailInvoices}
-                      onCheckedChange={(checked) =>
-                        updateNotifications('emailInvoices', checked)
-                      }
-                    />
                   </div>
                 </div>
-              </div>
 
-              <div className="border-t border-gray-200 pt-6 dark:border-gray-700">
-                <h3 className="mb-4 font-medium text-gray-900 dark:text-white">
-                  SMS Notifications
-                </h3>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium text-gray-700 dark:text-gray-300">
-                        New Orders
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Receive SMS when a new order is placed
-                      </p>
+                <div className="border-t border-gray-200 pt-6 dark:border-gray-700">
+                  <h3 className="mb-4 font-medium text-gray-900 dark:text-white">
+                    SMS Notifications
+                  </h3>
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-700 dark:text-gray-300">
+                          New Orders
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Receive SMS when a new order is placed
+                        </p>
+                      </div>
+                      <Switch
+                        checked={settings.notifications.smsNewOrders}
+                        onCheckedChange={(checked) =>
+                          updateNotifications('smsNewOrders', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.notifications.smsNewOrders}
-                      onCheckedChange={(checked) =>
-                        updateNotifications('smsNewOrders', checked)
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium text-gray-700 dark:text-gray-300">
-                        Order Updates
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Receive SMS when an order status changes
-                      </p>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-700 dark:text-gray-300">
+                          Order Updates
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Receive SMS when an order status changes
+                        </p>
+                      </div>
+                      <Switch
+                        checked={settings.notifications.smsOrderUpdates}
+                        onCheckedChange={(checked) =>
+                          updateNotifications('smsOrderUpdates', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.notifications.smsOrderUpdates}
-                      onCheckedChange={(checked) =>
-                        updateNotifications('smsOrderUpdates', checked)
-                      }
-                    />
                   </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
 
         {/* Scheduling Tab */}
-        <TabsContent
-          value="scheduling"
-          data-slot="provider-settings-scheduling"
-        >
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Scheduling Settings</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-gray-700 dark:text-gray-300">
-                      Accepting New Patients
-                    </p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Allow new patients to schedule appointments
-                    </p>
+        <TabsContent value="scheduling">
+          <div data-slot="provider-settings-scheduling">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Scheduling Settings</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-gray-700 dark:text-gray-300">
+                        Accepting New Patients
+                      </p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        Allow new patients to schedule appointments
+                      </p>
+                    </div>
+                    <Switch
+                      checked={settings.scheduling.acceptingNewPatients}
+                      onCheckedChange={(checked) =>
+                        updateScheduling('acceptingNewPatients', checked)
+                      }
+                    />
                   </div>
-                  <Switch
-                    checked={settings.scheduling.acceptingNewPatients}
-                    onCheckedChange={(checked) =>
-                      updateScheduling('acceptingNewPatients', checked)
-                    }
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-gray-700 dark:text-gray-300">
-                      Require Appointment
-                    </p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Patients must schedule before arriving
-                    </p>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-gray-700 dark:text-gray-300">
+                        Require Appointment
+                      </p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        Patients must schedule before arriving
+                      </p>
+                    </div>
+                    <Switch
+                      checked={settings.scheduling.requireAppointment}
+                      onCheckedChange={(checked) =>
+                        updateScheduling('requireAppointment', checked)
+                      }
+                    />
                   </div>
-                  <Switch
-                    checked={settings.scheduling.requireAppointment}
-                    onCheckedChange={(checked) =>
-                      updateScheduling('requireAppointment', checked)
-                    }
-                  />
                 </div>
-              </div>
 
-              <div className="grid gap-4 border-t border-gray-200 pt-6 md:grid-cols-2 dark:border-gray-700">
-                <div>
-                  <label
-                    htmlFor="appointment-buffer"
-                    className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >
-                    Appointment Buffer (minutes)
-                  </label>
-                  <Input
-                    id="appointment-buffer"
-                    type="number"
-                    min={0}
-                    value={settings.scheduling.appointmentBuffer}
-                    onChange={(e) =>
-                      updateScheduling(
-                        'appointmentBuffer',
-                        parseInt(e.target.value) || 0
-                      )
-                    }
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Minimum time between appointments
-                  </p>
+                <div className="grid gap-4 border-t border-gray-200 pt-6 md:grid-cols-2 dark:border-gray-700">
+                  <div>
+                    <label
+                      htmlFor="appointment-buffer"
+                      className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      Appointment Buffer (minutes)
+                    </label>
+                    <Input
+                      id="appointment-buffer"
+                      type="number"
+                      min={0}
+                      value={settings.scheduling.appointmentBuffer}
+                      onChange={(e) =>
+                        updateScheduling(
+                          'appointmentBuffer',
+                          parseInt(e.target.value) || 0
+                        )
+                      }
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      Minimum time between appointments
+                    </p>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="max-daily-appointments"
+                      className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      Max Daily Appointments
+                    </label>
+                    <Input
+                      id="max-daily-appointments"
+                      type="number"
+                      min={1}
+                      value={settings.scheduling.maxDailyAppointments}
+                      onChange={(e) =>
+                        updateScheduling(
+                          'maxDailyAppointments',
+                          parseInt(e.target.value) || 1
+                        )
+                      }
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      Maximum appointments allowed per day
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <label
-                    htmlFor="max-daily-appointments"
-                    className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >
-                    Max Daily Appointments
-                  </label>
-                  <Input
-                    id="max-daily-appointments"
-                    type="number"
-                    min={1}
-                    value={settings.scheduling.maxDailyAppointments}
-                    onChange={(e) =>
-                      updateScheduling(
-                        'maxDailyAppointments',
-                        parseInt(e.target.value) || 1
-                      )
-                    }
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Maximum appointments allowed per day
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
 
         {/* Payments Tab */}
-        <TabsContent value="payments" data-slot="provider-settings-payments">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Payment Settings</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div>
-                <h3 className="mb-4 font-medium text-gray-900 dark:text-white">
-                  Accepted Payment Methods
-                </h3>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
-                    <div className="flex items-center gap-3">
-                      <svg
-                        className="h-8 w-8 text-gray-600 dark:text-gray-300"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={1.5}
-                          d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
-                        />
-                      </svg>
-                      <span className="font-medium text-gray-700 dark:text-gray-300">
-                        Credit Card
-                      </span>
+        <TabsContent value="payments">
+          <div data-slot="provider-settings-payments">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Payment Settings</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div>
+                  <h3 className="mb-4 font-medium text-gray-900 dark:text-white">
+                    Accepted Payment Methods
+                  </h3>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
+                      <div className="flex items-center gap-3">
+                        <svg
+                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+                          />
+                        </svg>
+                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                          Credit Card
+                        </span>
+                      </div>
+                      <Switch
+                        checked={settings.payments.acceptsCreditCard}
+                        onCheckedChange={(checked) =>
+                          updatePayments('acceptsCreditCard', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.payments.acceptsCreditCard}
-                      onCheckedChange={(checked) =>
-                        updatePayments('acceptsCreditCard', checked)
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
-                    <div className="flex items-center gap-3">
-                      <svg
-                        className="h-8 w-8 text-gray-600 dark:text-gray-300"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={1.5}
-                          d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                        />
-                      </svg>
-                      <span className="font-medium text-gray-700 dark:text-gray-300">
-                        ACH / Bank Transfer
-                      </span>
+                    <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
+                      <div className="flex items-center gap-3">
+                        <svg
+                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                          />
+                        </svg>
+                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                          ACH / Bank Transfer
+                        </span>
+                      </div>
+                      <Switch
+                        checked={settings.payments.acceptsACH}
+                        onCheckedChange={(checked) =>
+                          updatePayments('acceptsACH', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.payments.acceptsACH}
-                      onCheckedChange={(checked) =>
-                        updatePayments('acceptsACH', checked)
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
-                    <div className="flex items-center gap-3">
-                      <svg
-                        className="h-8 w-8 text-gray-600 dark:text-gray-300"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={1.5}
-                          d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                      <span className="font-medium text-gray-700 dark:text-gray-300">
-                        Cash
-                      </span>
+                    <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
+                      <div className="flex items-center gap-3">
+                        <svg
+                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                          Cash
+                        </span>
+                      </div>
+                      <Switch
+                        checked={settings.payments.acceptsCash}
+                        onCheckedChange={(checked) =>
+                          updatePayments('acceptsCash', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.payments.acceptsCash}
-                      onCheckedChange={(checked) =>
-                        updatePayments('acceptsCash', checked)
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
-                    <div className="flex items-center gap-3">
-                      <svg
-                        className="h-8 w-8 text-gray-600 dark:text-gray-300"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={1.5}
-                          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                        />
-                      </svg>
-                      <span className="font-medium text-gray-700 dark:text-gray-300">
-                        Check
-                      </span>
+                    <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
+                      <div className="flex items-center gap-3">
+                        <svg
+                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                          />
+                        </svg>
+                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                          Check
+                        </span>
+                      </div>
+                      <Switch
+                        checked={settings.payments.acceptsCheck}
+                        onCheckedChange={(checked) =>
+                          updatePayments('acceptsCheck', checked)
+                        }
+                      />
                     </div>
-                    <Switch
-                      checked={settings.payments.acceptsCheck}
-                      onCheckedChange={(checked) =>
-                        updatePayments('acceptsCheck', checked)
-                      }
-                    />
                   </div>
                 </div>
-              </div>
 
-              <div className="border-t border-gray-200 pt-6 dark:border-gray-700">
-                <div className="max-w-xs">
-                  <label
-                    htmlFor="payment-terms"
-                    className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >
-                    Payment Terms (days)
-                  </label>
-                  <Input
-                    id="payment-terms"
-                    type="number"
-                    min={0}
-                    value={settings.payments.paymentTerms}
-                    onChange={(e) =>
-                      updatePayments(
-                        'paymentTerms',
-                        parseInt(e.target.value) || 0
-                      )
-                    }
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Number of days until invoice is due (e.g., Net 30)
-                  </p>
+                <div className="border-t border-gray-200 pt-6 dark:border-gray-700">
+                  <div className="max-w-xs">
+                    <label
+                      htmlFor="payment-terms"
+                      className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      Payment Terms (days)
+                    </label>
+                    <Input
+                      id="payment-terms"
+                      type="number"
+                      min={0}
+                      value={settings.payments.paymentTerms}
+                      onChange={(e) =>
+                        updatePayments(
+                          'paymentTerms',
+                          parseInt(e.target.value) || 0
+                        )
+                      }
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      Number of days until invoice is due (e.g., Net 30)
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/src/components/ProviderSettings/ProviderSettings.tsx
@@ -154,7 +154,10 @@ export function ProviderSettings({
 
   if (isLoading) {
     return (
-      <div className={`animate-pulse space-y-4 ${className}`}>
+      <div
+        data-slot="provider-settings"
+        className={`animate-pulse space-y-4 ${className}`}
+      >
         <div className="h-12 rounded-lg bg-gray-200 dark:bg-gray-700" />
         <div className="h-64 rounded-lg bg-gray-200 dark:bg-gray-700" />
       </div>
@@ -162,9 +165,12 @@ export function ProviderSettings({
   }
 
   return (
-    <div className={`space-y-6 ${className}`}>
+    <div data-slot="provider-settings" className={`space-y-6 ${className}`}>
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div
+        data-slot="provider-settings-header"
+        className="flex items-center justify-between"
+      >
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
           Provider Settings
         </h1>
@@ -400,7 +406,10 @@ export function ProviderSettings({
         </TabsContent>
 
         {/* Notifications Tab */}
-        <TabsContent value="notifications">
+        <TabsContent
+          value="notifications"
+          data-slot="provider-settings-notifications"
+        >
           <Card>
             <CardHeader>
               <CardTitle className="text-lg">
@@ -508,7 +517,10 @@ export function ProviderSettings({
         </TabsContent>
 
         {/* Scheduling Tab */}
-        <TabsContent value="scheduling">
+        <TabsContent
+          value="scheduling"
+          data-slot="provider-settings-scheduling"
+        >
           <Card>
             <CardHeader>
               <CardTitle className="text-lg">Scheduling Settings</CardTitle>
@@ -602,7 +614,7 @@ export function ProviderSettings({
         </TabsContent>
 
         {/* Payments Tab */}
-        <TabsContent value="payments">
+        <TabsContent value="payments" data-slot="provider-settings-payments">
           <Card>
             <CardHeader>
               <CardTitle className="text-lg">Payment Settings</CardTitle>

--- a/src/components/RecurringServiceCard/RecurringServiceCard.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.tsx
@@ -209,6 +209,7 @@ export function RecurringServiceCard({
 
   return (
     <div
+      data-slot="recurring-service-card"
       className={cn(
         'bg-card text-card-foreground rounded-xl border-2 shadow-sm',
         currentStyle.border,
@@ -229,7 +230,10 @@ export function RecurringServiceCard({
       }}
     >
       {/* Card Header - matches CSVColumnMapper style */}
-      <div className="flex items-center gap-2 px-4 py-3">
+      <div
+        data-slot="recurring-service-header"
+        className="flex items-center gap-2 px-4 py-3"
+      >
         {/* Status Icon */}
         {currentStyle.icon}
         <h6
@@ -241,7 +245,7 @@ export function RecurringServiceCard({
       </div>
 
       {/* Card Body - matches CSVColumnMapper style */}
-      <div className="space-y-4 px-4 pb-4">
+      <div data-slot="recurring-service-body" className="space-y-4 px-4 pb-4">
         {/* Provider */}
         {showProvider && service.providerName && (
           <div>
@@ -342,6 +346,7 @@ export function RecurringServiceAddCard({
     <button
       type="button"
       onClick={onClick}
+      data-slot="recurring-service-add"
       className={cn(
         'text-muted-foreground hover:border-primary hover:bg-primary/5 hover:text-primary border-border bg-muted/50 flex min-h-[200px] w-full flex-col items-center justify-center rounded-xl border-2 border-dashed p-4 transition-colors',
         className
@@ -453,6 +458,7 @@ export function RecurringServiceSetupModal({
           'bg-card text-card-foreground w-full max-w-lg rounded-lg shadow-xl',
           className
         )}
+        data-slot="recurring-service-modal"
       >
         {/* Header */}
         <div className="bg-primary text-primary-foreground flex items-center justify-between p-4">
@@ -611,7 +617,10 @@ export function RecurringServiceGrid({
   className,
 }: RecurringServiceGridProps) {
   return (
-    <div className={cn('grid grid-cols-1 gap-4 md:grid-cols-2', className)}>
+    <div
+      data-slot="recurring-service-grid"
+      className={cn('grid grid-cols-1 gap-4 md:grid-cols-2', className)}
+    >
       {/* Add Card */}
       <RecurringServiceAddCard onClick={onAdd} />
 

--- a/src/components/ReportDashboard/ReportDashboard.tsx
+++ b/src/components/ReportDashboard/ReportDashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { cn } from '../../utils/cn';
 import { Badge } from '../Badge/Badge';
 import { Button } from '../Button/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../Card/Card';
@@ -149,7 +150,7 @@ export function ReportDashboard({
     return (
       <div
         data-slot="report-dashboard"
-        className={`animate-pulse space-y-6 ${className}`}
+        className={cn('animate-pulse space-y-6', className)}
       >
         <div className="h-12 w-1/3 rounded-lg bg-gray-200 dark:bg-gray-700" />
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
@@ -166,7 +167,7 @@ export function ReportDashboard({
   }
 
   return (
-    <div data-slot="report-dashboard" className={`space-y-6 ${className}`}>
+    <div data-slot="report-dashboard" className={cn('space-y-6', className)}>
       {/* Header */}
       <div
         data-slot="report-dashboard-header"

--- a/src/components/ReportDashboard/ReportDashboard.tsx
+++ b/src/components/ReportDashboard/ReportDashboard.tsx
@@ -147,7 +147,10 @@ export function ReportDashboard({
 
   if (isLoading) {
     return (
-      <div className={`animate-pulse space-y-6 ${className}`}>
+      <div
+        data-slot="report-dashboard"
+        className={`animate-pulse space-y-6 ${className}`}
+      >
         <div className="h-12 w-1/3 rounded-lg bg-gray-200 dark:bg-gray-700" />
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           {[1, 2, 3, 4].map((i) => (
@@ -163,9 +166,12 @@ export function ReportDashboard({
   }
 
   return (
-    <div className={`space-y-6 ${className}`}>
+    <div data-slot="report-dashboard" className={`space-y-6 ${className}`}>
       {/* Header */}
-      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+      <div
+        data-slot="report-dashboard-header"
+        className="flex flex-col justify-between gap-4 md:flex-row md:items-center"
+      >
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             {title}
@@ -216,7 +222,10 @@ export function ReportDashboard({
       </div>
 
       {/* Metrics Grid */}
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+      <div
+        data-slot="report-dashboard-metrics"
+        className="grid grid-cols-2 gap-4 md:grid-cols-4"
+      >
         {metrics.map((metric, index) => (
           <Card key={index}>
             <CardContent className="p-4">
@@ -251,133 +260,148 @@ export function ReportDashboard({
 
       {/* Chart */}
       {chartData.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Order Volume</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex h-48 items-end gap-1">
-              {chartData.map((point, index) => (
-                <div
-                  key={index}
-                  className="flex flex-1 flex-col items-center gap-1"
-                >
-                  <div className="flex h-40 w-full items-end gap-0.5">
-                    {point.previousValue !== undefined && (
+        <div data-slot="report-dashboard-chart">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Order Volume</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex h-48 items-end gap-1">
+                {chartData.map((point, index) => (
+                  <div
+                    key={index}
+                    className="flex flex-1 flex-col items-center gap-1"
+                  >
+                    <div className="flex h-40 w-full items-end gap-0.5">
+                      {point.previousValue !== undefined && (
+                        <div
+                          className="flex-1 rounded-t bg-gray-200 dark:bg-gray-700"
+                          style={{
+                            height: `${(point.previousValue / maxChartValue) * 100}%`,
+                          }}
+                          title={`Previous: ${point.previousValue}`}
+                        />
+                      )}
                       <div
-                        className="flex-1 rounded-t bg-gray-200 dark:bg-gray-700"
+                        className="flex-1 rounded-t bg-blue-500 dark:bg-blue-400"
                         style={{
-                          height: `${(point.previousValue / maxChartValue) * 100}%`,
+                          height: `${(point.value / maxChartValue) * 100}%`,
                         }}
-                        title={`Previous: ${point.previousValue}`}
+                        title={`Current: ${point.value}`}
                       />
-                    )}
-                    <div
-                      className="flex-1 rounded-t bg-blue-500 dark:bg-blue-400"
-                      style={{
-                        height: `${(point.value / maxChartValue) * 100}%`,
-                      }}
-                      title={`Current: ${point.value}`}
-                    />
+                    </div>
+                    <span className="w-full truncate text-center text-xs text-gray-500 dark:text-gray-400">
+                      {point.label}
+                    </span>
                   </div>
-                  <span className="w-full truncate text-center text-xs text-gray-500 dark:text-gray-400">
-                    {point.label}
-                  </span>
-                </div>
-              ))}
-            </div>
-            <div className="mt-4 flex items-center justify-center gap-4 text-sm">
-              <div className="flex items-center gap-2">
-                <div className="h-3 w-3 rounded bg-blue-500 dark:bg-blue-400" />
-                <span className="text-gray-600 dark:text-gray-300">
-                  Current Period
-                </span>
+                ))}
               </div>
-              {chartData.some((d) => d.previousValue !== undefined) && (
+              <div className="mt-4 flex items-center justify-center gap-4 text-sm">
                 <div className="flex items-center gap-2">
-                  <div className="h-3 w-3 rounded bg-gray-200 dark:bg-gray-700" />
+                  <div className="h-3 w-3 rounded bg-blue-500 dark:bg-blue-400" />
                   <span className="text-gray-600 dark:text-gray-300">
-                    Previous Period
+                    Current Period
                   </span>
                 </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+                {chartData.some((d) => d.previousValue !== undefined) && (
+                  <div className="flex items-center gap-2">
+                    <div className="h-3 w-3 rounded bg-gray-200 dark:bg-gray-700" />
+                    <span className="text-gray-600 dark:text-gray-300">
+                      Previous Period
+                    </span>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       )}
 
       {/* Top Lists */}
-      <div className="grid gap-6 md:grid-cols-2">
+      <div
+        data-slot="report-dashboard-top-lists"
+        className="grid gap-6 md:grid-cols-2"
+      >
         {/* Top Services */}
         {topServices.length > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Top Services</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {topServices.map((service, index) => (
-                <div key={service.id} className="flex items-center gap-3">
-                  <Badge variant="secondary" className="h-6 w-6 justify-center">
-                    {index + 1}
-                  </Badge>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <p className="font-medium text-gray-900 dark:text-white">
-                        {service.name}
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-300">
-                        {formatNumber(service.value)}
-                      </p>
-                    </div>
-                    {service.percentage !== undefined && (
-                      <div className="mt-1 h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
-                        <div
-                          className="h-full rounded-full bg-blue-500 dark:bg-blue-400"
-                          style={{ width: `${service.percentage}%` }}
-                        />
+          <div data-slot="report-dashboard-services">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Top Services</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {topServices.map((service, index) => (
+                  <div key={service.id} className="flex items-center gap-3">
+                    <Badge
+                      variant="secondary"
+                      className="h-6 w-6 justify-center"
+                    >
+                      {index + 1}
+                    </Badge>
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <p className="font-medium text-gray-900 dark:text-white">
+                          {service.name}
+                        </p>
+                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                          {formatNumber(service.value)}
+                        </p>
                       </div>
-                    )}
+                      {service.percentage !== undefined && (
+                        <div className="mt-1 h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                          <div
+                            className="h-full rounded-full bg-blue-500 dark:bg-blue-400"
+                            style={{ width: `${service.percentage}%` }}
+                          />
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
         )}
 
         {/* Top Employers */}
         {topEmployers.length > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Top Employers</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {topEmployers.map((employer, index) => (
-                <div key={employer.id} className="flex items-center gap-3">
-                  <Badge variant="secondary" className="h-6 w-6 justify-center">
-                    {index + 1}
-                  </Badge>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <p className="font-medium text-gray-900 dark:text-white">
-                        {employer.name}
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-300">
-                        {formatCurrency(employer.value)}
-                      </p>
-                    </div>
-                    {employer.percentage !== undefined && (
-                      <div className="mt-1 h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
-                        <div
-                          className="h-full rounded-full bg-green-500 dark:bg-green-400"
-                          style={{ width: `${employer.percentage}%` }}
-                        />
+          <div data-slot="report-dashboard-employers">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Top Employers</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {topEmployers.map((employer, index) => (
+                  <div key={employer.id} className="flex items-center gap-3">
+                    <Badge
+                      variant="secondary"
+                      className="h-6 w-6 justify-center"
+                    >
+                      {index + 1}
+                    </Badge>
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <p className="font-medium text-gray-900 dark:text-white">
+                          {employer.name}
+                        </p>
+                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                          {formatCurrency(employer.value)}
+                        </p>
                       </div>
-                    )}
+                      {employer.percentage !== undefined && (
+                        <div className="mt-1 h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                          <div
+                            className="h-full rounded-full bg-green-500 dark:bg-green-400"
+                            style={{ width: `${employer.percentage}%` }}
+                          />
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/ScheduleCalendar/ScheduleCalendar.tsx
+++ b/src/components/ScheduleCalendar/ScheduleCalendar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { cn } from '../../utils/cn';
 import { Button } from '../Button/Button';
 
 export interface CalendarAppointment {
@@ -155,7 +156,11 @@ export function ScheduleCalendar({
   if (isLoading) {
     return (
       <div
-        className={`rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900 ${className}`}
+        data-slot="schedule-calendar"
+        className={cn(
+          'rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900',
+          className
+        )}
       >
         <div className="h-12 animate-pulse rounded-t-lg bg-gray-200 dark:bg-gray-700" />
         <div className="space-y-2 p-4">
@@ -174,10 +179,17 @@ export function ScheduleCalendar({
 
   return (
     <div
-      className={`rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900 ${className}`}
+      data-slot="schedule-calendar"
+      className={cn(
+        'rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900',
+        className
+      )}
     >
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-700">
+      <div
+        data-slot="schedule-calendar-header"
+        className="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-700"
+      >
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
@@ -243,11 +255,14 @@ export function ScheduleCalendar({
       </div>
 
       {/* Calendar Grid */}
-      <div className="overflow-auto">
+      <div data-slot="schedule-calendar-grid" className="overflow-auto">
         <div className="min-w-[600px]">
           {/* Day Headers for Week View */}
           {view === 'week' && (
-            <div className="flex border-b border-gray-200 dark:border-gray-700">
+            <div
+              data-slot="schedule-calendar-day-headers"
+              className="flex border-b border-gray-200 dark:border-gray-700"
+            >
               <div className="w-16 flex-shrink-0" />
               {weekDates.map((date, i) => (
                 <div
@@ -278,7 +293,10 @@ export function ScheduleCalendar({
           {/* Time Grid */}
           <div className="flex">
             {/* Time Labels */}
-            <div className="w-16 flex-shrink-0">
+            <div
+              data-slot="schedule-calendar-time-labels"
+              className="w-16 flex-shrink-0"
+            >
               {hours.map((hour) => (
                 <div
                   key={hour}
@@ -335,6 +353,7 @@ export function ScheduleCalendar({
                     return (
                       <div
                         key={appointment.id}
+                        data-slot="schedule-calendar-appointment"
                         role="button"
                         tabIndex={0}
                         className={`absolute right-1 left-1 cursor-pointer overflow-hidden rounded border-l-4 px-2 py-1 text-xs text-white ${getStatusColor(appointment.status)}`}
@@ -365,7 +384,10 @@ export function ScheduleCalendar({
       </div>
 
       {/* Legend */}
-      <div className="flex items-center gap-4 border-t border-gray-200 p-4 text-xs dark:border-gray-700">
+      <div
+        data-slot="schedule-calendar-legend"
+        className="flex items-center gap-4 border-t border-gray-200 p-4 text-xs dark:border-gray-700"
+      >
         <div className="flex items-center gap-1">
           <span className="h-3 w-3 rounded bg-blue-700" />
           <span className="text-gray-600 dark:text-gray-400">Confirmed</span>

--- a/src/components/ServiceAccordion/ServiceAccordion.tsx
+++ b/src/components/ServiceAccordion/ServiceAccordion.tsx
@@ -198,6 +198,7 @@ export function ServiceLink({
       href={`${basePath}/${service.slug}`}
       onClick={handleClick}
       className={serviceLinkVariants({ size })}
+      data-slot="service-accordion-link"
       data-cy={`service-link-${service.slug}`}
     >
       <LinkIcon className="flex-shrink-0 text-neutral-400" />
@@ -230,7 +231,7 @@ function SubCategoryAccordion({
   const contentId = `sub-content-${index}`;
 
   return (
-    <div className="sub-category">
+    <div data-slot="service-accordion-subcategory" className="sub-category">
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
@@ -323,6 +324,7 @@ function CategoryAccordionItem({
 
   return (
     <div
+      data-slot="service-accordion-category"
       className={cn(
         variant === 'cards' && 'overflow-hidden rounded-lg',
         variant === 'cards' && isExpanded && 'shadow-md'
@@ -334,6 +336,7 @@ function CategoryAccordionItem({
         className={categoryHeaderVariants({ variant, isExpanded })}
         aria-expanded={isExpanded}
         aria-controls={contentId}
+        data-slot="service-accordion-category-header"
         data-cy={`btn-category-${index}`}
       >
         <div className="flex items-center gap-3">
@@ -363,6 +366,7 @@ function CategoryAccordionItem({
       {hasContent && (
         <div
           id={contentId}
+          data-slot="service-accordion-category-content"
           className={cn(
             'overflow-hidden transition-all duration-200 ease-in-out',
             isExpanded ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0',
@@ -467,6 +471,7 @@ export function ServiceAccordion({
 
   return (
     <div
+      data-slot="service-accordion"
       className={cn(accordionVariants({ variant }), className)}
       role="region"
       aria-label="Service categories"
@@ -519,7 +524,10 @@ export function ServiceTagCloud({
   const hasMore = maxItems && services.length > maxItems;
 
   return (
-    <div className={cn('flex flex-wrap gap-2', className)}>
+    <div
+      data-slot="service-tag-cloud"
+      className={cn('flex flex-wrap gap-2', className)}
+    >
       {displayedServices.map((service, index) => (
         <a
           key={index}
@@ -592,7 +600,10 @@ export function ServiceList({
   };
 
   return (
-    <ul className={cn('grid gap-1', gridClasses[columns], className)}>
+    <ul
+      data-slot="service-list"
+      className={cn('grid gap-1', gridClasses[columns], className)}
+    >
       {services.map((service, index) => (
         <li key={index}>
           <a

--- a/src/components/ServiceCard/ServiceCard.tsx
+++ b/src/components/ServiceCard/ServiceCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { cn } from '../../utils/cn';
 import { Card } from '../Card/Card';
 import { Badge } from '../Badge/Badge';
 import { SlidersHorizontal, Trash2, Pencil, Plus } from 'lucide-react';
@@ -109,129 +110,138 @@ export function ServiceCard({
     showInventory && inventoryTotal && inventoryCount / inventoryTotal < 0.2;
 
   return (
-    <Card
-      data-slot="service-card"
-      className={`h-full transition-all duration-200 ${onClick ? 'cursor-pointer hover:shadow-md' : ''} ${selected ? 'ring-primary ring-2' : ''} ${!currentlyOffered ? 'opacity-60' : ''} ${className} `.trim()}
-      onClick={onClick ? handleCardClick : undefined}
-    >
-      <div className="flex h-full flex-col p-4">
-        {/* Header */}
-        <div className="mb-2 flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <h3 className="text-foreground truncate font-semibold">{name}</h3>
-            {category && (
-              <p className="text-muted-foreground mt-0.5 text-xs">{category}</p>
+    <div data-slot="service-card">
+      <Card
+        className={cn(
+          'h-full transition-all duration-200',
+          onClick && 'cursor-pointer hover:shadow-md',
+          selected && 'ring-primary ring-2',
+          !currentlyOffered && 'opacity-60',
+          className
+        )}
+        onClick={onClick ? handleCardClick : undefined}
+      >
+        <div className="flex h-full flex-col p-4">
+          {/* Header */}
+          <div className="mb-2 flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <h3 className="text-foreground truncate font-semibold">{name}</h3>
+              {category && (
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  {category}
+                </p>
+              )}
+            </div>
+            {!currentlyOffered && (
+              <Badge variant="warning" size="sm">
+                Not Offered
+              </Badge>
             )}
           </div>
-          {!currentlyOffered && (
-            <Badge variant="warning" size="sm">
-              Not Offered
-            </Badge>
+
+          {/* Description */}
+          {description && (
+            <p className="text-muted-foreground mb-3 line-clamp-2 text-sm">
+              {description}
+            </p>
           )}
-        </div>
 
-        {/* Description */}
-        {description && (
-          <p className="text-muted-foreground mb-3 line-clamp-2 text-sm">
-            {description}
-          </p>
-        )}
+          {/* Tags */}
+          {tags.length > 0 && (
+            <div className="mb-3 flex flex-wrap gap-1">
+              {tags.slice(0, 3).map((tag) => (
+                <span
+                  key={tag}
+                  className="bg-muted text-foreground/70 inline-flex items-center rounded px-2 py-0.5 text-xs font-medium"
+                >
+                  {tag}
+                </span>
+              ))}
+              {tags.length > 3 && (
+                <span className="text-muted-foreground text-xs">
+                  +{tags.length - 3}
+                </span>
+              )}
+            </div>
+          )}
 
-        {/* Tags */}
-        {tags.length > 0 && (
-          <div className="mb-3 flex flex-wrap gap-1">
-            {tags.slice(0, 3).map((tag) => (
-              <span
-                key={tag}
-                className="bg-muted text-foreground/70 inline-flex items-center rounded px-2 py-0.5 text-xs font-medium"
-              >
-                {tag}
-              </span>
-            ))}
-            {tags.length > 3 && (
-              <span className="text-muted-foreground text-xs">
-                +{tags.length - 3}
-              </span>
+          {/* Price & Stats */}
+          <div className="mt-auto">
+            {/* Price */}
+            {price !== undefined && (
+              <div className="mb-2 flex items-baseline justify-between">
+                <span className="text-muted-foreground text-xs font-medium uppercase">
+                  Base Price
+                </span>
+                <span className="text-foreground text-lg font-bold">
+                  {formatCurrency(price, currency)}
+                </span>
+              </div>
+            )}
+
+            {/* Inventory */}
+            {showInventory && (
+              <div className="mb-2 flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Inventory</span>
+                <span
+                  className={`font-medium ${isLowInventory ? 'text-destructive' : 'text-foreground'}`}
+                >
+                  {inventoryCount}
+                  {inventoryTotal && ` / ${inventoryTotal}`}
+                </span>
+              </div>
+            )}
+
+            {/* Custom Pricing Indicator */}
+            {(hasCustomAvailability || customPricingCount > 0) && (
+              <div className="text-muted-foreground mb-3 flex items-center gap-2 text-xs">
+                <SlidersHorizontal className="h-3.5 w-3.5" />
+                <span>
+                  {customPricingCount > 0
+                    ? `${customPricingCount} custom pricing tier${customPricingCount > 1 ? 's' : ''}`
+                    : 'Custom availability'}
+                </span>
+              </div>
+            )}
+
+            {/* Actions */}
+            {(onEdit || onManage || onDelete) && (
+              <div className="border-border flex items-center gap-2 border-t pt-2">
+                {onDelete && (
+                  <button
+                    type="button"
+                    onClick={handleDeleteClick}
+                    className="text-muted-foreground hover:text-destructive p-1.5 transition-colors"
+                    title="Delete service"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+                {onEdit && (
+                  <button
+                    type="button"
+                    onClick={handleEditClick}
+                    className="text-muted-foreground hover:text-primary p-1.5 transition-colors"
+                    title="Edit service"
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
+                )}
+                {onManage && (
+                  <button
+                    type="button"
+                    onClick={handleManageClick}
+                    className="text-primary-800 hover:text-primary-900 dark:text-primary-300 dark:hover:text-primary-200 hover:bg-primary/10 ml-auto rounded px-3 py-1 text-sm font-medium transition-colors"
+                  >
+                    Manage
+                  </button>
+                )}
+              </div>
             )}
           </div>
-        )}
-
-        {/* Price & Stats */}
-        <div className="mt-auto">
-          {/* Price */}
-          {price !== undefined && (
-            <div className="mb-2 flex items-baseline justify-between">
-              <span className="text-muted-foreground text-xs font-medium uppercase">
-                Base Price
-              </span>
-              <span className="text-foreground text-lg font-bold">
-                {formatCurrency(price, currency)}
-              </span>
-            </div>
-          )}
-
-          {/* Inventory */}
-          {showInventory && (
-            <div className="mb-2 flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">Inventory</span>
-              <span
-                className={`font-medium ${isLowInventory ? 'text-destructive' : 'text-foreground'}`}
-              >
-                {inventoryCount}
-                {inventoryTotal && ` / ${inventoryTotal}`}
-              </span>
-            </div>
-          )}
-
-          {/* Custom Pricing Indicator */}
-          {(hasCustomAvailability || customPricingCount > 0) && (
-            <div className="text-muted-foreground mb-3 flex items-center gap-2 text-xs">
-              <SlidersHorizontal className="h-3.5 w-3.5" />
-              <span>
-                {customPricingCount > 0
-                  ? `${customPricingCount} custom pricing tier${customPricingCount > 1 ? 's' : ''}`
-                  : 'Custom availability'}
-              </span>
-            </div>
-          )}
-
-          {/* Actions */}
-          {(onEdit || onManage || onDelete) && (
-            <div className="border-border flex items-center gap-2 border-t pt-2">
-              {onDelete && (
-                <button
-                  type="button"
-                  onClick={handleDeleteClick}
-                  className="text-muted-foreground hover:text-destructive p-1.5 transition-colors"
-                  title="Delete service"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              )}
-              {onEdit && (
-                <button
-                  type="button"
-                  onClick={handleEditClick}
-                  className="text-muted-foreground hover:text-primary p-1.5 transition-colors"
-                  title="Edit service"
-                >
-                  <Pencil className="h-4 w-4" />
-                </button>
-              )}
-              {onManage && (
-                <button
-                  type="button"
-                  onClick={handleManageClick}
-                  className="text-primary-800 hover:text-primary-900 dark:text-primary-300 dark:hover:text-primary-200 hover:bg-primary/10 ml-auto rounded px-3 py-1 text-sm font-medium transition-colors"
-                >
-                  Manage
-                </button>
-              )}
-            </div>
-          )}
         </div>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 }
 
@@ -250,20 +260,24 @@ export function AddServiceCard({
   className = '',
 }: AddServiceCardProps) {
   return (
-    <Card
-      data-slot="add-service-card"
-      className={`border-border bg-muted/50 hover:border-primary hover:bg-muted h-full cursor-pointer border-2 border-dashed transition-all duration-200 ${className} `.trim()}
-      onClick={onClick}
-    >
-      <div className="flex h-full min-h-[160px] flex-col items-center justify-center p-4">
-        <div className="bg-muted mb-3 flex h-12 w-12 items-center justify-center rounded-full">
-          <Plus className="text-muted-foreground h-6 w-6" />
+    <div data-slot="add-service-card">
+      <Card
+        className={cn(
+          'border-border bg-muted/50 hover:border-primary hover:bg-muted h-full cursor-pointer border-2 border-dashed transition-all duration-200',
+          className
+        )}
+        onClick={onClick}
+      >
+        <div className="flex h-full min-h-[160px] flex-col items-center justify-center p-4">
+          <div className="bg-muted mb-3 flex h-12 w-12 items-center justify-center rounded-full">
+            <Plus className="text-muted-foreground h-6 w-6" />
+          </div>
+          <p className="text-muted-foreground text-sm font-medium">
+            Add New Service
+          </p>
         </div>
-        <p className="text-muted-foreground text-sm font-medium">
-          Add New Service
-        </p>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 }
 

--- a/src/components/ServicePricingManager/ServicePricingManager.tsx
+++ b/src/components/ServicePricingManager/ServicePricingManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { cn } from '../../utils/cn';
 import { Badge } from '../Badge/Badge';
 import { Button } from '../Button/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../Card/Card';
@@ -159,7 +160,10 @@ export function ServicePricingManager({
 
   if (isLoading) {
     return (
-      <div className={`animate-pulse space-y-4 ${className}`}>
+      <div
+        data-slot="service-pricing-manager"
+        className={cn('animate-pulse space-y-4', className)}
+      >
         <div className="h-12 w-1/2 rounded-lg bg-gray-200 dark:bg-gray-700" />
         <div className="h-10 rounded-lg bg-gray-200 dark:bg-gray-700" />
         {[1, 2, 3, 4, 5].map((i) => (
@@ -173,9 +177,15 @@ export function ServicePricingManager({
   }
 
   return (
-    <div className={`space-y-6 ${className}`}>
+    <div
+      data-slot="service-pricing-manager"
+      className={cn('space-y-6', className)}
+    >
       {/* Header */}
-      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+      <div
+        data-slot="service-pricing-header"
+        className="flex flex-col justify-between gap-4 md:flex-row md:items-center"
+      >
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Service Pricing
@@ -192,148 +202,155 @@ export function ServicePricingManager({
       </div>
 
       {/* Filters */}
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex flex-col gap-4 md:flex-row">
-            <div className="flex-1">
-              <Input
-                placeholder="Search services..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </div>
-            {uniqueCategories.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  variant={selectedCategory === null ? 'primary' : 'ghost'}
-                  size="sm"
-                  onClick={() => setSelectedCategory(null)}
-                >
-                  All
-                </Button>
-                {uniqueCategories.map((category) => (
-                  <Button
-                    key={category}
-                    variant={
-                      selectedCategory === category ? 'primary' : 'ghost'
-                    }
-                    size="sm"
-                    onClick={() => setSelectedCategory(category)}
-                  >
-                    {category}
-                  </Button>
-                ))}
+      <div data-slot="service-pricing-filters">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex flex-col gap-4 md:flex-row">
+              <div className="flex-1">
+                <Input
+                  placeholder="Search services..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
               </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+              {uniqueCategories.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    variant={selectedCategory === null ? 'primary' : 'ghost'}
+                    size="sm"
+                    onClick={() => setSelectedCategory(null)}
+                  >
+                    All
+                  </Button>
+                  {uniqueCategories.map((category) => (
+                    <Button
+                      key={category}
+                      variant={
+                        selectedCategory === category ? 'primary' : 'ghost'
+                      }
+                      size="sm"
+                      onClick={() => setSelectedCategory(category)}
+                    >
+                      {category}
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
 
       {/* Services List */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">
-            Services ({filteredServices.length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {filteredServices.length === 0 ? (
-            <p className="py-8 text-center text-gray-500 dark:text-gray-400">
-              No services found
-            </p>
-          ) : (
-            <div className="divide-y divide-gray-200 dark:divide-gray-700">
-              {/* Desktop header */}
-              <div className="hidden gap-4 py-3 text-xs font-medium text-gray-500 uppercase md:grid md:grid-cols-6 dark:text-gray-400">
-                <div className="col-span-2">Service</div>
-                <div className="text-right">Base Price</div>
-                <div className="text-right">Employer Price</div>
-                <div className="text-center">Status</div>
-                <div className="text-right">Actions</div>
-              </div>
+      <div data-slot="service-pricing-table">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">
+              Services ({filteredServices.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {filteredServices.length === 0 ? (
+              <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+                No services found
+              </p>
+            ) : (
+              <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                {/* Desktop header */}
+                <div className="hidden gap-4 py-3 text-xs font-medium text-gray-500 uppercase md:grid md:grid-cols-6 dark:text-gray-400">
+                  <div className="col-span-2">Service</div>
+                  <div className="text-right">Base Price</div>
+                  <div className="text-right">Employer Price</div>
+                  <div className="text-center">Status</div>
+                  <div className="text-right">Actions</div>
+                </div>
 
-              {filteredServices.map((service) => (
-                <div
-                  key={service.id}
-                  className="items-center gap-4 py-4 md:grid md:grid-cols-6"
-                >
-                  {/* Service info */}
-                  <div className="col-span-2 mb-2 md:mb-0">
-                    <p className="font-medium text-gray-900 dark:text-white">
-                      {service.serviceName}
-                    </p>
-                    <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-                      {service.serviceCode && (
-                        <span>{service.serviceCode}</span>
+                {filteredServices.map((service) => (
+                  <div
+                    key={service.id}
+                    data-slot="service-pricing-row"
+                    className="items-center gap-4 py-4 md:grid md:grid-cols-6"
+                  >
+                    {/* Service info */}
+                    <div className="col-span-2 mb-2 md:mb-0">
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        {service.serviceName}
+                      </p>
+                      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                        {service.serviceCode && (
+                          <span>{service.serviceCode}</span>
+                        )}
+                        {service.category && (
+                          <Badge variant="secondary">{service.category}</Badge>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Base price */}
+                    <div className="mb-2 flex items-center justify-between md:mb-0 md:block">
+                      <span className="text-sm text-gray-500 md:hidden">
+                        Base:
+                      </span>
+                      <p className="text-right font-semibold text-gray-900 dark:text-white">
+                        {formatCurrency(service.basePrice)}
+                      </p>
+                    </div>
+
+                    {/* Employer price */}
+                    <div className="mb-2 flex items-center justify-between md:mb-0 md:block">
+                      <span className="text-sm text-gray-500 md:hidden">
+                        Employer:
+                      </span>
+                      <p className="text-right text-gray-600 dark:text-gray-300">
+                        {service.employerPrice
+                          ? formatCurrency(service.employerPrice)
+                          : '—'}
+                      </p>
+                    </div>
+
+                    {/* Status */}
+                    <div className="mb-2 flex items-center md:mb-0 md:justify-center">
+                      <span className="mr-2 text-sm text-gray-500 md:hidden">
+                        Status:
+                      </span>
+                      <Badge
+                        variant={service.isActive ? 'success' : 'secondary'}
+                      >
+                        {service.isActive ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </div>
+
+                    {/* Actions */}
+                    <div className="flex justify-end gap-2">
+                      {onToggleStatus && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() =>
+                            onToggleStatus(service.id, !service.isActive)
+                          }
+                        >
+                          {service.isActive ? 'Deactivate' : 'Activate'}
+                        </Button>
                       )}
-                      {service.category && (
-                        <Badge variant="secondary">{service.category}</Badge>
+                      {onUpdatePrice && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          leftIcon={<PencilIcon className="h-3.5 w-3.5" />}
+                          onClick={() => handleEditClick(service)}
+                        >
+                          Edit
+                        </Button>
                       )}
                     </div>
                   </div>
-
-                  {/* Base price */}
-                  <div className="mb-2 flex items-center justify-between md:mb-0 md:block">
-                    <span className="text-sm text-gray-500 md:hidden">
-                      Base:
-                    </span>
-                    <p className="text-right font-semibold text-gray-900 dark:text-white">
-                      {formatCurrency(service.basePrice)}
-                    </p>
-                  </div>
-
-                  {/* Employer price */}
-                  <div className="mb-2 flex items-center justify-between md:mb-0 md:block">
-                    <span className="text-sm text-gray-500 md:hidden">
-                      Employer:
-                    </span>
-                    <p className="text-right text-gray-600 dark:text-gray-300">
-                      {service.employerPrice
-                        ? formatCurrency(service.employerPrice)
-                        : '—'}
-                    </p>
-                  </div>
-
-                  {/* Status */}
-                  <div className="mb-2 flex items-center md:mb-0 md:justify-center">
-                    <span className="mr-2 text-sm text-gray-500 md:hidden">
-                      Status:
-                    </span>
-                    <Badge variant={service.isActive ? 'success' : 'secondary'}>
-                      {service.isActive ? 'Active' : 'Inactive'}
-                    </Badge>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex justify-end gap-2">
-                    {onToggleStatus && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
-                          onToggleStatus(service.id, !service.isActive)
-                        }
-                      >
-                        {service.isActive ? 'Deactivate' : 'Activate'}
-                      </Button>
-                    )}
-                    {onUpdatePrice && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        leftIcon={<PencilIcon className="h-3.5 w-3.5" />}
-                        onClick={() => handleEditClick(service)}
-                      >
-                        Edit
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
 
       {/* Edit Price Modal */}
       <Modal

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10480,3 +10480,142 @@ body.condensed [data-slot='provider-search-hero'] > p {
 body.condensed [data-slot='provider-search-hero'] > div {
   max-width: 20rem !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ProviderSearchFilters – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Main filter container (horizontal / vertical / compact layouts) ── */
+
+body.condensed [data-slot='provider-search-filters'] {
+  gap: 0.375rem !important;
+}
+
+/* ── Labels ── */
+
+body.condensed [data-slot='provider-search-filters'] label {
+  font-size: 0.6875rem !important;
+  margin-bottom: 0.125rem !important;
+}
+
+/* ── Inputs & selects ── */
+
+body.condensed [data-slot='provider-search-filters'] input,
+body.condensed [data-slot='provider-search-filters'] select {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+  padding-top: 0.125rem !important;
+  padding-bottom: 0.125rem !important;
+}
+
+/* ── Input icons ── */
+
+body.condensed [data-slot='provider-search-filters'] svg {
+  width: 0.875rem !important;
+  height: 0.875rem !important;
+}
+
+/* ── Field groups (min-width overrides) ── */
+
+body.condensed [data-slot='provider-search-filters'] > div {
+  min-width: 80px !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   ServiceMultiSelect – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Selected tags ── */
+
+body.condensed [data-slot='provider-service-select'] span {
+  font-size: 0.6875rem !important;
+  padding: 0.0625rem 0.25rem !important;
+  gap: 0.125rem !important;
+}
+
+body.condensed [data-slot='provider-service-select'] span button svg {
+  width: 0.5rem !important;
+  height: 0.5rem !important;
+}
+
+/* ── Dropdown trigger button ── */
+
+body.condensed [data-slot='provider-service-select'] > div > button {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* ── Dropdown panel items ── */
+
+body.condensed [data-slot='provider-service-select'] [role='listbox'] button {
+  font-size: 0.6875rem !important;
+  padding: 0.25rem 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-service-select'] [role='listbox'] input {
+  height: 1.5rem !important;
+  font-size: 0.6875rem !important;
+}
+
+/* ── Category headers ── */
+
+body.condensed
+  [data-slot='provider-service-select']
+  [role='listbox']
+  > div
+  > div:first-child {
+  font-size: 0.5625rem !important;
+  padding: 0.25rem 0.5rem !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   CompactFilterBar – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+body.condensed [data-slot='provider-compact-filter'] {
+  gap: 0.25rem !important;
+  padding: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-compact-filter'] input,
+body.condensed [data-slot='provider-compact-filter'] select {
+  height: 1.5rem !important;
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='provider-compact-filter'] svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-compact-filter'] button {
+  height: 1.5rem !important;
+  font-size: 0.6875rem !important;
+  padding: 0 0.5rem !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   ActiveFilters – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+body.condensed [data-slot='provider-active-filters'] {
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-active-filters'] > span:first-child {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='provider-active-filters'] > span:not(:first-child) {
+  font-size: 0.6875rem !important;
+  padding: 0.0625rem 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-active-filters'] > span svg {
+  width: 0.5rem !important;
+  height: 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-active-filters'] > button {
+  font-size: 0.6875rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10626,12 +10626,8 @@ body.condensed [data-slot='provider-active-filters'] > button {
 
 /* ── Root spacing ── */
 
-body.condensed [data-slot='provider-settings'] {
-  gap: 0.75rem !important;
-}
-
 body.condensed [data-slot='provider-settings'] > * + * {
-  margin-top: 0 !important;
+  margin-top: 0.5rem !important;
 }
 
 /* ── Header ── */

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -9841,3 +9841,184 @@ body.condensed [data-slot='pending-claims-card'] button {
   height: auto !important;
   min-height: 0 !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ProviderCard – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Card root ── */
+
+body.condensed [data-slot='provider-card'] {
+  border-radius: 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-card'][data-variant='list'] {
+  min-height: 5rem !important;
+}
+
+body.condensed [data-slot='provider-card'][data-variant='featured'] {
+  padding: 0 !important;
+}
+
+/* ── Logo (compact / featured) ── */
+
+body.condensed
+  [data-slot='provider-card'][data-variant='compact']
+  [data-slot='provider-card-logo'] {
+  height: 3rem !important;
+}
+
+body.condensed
+  [data-slot='provider-card'][data-variant='featured']
+  [data-slot='provider-card-logo'] {
+  height: 3rem !important;
+  margin-bottom: 0.25rem !important;
+  border-radius: 0 !important;
+}
+
+/* ── Logo (list) ── */
+
+body.condensed
+  [data-slot='provider-card'][data-variant='list']
+  [data-slot='provider-card-logo'] {
+  width: 5rem !important;
+}
+
+/* ── Logo inner (fallback initial circle + image) ── */
+
+body.condensed [data-slot='provider-card-logo'] > div {
+  width: 1.75rem !important;
+  height: 1.75rem !important;
+}
+
+body.condensed [data-slot='provider-card-logo'] > div span {
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-card-logo'] img {
+  padding: 0.25rem !important;
+}
+
+/* ── Content ── */
+
+body.condensed [data-slot='provider-card-content'] {
+  padding: 0.375rem 0.5rem !important;
+}
+
+body.condensed
+  [data-slot='provider-card'][data-variant='featured']
+  [data-slot='provider-card-content'] {
+  padding: 0.375rem 0.5rem !important;
+}
+
+/* ── Header (name + verified) ── */
+
+body.condensed [data-slot='provider-card-header'] {
+  margin-bottom: 0.125rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-card-header'] h3 {
+  font-size: 0.75rem !important;
+  line-height: 1rem !important;
+}
+
+body.condensed
+  [data-slot='provider-card'][data-variant='featured']
+  [data-slot='provider-card-header']
+  h3 {
+  font-size: 0.75rem !important;
+  line-height: 1rem !important;
+}
+
+body.condensed [data-slot='provider-card-header'] > span {
+  font-size: 0.5625rem !important;
+}
+
+body.condensed [data-slot='provider-card-header'] > span svg {
+  width: 0.625rem !important;
+  height: 0.625rem !important;
+}
+
+/* ── Address ── */
+
+body.condensed [data-slot='provider-card-address'] {
+  font-size: 0.625rem !important;
+  line-height: 0.875rem !important;
+}
+
+body.condensed
+  [data-slot='provider-card'][data-variant='featured']
+  [data-slot='provider-card-address'] {
+  font-size: 0.625rem !important;
+  line-height: 0.875rem !important;
+}
+
+/* ── Phone ── */
+
+body.condensed [data-slot='provider-card-phone'] {
+  font-size: 0.625rem !important;
+  margin-top: 0.125rem !important;
+}
+
+/* ── Services badges ── */
+
+body.condensed [data-slot='provider-card-services'] {
+  margin-top: 0.25rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-card-services'] [data-slot='badge'] {
+  font-size: 0.5625rem !important;
+  padding: 0 0.25rem !important;
+}
+
+/* ── Footer (distance + actions) ── */
+
+body.condensed [data-slot='provider-card-footer'] {
+  margin-top: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-card-footer'] span {
+  font-size: 0.5625rem !important;
+}
+
+body.condensed [data-slot='provider-card-footer'] span svg {
+  width: 0.5rem !important;
+  height: 0.5rem !important;
+}
+
+/* ── Safe from wildfires notice ── */
+
+body.condensed [data-slot='provider-card-footer'] > div > div {
+  font-size: 0.5625rem !important;
+  padding: 0.0625rem 0.25rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-card-footer'] > div > div svg {
+  width: 0.625rem !important;
+  height: 0.625rem !important;
+}
+
+/* ── Grid ── */
+
+body.condensed [data-slot='provider-card-grid'] {
+  gap: 0.5rem !important;
+}
+
+/* ── Grid empty state ── */
+
+body.condensed [data-slot='provider-card-grid'] > div > svg {
+  width: 1.5rem !important;
+  height: 1.5rem !important;
+  margin-bottom: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-card-grid'] > div > p:first-of-type {
+  font-size: 0.875rem !important;
+}
+
+body.condensed [data-slot='provider-card-grid'] > div > p + p {
+  font-size: 0.75rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10418,3 +10418,65 @@ body.condensed
   font-size: 0.5625rem !important;
   margin-top: 0 !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ProviderSearchBar – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Search input row ── */
+
+body.condensed [data-slot='provider-search-input'] {
+  border-radius: 0.375rem !important;
+  gap: 0 !important;
+}
+
+body.condensed [data-slot='provider-search-input'] [data-slot='button'] {
+  width: 2rem !important;
+  height: 2rem !important;
+}
+
+body.condensed [data-slot='provider-search-input'] [data-slot='button'] svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-search-input'] [data-slot='input'] {
+  height: 2rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* ── Error message ── */
+
+body.condensed [data-slot='provider-search'] p[role='alert'] {
+  font-size: 0.6875rem !important;
+  margin-top: 0.25rem !important;
+}
+
+/* ── Results message ── */
+
+body.condensed [data-slot='provider-search-results'] {
+  margin-top: 0.25rem !important;
+  font-size: 0.6875rem !important;
+}
+
+/* ── Hero variant ── */
+
+body.condensed [data-slot='provider-search-hero'] {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-search-hero-title'] {
+  font-size: 0.9375rem !important;
+  line-height: 1.25rem !important;
+  margin-bottom: 0.125rem !important;
+}
+
+body.condensed [data-slot='provider-search-hero'] > p {
+  font-size: 0.6875rem !important;
+  margin-bottom: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-search-hero'] > div {
+  max-width: 20rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -11188,3 +11188,78 @@ body.condensed [data-slot='report-dashboard-employers'] .h-2 {
   height: 0.25rem !important;
   margin-top: 0.125rem !important;
 }
+
+/* ==========================================================================
+   ScheduleCalendar
+   ========================================================================== */
+
+/* Root — tighter border radius */
+body.condensed [data-slot='schedule-calendar'] {
+  border-radius: 0.375rem !important;
+}
+
+/* Header — compact padding, smaller title */
+body.condensed [data-slot='schedule-calendar-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed [data-slot='schedule-calendar-header'] h2 {
+  font-size: 0.875rem !important;
+}
+
+body.condensed [data-slot='schedule-calendar-header'] [data-slot='button'] {
+  height: 1.75rem !important;
+  padding: 0 0.5rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* Day headers (week view) — smaller text, tighter padding */
+body.condensed [data-slot='schedule-calendar-day-headers'] > div {
+  padding: 0.25rem !important;
+}
+
+body.condensed [data-slot='schedule-calendar-day-headers'] p.text-xs {
+  font-size: 0.625rem !important;
+}
+
+body.condensed [data-slot='schedule-calendar-day-headers'] p.text-lg {
+  font-size: 0.875rem !important;
+}
+
+/* Time labels — narrower column, smaller text */
+body.condensed [data-slot='schedule-calendar-time-labels'] {
+  width: 2.75rem !important;
+}
+
+body.condensed [data-slot='schedule-calendar-time-labels'] > div {
+  height: 2.5rem !important;
+  font-size: 0.625rem !important;
+}
+
+/* Time grid — shorter hour rows */
+body.condensed [data-slot='schedule-calendar-grid'] .h-16 {
+  height: 2.5rem !important;
+}
+
+/* Appointments — smaller text, tighter padding */
+body.condensed [data-slot='schedule-calendar-appointment'] {
+  padding: 0.125rem 0.375rem !important;
+  font-size: 0.625rem !important;
+  border-left-width: 3px !important;
+}
+
+body.condensed [data-slot='schedule-calendar-appointment'] p {
+  line-height: 1.2 !important;
+}
+
+/* Legend — compact padding, smaller badges */
+body.condensed [data-slot='schedule-calendar-legend'] {
+  padding: 0.375rem 0.75rem !important;
+  gap: 0.5rem !important;
+  font-size: 0.625rem !important;
+}
+
+body.condensed [data-slot='schedule-calendar-legend'] span.h-3 {
+  height: 0.5rem !important;
+  width: 0.5rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10207,3 +10207,204 @@ body.condensed [data-slot='provider-detail-compact'] button {
   padding: 0.25rem 0.5rem !important;
   font-size: 0.6875rem !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ProviderOverview – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Root spacing ── */
+
+body.condensed [data-slot='provider-overview'] {
+  gap: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-overview'] > * + * {
+  margin-top: 0.75rem !important;
+}
+
+/* ── Header (logo + name) ── */
+
+body.condensed [data-slot='provider-overview-header'] {
+  gap: 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-overview-header'] img,
+body.condensed [data-slot='provider-overview-header'] > div:first-child {
+  width: 2rem !important;
+  height: 2rem !important;
+}
+
+body.condensed [data-slot='provider-overview-header'] > div:first-child span {
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-overview-header'] h1 {
+  font-size: 0.9375rem !important;
+  line-height: 1.25rem !important;
+}
+
+body.condensed [data-slot='provider-overview-header'] p {
+  font-size: 0.6875rem !important;
+}
+
+/* ── Stats Grid ── */
+
+body.condensed [data-slot='provider-overview-stats'] {
+  gap: 0.5rem !important;
+}
+
+/* ── Stat Card ── */
+
+body.condensed [data-slot='provider-overview-stat'] {
+  padding: 0.5rem !important;
+  border-radius: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-overview-stat'] > div {
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-overview-stat'] > div > div:first-child {
+  padding: 0.25rem !important;
+  border-radius: 0.25rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-stat']
+  > div
+  > div:first-child
+  svg {
+  width: 0.875rem !important;
+  height: 0.875rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-stat']
+  > div
+  > div:last-child
+  p:first-child {
+  font-size: 1.125rem !important;
+  line-height: 1.375rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-stat']
+  > div
+  > div:last-child
+  p:last-child {
+  font-size: 0.625rem !important;
+}
+
+/* ── Quick Actions Card ── */
+
+body.condensed
+  [data-slot='provider-overview-actions']
+  [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-actions']
+  [data-slot='card-title'] {
+  font-size: 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-actions']
+  [data-slot='card-content'] {
+  padding: 0 0.75rem 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-overview-actions'] button {
+  padding: 0.375rem !important;
+  gap: 0.25rem !important;
+  border-radius: 0.25rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-actions']
+  button
+  span:first-child
+  svg {
+  width: 0.875rem !important;
+  height: 0.875rem !important;
+}
+
+body.condensed [data-slot='provider-overview-actions'] button span:last-child {
+  font-size: 0.625rem !important;
+}
+
+/* ── Recent Activity Card ── */
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-title'] {
+  font-size: 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content'] {
+  padding: 0 0.75rem 0.5rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  > div {
+  gap: 0.25rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  > div
+  > div {
+  gap: 0.375rem !important;
+  padding: 0.25rem !important;
+  border-radius: 0.25rem !important;
+}
+
+/* Activity icon */
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  > div
+  > div
+  > div:first-child {
+  padding: 0.25rem !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  > div
+  > div
+  > div:first-child
+  svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+}
+
+/* Activity title */
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  p {
+  font-size: 0.6875rem !important;
+}
+
+/* Activity timestamp */
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  p:last-child {
+  font-size: 0.5625rem !important;
+  margin-top: 0 !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10938,3 +10938,253 @@ body.condensed
 body.condensed [data-slot='recurring-service-grid'] {
   gap: 0.5rem !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ReportDashboard – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Root spacing (space-y-6 → smaller) ── */
+
+body.condensed [data-slot='report-dashboard'] > * + * {
+  margin-top: 0.5rem !important;
+}
+
+/* ── Header ── */
+
+body.condensed [data-slot='report-dashboard-header'] {
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-header'] h1 {
+  font-size: 1rem !important;
+  line-height: 1.375rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-header'] p {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-header'] [data-slot='button'] {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+  padding: 0 0.625rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-header'] [data-slot='button'] svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+  margin-right: 0.25rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-header']
+  [data-slot='select-trigger'] {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* ── Metrics grid ── */
+
+body.condensed [data-slot='report-dashboard-metrics'] {
+  gap: 0.375rem !important;
+}
+
+/* ── Metric cards ── */
+
+body.condensed
+  [data-slot='report-dashboard-metrics']
+  [data-slot='card-content'] {
+  padding: 0.5rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-metrics']
+  [data-slot='card-content']
+  > p:first-child {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-metrics']
+  [data-slot='card-content']
+  > p:nth-child(2) {
+  font-size: 1.125rem !important;
+  margin-top: 0.125rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-metrics']
+  [data-slot='card-content']
+  > div {
+  font-size: 0.625rem !important;
+  margin-top: 0.125rem !important;
+  gap: 0.125rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-metrics']
+  [data-slot='card-content']
+  > div
+  svg {
+  width: 0.625rem !important;
+  height: 0.625rem !important;
+}
+
+/* ── Chart card ── */
+
+body.condensed [data-slot='report-dashboard-chart'] [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-chart'] [data-slot='card-title'] {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-chart'] [data-slot='card-content'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+/* ── Chart bar area ── */
+
+body.condensed [data-slot='report-dashboard-chart'] .h-48 {
+  height: 8rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-chart'] .h-40 {
+  height: 6.5rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-chart'] span {
+  font-size: 0.5625rem !important;
+}
+
+/* ── Chart legend ── */
+
+body.condensed [data-slot='report-dashboard-chart'] .mt-4 {
+  margin-top: 0.375rem !important;
+  font-size: 0.6875rem !important;
+  gap: 0.5rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-chart'] .mt-4 .h-3 {
+  width: 0.5rem !important;
+  height: 0.5rem !important;
+}
+
+/* ── Top lists grid ── */
+
+body.condensed [data-slot='report-dashboard-top-lists'] {
+  gap: 0.5rem !important;
+}
+
+/* ── Top Services card ── */
+
+body.condensed
+  [data-slot='report-dashboard-services']
+  [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-services']
+  [data-slot='card-title'] {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-services']
+  [data-slot='card-content'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-services']
+  [data-slot='card-content']
+  > *
+  + * {
+  margin-top: 0.25rem !important;
+}
+
+/* ── Ranked items (services) ── */
+
+body.condensed
+  [data-slot='report-dashboard-services']
+  .flex.items-center.gap-3 {
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-services'] [data-slot='badge'] {
+  width: 1.125rem !important;
+  height: 1.125rem !important;
+  font-size: 0.5625rem !important;
+  padding: 0 !important;
+}
+
+body.condensed [data-slot='report-dashboard-services'] p.font-medium {
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-services'] p.text-sm {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-services'] .h-2 {
+  height: 0.25rem !important;
+  margin-top: 0.125rem !important;
+}
+
+/* ── Top Employers card ── */
+
+body.condensed
+  [data-slot='report-dashboard-employers']
+  [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-employers']
+  [data-slot='card-title'] {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-employers']
+  [data-slot='card-content'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='report-dashboard-employers']
+  [data-slot='card-content']
+  > *
+  + * {
+  margin-top: 0.25rem !important;
+}
+
+/* ── Ranked items (employers) ── */
+
+body.condensed
+  [data-slot='report-dashboard-employers']
+  .flex.items-center.gap-3 {
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-employers'] [data-slot='badge'] {
+  width: 1.125rem !important;
+  height: 1.125rem !important;
+  font-size: 0.5625rem !important;
+  padding: 0 !important;
+}
+
+body.condensed [data-slot='report-dashboard-employers'] p.font-medium {
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-employers'] p.text-sm {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='report-dashboard-employers'] .h-2 {
+  height: 0.25rem !important;
+  margin-top: 0.125rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10022,3 +10022,188 @@ body.condensed [data-slot='provider-card-grid'] > div > p:first-of-type {
 body.condensed [data-slot='provider-card-grid'] > div > p + p {
   font-size: 0.75rem !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ProviderDetailHeader – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Action Buttons Bar ── */
+
+body.condensed [data-slot='provider-detail-actions'] {
+  padding-top: 0.125rem !important;
+  padding-bottom: 0.125rem !important;
+}
+
+body.condensed [data-slot='provider-detail-actions'] a,
+body.condensed [data-slot='provider-detail-actions'] button {
+  padding: 0.375rem 0.25rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-actions'] a > span:first-child,
+body.condensed [data-slot='provider-detail-actions'] button > span:first-child {
+  font-size: 0.875rem !important;
+}
+
+body.condensed [data-slot='provider-detail-actions'] a > span:last-child,
+body.condensed [data-slot='provider-detail-actions'] button > span:last-child {
+  font-size: 0.625rem !important;
+}
+
+/* ── Breadcrumb ── */
+
+body.condensed [data-slot='provider-detail-breadcrumb'] {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-breadcrumb'] ol {
+  font-size: 0.6875rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-breadcrumb'] svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+  margin-left: 0.25rem !important;
+  margin-right: 0.25rem !important;
+}
+
+/* ── Mobile Back Button ── */
+
+body.condensed [data-slot='provider-detail-back'] {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-back'] a {
+  padding: 0.25rem 0.5rem !important;
+  font-size: 0.6875rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-back'] a svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+}
+
+/* ── Main Content Container ── */
+
+body.condensed [data-slot='provider-detail-content'] {
+  padding-top: 0.75rem !important;
+  padding-bottom: 0.75rem !important;
+}
+
+/* ── Logo ── */
+
+body.condensed [data-slot='provider-detail-logo'] {
+  width: 2.5rem !important;
+  height: 2.5rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* ── Provider Name ── */
+
+body.condensed [data-slot='provider-detail-name'] {
+  font-size: 1.125rem !important;
+  line-height: 1.375rem !important;
+  margin-bottom: 0.25rem !important;
+}
+
+/* ── Social Media Links ── */
+
+body.condensed [data-slot='provider-detail-social'] {
+  gap: 0.375rem !important;
+  margin-bottom: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-detail-social'] a {
+  font-size: 0.875rem !important;
+}
+
+/* ── Verified Badge ── */
+
+body.condensed [data-slot='provider-detail-verified'] {
+  font-size: 0.6875rem !important;
+  gap: 0.25rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-detail-verified'] svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+}
+
+/* ── Provider Info Section (logo + details flex row) ── */
+
+body.condensed [data-slot='provider-detail-content'] > :last-child {
+  gap: 0.75rem !important;
+}
+
+/* ── Address ── */
+
+body.condensed [data-slot='provider-detail-header'] a[href*='maps'],
+body.condensed [data-slot='provider-detail-header'] address {
+  font-size: 0.75rem !important;
+  line-height: 1.125rem !important;
+  margin-bottom: 0.375rem !important;
+}
+
+/* ── Divider ── */
+
+body.condensed [data-slot='provider-detail-content'] hr {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+/* ── Report/Claim links ── */
+
+body.condensed [data-slot='provider-detail-header'] a[href*='report'],
+body.condensed [data-slot='provider-detail-header'] a[href*='claim'] {
+  font-size: 0.6875rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-header'] a[href*='report'] svg,
+body.condensed [data-slot='provider-detail-header'] a[href*='claim'] svg {
+  width: 0.75rem !important;
+  height: 0.75rem !important;
+}
+
+/* ── Book Appointment Button ── */
+
+body.condensed [data-slot='provider-detail-header'] button[type='button'] {
+  padding: 0.375rem 0.75rem !important;
+  font-size: 0.75rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='provider-detail-header'] button[type='button'] svg {
+  width: 0.875rem !important;
+  height: 0.875rem !important;
+}
+
+/* ── Compact Header Variant ── */
+
+body.condensed [data-slot='provider-detail-compact'] {
+  padding: 0.5rem !important;
+  border-radius: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-detail-compact'] > div {
+  gap: 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-detail-compact'] h2 {
+  font-size: 0.8125rem !important;
+  line-height: 1.125rem !important;
+}
+
+body.condensed [data-slot='provider-detail-compact'] p {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='provider-detail-compact'] button {
+  padding: 0.25rem 0.5rem !important;
+  font-size: 0.6875rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -11263,3 +11263,82 @@ body.condensed [data-slot='schedule-calendar-legend'] span.h-3 {
   height: 0.5rem !important;
   width: 0.5rem !important;
 }
+
+/* ==========================================================================
+   ServiceAccordion
+   ========================================================================== */
+
+/* Category header — tighter padding, smaller text */
+body.condensed [data-slot='service-accordion-category-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed
+  [data-slot='service-accordion-category-header']
+  span.font-semibold {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='service-accordion-category-header'] svg {
+  height: 1rem !important;
+  width: 1rem !important;
+}
+
+/* Category content — tighter inner padding */
+body.condensed [data-slot='service-accordion-category-content'] > div {
+  padding: 0.375rem 0.75rem !important;
+  gap: 0.125rem !important;
+}
+
+/* Service links — compact height, smaller text */
+body.condensed [data-slot='service-accordion-link'] {
+  padding: 0.25rem 0.5rem !important;
+  font-size: 0.8125rem !important;
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='service-accordion-link'] svg {
+  height: 0.75rem !important;
+  width: 0.75rem !important;
+}
+
+body.condensed [data-slot='service-accordion-link'] span.text-xs {
+  font-size: 0.625rem !important;
+}
+
+/* Sub-category — tighter button, reduced indent */
+body.condensed [data-slot='service-accordion-subcategory'] button {
+  padding: 0.25rem 0.5rem !important;
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='service-accordion-subcategory'] .space-y-1 {
+  padding-left: 0.75rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+/* Cards variant — reduced spacing between cards */
+body.condensed [data-slot='service-accordion'].space-y-3 > * + * {
+  margin-top: 0.375rem !important;
+}
+
+/* ServiceTagCloud — smaller tags */
+body.condensed [data-slot='service-tag-cloud'] {
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='service-tag-cloud'] a {
+  padding: 0.25rem 0.625rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* ServiceList — tighter rows */
+body.condensed [data-slot='service-list'] a {
+  padding-top: 0.125rem !important;
+  padding-bottom: 0.125rem !important;
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='service-list'] span.text-xs {
+  font-size: 0.625rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10142,8 +10142,8 @@ body.condensed [data-slot='provider-detail-content'] > :last-child {
 
 /* ── Address ── */
 
-body.condensed [data-slot='provider-detail-header'] a[href*='maps'],
-body.condensed [data-slot='provider-detail-header'] address {
+body.condensed [data-slot='provider-detail-content'] a[href*='maps'],
+body.condensed [data-slot='provider-detail-content'] address {
   font-size: 0.75rem !important;
   line-height: 1.125rem !important;
   margin-bottom: 0.375rem !important;
@@ -10527,13 +10527,13 @@ body.condensed [data-slot='provider-search-filters'] > div {
 
 /* ── Selected tags ── */
 
-body.condensed [data-slot='provider-service-select'] span {
+body.condensed [data-slot='provider-service-tag'] {
   font-size: 0.6875rem !important;
   padding: 0.0625rem 0.25rem !important;
   gap: 0.125rem !important;
 }
 
-body.condensed [data-slot='provider-service-select'] span button svg {
+body.condensed [data-slot='provider-service-tag'] button svg {
   width: 0.5rem !important;
   height: 0.5rem !important;
 }

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10172,13 +10172,13 @@ body.condensed [data-slot='provider-detail-header'] a[href*='claim'] svg {
 
 /* ── Book Appointment Button ── */
 
-body.condensed [data-slot='provider-detail-header'] button[type='button'] {
+body.condensed [data-slot='provider-detail-content'] button[type='button'] {
   padding: 0.375rem 0.75rem !important;
   font-size: 0.75rem !important;
   gap: 0.25rem !important;
 }
 
-body.condensed [data-slot='provider-detail-header'] button[type='button'] svg {
+body.condensed [data-slot='provider-detail-content'] button[type='button'] svg {
   width: 0.875rem !important;
   height: 0.875rem !important;
 }

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10357,8 +10357,18 @@ body.condensed
 body.condensed
   [data-slot='provider-overview-activity']
   [data-slot='card-content']
-  > div {
-  gap: 0.25rem !important;
+  > div
+  > * {
+  margin-top: 0 !important;
+}
+
+body.condensed
+  [data-slot='provider-overview-activity']
+  [data-slot='card-content']
+  > div
+  > *
+  + * {
+  margin-top: 0.25rem !important;
 }
 
 body.condensed

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -9931,11 +9931,11 @@ body.condensed
   line-height: 1rem !important;
 }
 
-body.condensed [data-slot='provider-card-header'] > span {
+body.condensed [data-slot='provider-card-verified'] {
   font-size: 0.5625rem !important;
 }
 
-body.condensed [data-slot='provider-card-header'] > span svg {
+body.condensed [data-slot='provider-card-verified'] svg {
   width: 0.625rem !important;
   height: 0.625rem !important;
 }
@@ -9990,13 +9990,13 @@ body.condensed [data-slot='provider-card-footer'] span svg {
 
 /* ── Safe from wildfires notice ── */
 
-body.condensed [data-slot='provider-card-footer'] > div > div {
+body.condensed [data-slot='provider-card-safe-notice'] {
   font-size: 0.5625rem !important;
   padding: 0.0625rem 0.25rem !important;
   gap: 0.25rem !important;
 }
 
-body.condensed [data-slot='provider-card-footer'] > div > div svg {
+body.condensed [data-slot='provider-card-safe-notice'] svg {
   width: 0.625rem !important;
   height: 0.625rem !important;
 }

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10778,3 +10778,163 @@ body.condensed [data-slot='provider-settings'] p.text-xs {
   font-size: 0.5625rem !important;
   margin-top: 0.0625rem !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   RecurringServiceCard – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Card root ── */
+
+body.condensed [data-slot='recurring-service-card'] {
+  border-radius: 0.5rem !important;
+  border-width: 1px !important;
+}
+
+/* ── Header ── */
+
+body.condensed [data-slot='recurring-service-header'] {
+  padding: 0.375rem 0.5rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='recurring-service-header'] h6 {
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='recurring-service-header'] span {
+  width: 1rem !important;
+  height: 1rem !important;
+}
+
+body.condensed [data-slot='recurring-service-header'] span svg {
+  width: 0.5rem !important;
+  height: 0.5rem !important;
+}
+
+/* ── Body ── */
+
+body.condensed [data-slot='recurring-service-body'] {
+  padding: 0 0.5rem 0.375rem !important;
+}
+
+body.condensed [data-slot='recurring-service-body'] > * + * {
+  margin-top: 0.25rem !important;
+}
+
+/* ── Field labels ── */
+
+body.condensed [data-slot='recurring-service-body'] span {
+  font-size: 0.5625rem !important;
+  margin-bottom: 0.0625rem !important;
+}
+
+/* ── Field values (bg-muted boxes) ── */
+
+body.condensed [data-slot='recurring-service-body'] > div > div {
+  font-size: 0.6875rem !important;
+  padding: 0.25rem 0.375rem !important;
+  border-radius: 0.25rem !important;
+}
+
+/* ── State-based notes (warning/error) ── */
+
+body.condensed
+  [data-slot='recurring-service-body']
+  > div:last-of-type[class*='bg-warning'],
+body.condensed
+  [data-slot='recurring-service-body']
+  > div:last-of-type[class*='bg-destructive'] {
+  font-size: 0.625rem !important;
+  padding: 0.25rem 0.375rem !important;
+}
+
+/* ── Delete button ── */
+
+body.condensed [data-slot='recurring-service-body'] > button {
+  font-size: 0.625rem !important;
+  gap: 0.25rem !important;
+}
+
+body.condensed [data-slot='recurring-service-body'] > button svg {
+  width: 0.5rem !important;
+  height: 0.5rem !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   RecurringServiceAddCard – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+body.condensed [data-slot='recurring-service-add'] {
+  min-height: 100px !important;
+  border-radius: 0.5rem !important;
+  border-width: 1px !important;
+  padding: 0.5rem !important;
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='recurring-service-add'] i {
+  font-size: 1rem !important;
+  margin-bottom: 0.25rem !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   RecurringServiceSetupModal – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+body.condensed [data-slot='recurring-service-modal'] {
+  max-width: 24rem !important;
+}
+
+/* ── Modal header ── */
+
+body.condensed [data-slot='recurring-service-modal'] > div:first-child {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed [data-slot='recurring-service-modal'] > div:first-child h4 {
+  font-size: 0.875rem !important;
+}
+
+/* ── Modal form ── */
+
+body.condensed [data-slot='recurring-service-modal'] form {
+  padding: 0.75rem !important;
+}
+
+body.condensed [data-slot='recurring-service-modal'] form > div {
+  margin-bottom: 0.375rem !important;
+}
+
+body.condensed [data-slot='recurring-service-modal'] form label {
+  font-size: 0.625rem !important;
+  margin-bottom: 0.0625rem !important;
+}
+
+body.condensed [data-slot='recurring-service-modal'] form select,
+body.condensed [data-slot='recurring-service-modal'] form input {
+  padding: 0.25rem 0.5rem !important;
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='recurring-service-modal'] form p {
+  font-size: 0.5625rem !important;
+}
+
+/* ── Modal action buttons ── */
+
+body.condensed
+  [data-slot='recurring-service-modal']
+  form
+  > div:last-child
+  button {
+  padding: 0.25rem 0.75rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   RecurringServiceGrid – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+body.condensed [data-slot='recurring-service-grid'] {
+  gap: 0.5rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10219,10 +10219,6 @@ body.condensed [data-slot='provider-detail-compact'] button {
 
 /* ── Root spacing ── */
 
-body.condensed [data-slot='provider-overview'] {
-  gap: 0.75rem !important;
-}
-
 body.condensed [data-slot='provider-overview'] > * + * {
   margin-top: 0.75rem !important;
 }

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -728,12 +728,12 @@ body.condensed [data-slot='service-grid'] {
 }
 
 /* Service card inner padding */
-body.condensed [data-slot='service-card'] > div {
+body.condensed [data-slot='service-card'] > [data-slot='card'] > div {
   padding: 0.5rem 0.625rem;
 }
 
 /* Service card border-radius & remove Card's own padding (inner div handles it) */
-body.condensed [data-slot='service-card'] {
+body.condensed [data-slot='service-card'] > [data-slot='card'] {
   border-radius: 0.375rem;
   padding: 0 !important;
 }
@@ -812,23 +812,28 @@ body.condensed [data-slot='service-card'] .border-t .text-sm {
 }
 
 /* Add service card */
-body.condensed [data-slot='add-service-card'] {
+body.condensed [data-slot='add-service-card'] > [data-slot='card'] {
   border-radius: 0.375rem;
   padding: 0 !important;
 }
 
-body.condensed [data-slot='add-service-card'] > div {
+body.condensed [data-slot='add-service-card'] > [data-slot='card'] > div {
   min-height: 80px;
   padding: 0.5rem;
 }
 
-body.condensed [data-slot='add-service-card'] > div > div {
+body.condensed [data-slot='add-service-card'] > [data-slot='card'] > div > div {
   height: 2rem;
   width: 2rem;
   margin-bottom: 0.25rem;
 }
 
-body.condensed [data-slot='add-service-card'] > div > div svg {
+body.condensed
+  [data-slot='add-service-card']
+  > [data-slot='card']
+  > div
+  > div
+  svg {
   height: 1rem;
   width: 1rem;
 }

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -11347,3 +11347,94 @@ body.condensed [data-slot='service-list'] a {
 body.condensed [data-slot='service-list'] span.text-xs {
   font-size: 0.625rem !important;
 }
+
+/* ==========================================================================
+   ServicePricingManager
+   ========================================================================== */
+
+/* Root — tighter vertical spacing */
+body.condensed [data-slot='service-pricing-manager'] > * + * {
+  margin-top: 0.75rem !important;
+}
+
+/* Header — smaller title, tighter layout */
+body.condensed [data-slot='service-pricing-header'] h1 {
+  font-size: 1.125rem !important;
+}
+
+body.condensed [data-slot='service-pricing-header'] p {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='service-pricing-header'] [data-slot='button'] {
+  height: 1.75rem !important;
+  padding: 0 0.5rem !important;
+  font-size: 0.75rem !important;
+}
+
+/* Filters card — compact padding */
+body.condensed
+  [data-slot='service-pricing-filters']
+  [data-slot='card-content'] {
+  padding: 0.5rem !important;
+}
+
+body.condensed [data-slot='service-pricing-filters'] [data-slot='input'] {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='service-pricing-filters'] [data-slot='button'] {
+  height: 1.5rem !important;
+  padding: 0 0.375rem !important;
+  font-size: 0.6875rem !important;
+}
+
+/* Table card — compact header and rows */
+body.condensed [data-slot='service-pricing-table'] [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed [data-slot='service-pricing-table'] [data-slot='card-title'] {
+  font-size: 0.875rem !important;
+}
+
+body.condensed [data-slot='service-pricing-table'] [data-slot='card-content'] {
+  padding: 0 0.75rem 0.5rem !important;
+}
+
+/* Table header row */
+body.condensed [data-slot='service-pricing-table'] .text-xs.uppercase {
+  font-size: 0.5625rem !important;
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+/* Service rows — compact vertical spacing */
+body.condensed [data-slot='service-pricing-row'] {
+  padding-top: 0.375rem !important;
+  padding-bottom: 0.375rem !important;
+}
+
+body.condensed [data-slot='service-pricing-row'] p.font-medium {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='service-pricing-row'] .text-sm {
+  font-size: 0.6875rem !important;
+}
+
+body.condensed [data-slot='service-pricing-row'] p.font-semibold {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='service-pricing-row'] [data-slot='badge'] {
+  font-size: 0.5625rem !important;
+  padding: 0 0.25rem !important;
+}
+
+body.condensed [data-slot='service-pricing-row'] [data-slot='button'] {
+  height: 1.5rem !important;
+  padding: 0 0.375rem !important;
+  font-size: 0.6875rem !important;
+}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -10619,3 +10619,166 @@ body.condensed [data-slot='provider-active-filters'] > span svg {
 body.condensed [data-slot='provider-active-filters'] > button {
   font-size: 0.6875rem !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   ProviderSettings – condensed overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Root spacing ── */
+
+body.condensed [data-slot='provider-settings'] {
+  gap: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-settings'] > * + * {
+  margin-top: 0 !important;
+}
+
+/* ── Header ── */
+
+body.condensed [data-slot='provider-settings-header'] h1 {
+  font-size: 1rem !important;
+  line-height: 1.375rem !important;
+}
+
+body.condensed [data-slot='provider-settings-header'] [data-slot='button'] {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+  padding: 0 0.625rem !important;
+}
+
+body.condensed [data-slot='provider-settings-header'] [data-slot='badge'] {
+  font-size: 0.625rem !important;
+  padding: 0.0625rem 0.375rem !important;
+}
+
+/* ── Tabs ── */
+
+body.condensed [data-slot='provider-settings'] [data-slot='tabs-list'] {
+  height: auto !important;
+}
+
+body.condensed [data-slot='provider-settings'] [data-slot='tabs-trigger'] {
+  font-size: 0.75rem !important;
+  padding: 0.25rem 0.625rem !important;
+}
+
+/* ── Cards inside tabs ── */
+
+body.condensed [data-slot='provider-settings'] [data-slot='card'] {
+  border-radius: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-settings'] [data-slot='card-header'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-settings'] [data-slot='card-title'] {
+  font-size: 0.8125rem !important;
+}
+
+body.condensed [data-slot='provider-settings'] [data-slot='card-content'] {
+  padding: 0.5rem 0.75rem !important;
+}
+
+/* ── space-y-4 / space-y-6 inside card content ── */
+
+body.condensed
+  [data-slot='provider-settings']
+  [data-slot='card-content']
+  > *
+  + * {
+  margin-top: 0.375rem !important;
+}
+
+/* ── Labels ── */
+
+body.condensed [data-slot='provider-settings'] label {
+  font-size: 0.6875rem !important;
+  margin-bottom: 0.0625rem !important;
+}
+
+/* ── Inputs & textareas ── */
+
+body.condensed [data-slot='provider-settings'] [data-slot='input'] {
+  height: 1.75rem !important;
+  font-size: 0.75rem !important;
+}
+
+body.condensed [data-slot='provider-settings'] [data-slot='textarea'] {
+  font-size: 0.75rem !important;
+  padding: 0.25rem 0.5rem !important;
+  min-height: 3rem !important;
+}
+
+/* ── Switch rows (notification/scheduling/payment toggles) ── */
+
+body.condensed
+  [data-slot='provider-settings']
+  .flex.items-center.justify-between
+  p {
+  font-size: 0.75rem !important;
+  line-height: 1.125rem !important;
+}
+
+body.condensed
+  [data-slot='provider-settings']
+  .flex.items-center.justify-between
+  p.text-sm,
+body.condensed
+  [data-slot='provider-settings']
+  .flex.items-center.justify-between
+  p.text-xs {
+  font-size: 0.625rem !important;
+  line-height: 0.875rem !important;
+}
+
+/* ── Grid gaps inside general tab ── */
+
+body.condensed [data-slot='provider-settings'] .grid {
+  gap: 0.375rem !important;
+}
+
+/* ── Payment method cards ── */
+
+body.condensed [data-slot='provider-settings-payments'] .rounded-lg.bg-gray-50,
+body.condensed
+  [data-slot='provider-settings-payments']
+  .rounded-lg.dark\:bg-gray-800 {
+  padding: 0.375rem 0.5rem !important;
+}
+
+body.condensed [data-slot='provider-settings-payments'] svg {
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+}
+
+body.condensed
+  [data-slot='provider-settings-payments']
+  .flex.items-center.gap-3 {
+  gap: 0.375rem !important;
+}
+
+body.condensed [data-slot='provider-settings-payments'] span.font-medium {
+  font-size: 0.75rem !important;
+}
+
+/* ── Section dividers ── */
+
+body.condensed [data-slot='provider-settings'] .border-t {
+  padding-top: 0.5rem !important;
+}
+
+/* ── Section headings (h3) ── */
+
+body.condensed [data-slot='provider-settings'] h3 {
+  font-size: 0.8125rem !important;
+  margin-bottom: 0.375rem !important;
+}
+
+/* ── Helper text (xs) ── */
+
+body.condensed [data-slot='provider-settings'] p.text-xs {
+  font-size: 0.5625rem !important;
+  margin-top: 0.0625rem !important;
+}


### PR DESCRIPTION
## Summary

Add `data-slot` attributes and condensed CSS overrides for all Provider components:

- **ProviderCard / ProviderCardGrid** — 10 data-slots, `data-variant` for variant-aware CSS, compact/list/featured condensed styling
- **ProviderDetailHeader** — 11 data-slots, condensed action bar, breadcrumb, logo (2.5rem), social links, book button
- **ProviderOverview** — 6 data-slots (including loading skeleton), condensed stats grid, quick actions, recent activity
- **ProviderSearchBar / HeroSearchBar** — 5 data-slots, condensed input row (2rem buttons), compact hero variant (smaller title/subtitle)
- **ProviderSearchFilters / ServiceMultiSelect / CompactFilterBar / ActiveFilters** — 5 data-slots, condensed inputs (1.75rem), compact filter bar, smaller active filter pills
- **ProviderSettings** — 5 data-slots, condensed header/tabs/cards/inputs/toggles across General, Notifications, Scheduling, and Payments tabs
- **RecurringServiceCard** — 6 data-slots, condensed header/body/grid/modal/add button
- **ReportDashboard** — 7 data-slots (including loading skeleton), condensed metrics/charts/top-lists/services/employers
- **ScheduleCalendar** — 7 data-slots, condensed header/grid/day-headers/time-labels/appointments/legend
- **ServiceAccordion** — 8 data-slots, condensed category headers/content/links/subcategories, plus ServiceTagCloud and ServiceList

All components use structural `data-slot` selectors in `condensed-view.css` with `body.condensed` scoping. Props spread order ensures `data-slot`/`data-variant` cannot be overridden by consumers.