### PR TITLE
feat(workflow): add manual workflow dispatch 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,6 @@ jobs:
             # Tag-based release (stable or tagged prerelease)
             VERSION=${GITHUB_REF#refs/tags/v}
             IS_TAG=true
-            CREATE_TAG=false
             if [[ "$VERSION" == *"-"* ]]; then
               NPM_TAG=next
               IS_PRERELEASE=true
@@ -115,7 +114,6 @@ jobs:
             BASE_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
             VERSION="${BASE_VERSION}-dev.${GITHUB_RUN_NUMBER}"
             IS_TAG=false
-            CREATE_TAG=false
             NPM_TAG=next
             IS_PRERELEASE=true
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,17 +146,21 @@ jobs:
           VERSION="${{ steps.release-info.outputs.version }}"
           node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('./package.json'));p.version='$VERSION';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')"
 
+      - name: Publish to npm
+        run: npm publish --access public --tag ${{ steps.release-info.outputs.npm_tag }}
+
       - name: Create and push tag
         if: steps.release-info.outputs.create_tag == 'true'
         run: |
-          VERSION="${{ steps.release-info.outputs.version }}"
+          TAG="v${{ steps.release-info.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release v${VERSION}"
-          git push origin "v${VERSION}"
-
-      - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.release-info.outputs.npm_tag }}
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Error: tag ${TAG} already exists on origin. This usually means a previous release attempt partially succeeded. Aborting to keep reruns predictable."
+            exit 1
+          fi
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
 
       - name: Create GitHub Release
         if: steps.release-info.outputs.is_tag == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,10 @@ jobs:
   release:
     name: Build and Publish
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    # Skip: (1) manual dispatch not on main, (2) tag pushes by github-actions[bot] (avoids double-run from manual dispatch)
+    if: |
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') &&
+      !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.actor == 'github-actions[bot]')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -88,8 +91,9 @@ jobs:
         id: release-info
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Manual dispatch — bump version based on input
-            CURRENT_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
+            # Manual dispatch — bump version based on latest git tag (not package.json)
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo 'v0.0.0')
+            CURRENT_VERSION=$(echo "${LATEST_TAG#v}" | sed 's/-.*//')
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
             
             BUMP_INPUT="${{ github.event.inputs.bump }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
   release:
     name: Build and Publish
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,32 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump level'
+        required: true
+        type: choice
+        options:
+          - 'patch (0.0.x)'
+          - 'minor (0.x.0)'
+          - 'major (x.0.0)'
+        default: 'patch (0.0.x)'
+      prerelease:
+        description: 'Prerelease type'
+        required: true
+        type: choice
+        options:
+          - 'stable'
+          - 'alpha'
+          - 'beta'
+          - 'rc'
+        default: 'stable'
+      create_tag:
+        description: 'Create a release tag'
+        required: true
+        type: boolean
+        default: true
   push:
     tags:
       - 'v*'  # Stable and prerelease tags, e.g. v1.0.0 or v1.0.0-beta.1
@@ -60,10 +86,37 @@ jobs:
       - name: Determine release info
         id: release-info
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual dispatch — bump version based on input
+            CURRENT_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+            
+            BUMP_INPUT="${{ github.event.inputs.bump }}"
+            if [[ "$BUMP_INPUT" == "major"* ]]; then
+              VERSION="$((MAJOR + 1)).0.0"
+            elif [[ "$BUMP_INPUT" == "minor"* ]]; then
+              VERSION="${MAJOR}.$((MINOR + 1)).0"
+            else
+              VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            fi
+            
+            PRERELEASE="${{ github.event.inputs.prerelease }}"
+            if [[ "$PRERELEASE" != "stable" ]]; then
+              VERSION="${VERSION}-${PRERELEASE}.1"
+              NPM_TAG=next
+              IS_PRERELEASE=true
+            else
+              NPM_TAG=latest
+              IS_PRERELEASE=false
+            fi
+            
+            CREATE_TAG="${{ github.event.inputs.create_tag }}"
+            IS_TAG=$CREATE_TAG
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             # Tag-based release (stable or tagged prerelease)
             VERSION=${GITHUB_REF#refs/tags/v}
             IS_TAG=true
+            CREATE_TAG=false
             if [[ "$VERSION" == *"-"* ]]; then
               NPM_TAG=next
               IS_PRERELEASE=true
@@ -76,6 +129,7 @@ jobs:
             BASE_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
             VERSION="${BASE_VERSION}-dev.${GITHUB_RUN_NUMBER}"
             IS_TAG=false
+            CREATE_TAG=false
             NPM_TAG=next
             IS_PRERELEASE=true
           fi
@@ -83,12 +137,22 @@ jobs:
           echo "npm_tag=$NPM_TAG" >> $GITHUB_OUTPUT
           echo "is_tag=$IS_TAG" >> $GITHUB_OUTPUT
           echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
-          echo "IS_TAG=$IS_TAG  version=$VERSION  npm_tag=$NPM_TAG"
+          echo "create_tag=$CREATE_TAG" >> $GITHUB_OUTPUT
+          echo "IS_TAG=$IS_TAG  version=$VERSION  npm_tag=$NPM_TAG  create_tag=$CREATE_TAG"
 
       - name: Set package version
         run: |
           VERSION="${{ steps.release-info.outputs.version }}"
           node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('./package.json'));p.version='$VERSION';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')"
+
+      - name: Create and push tag
+        if: steps.release-info.outputs.create_tag == 'true'
+        run: |
+          VERSION="${{ steps.release-info.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Publish to npm
         run: npm publish --access public --tag ${{ steps.release-info.outputs.npm_tag }}
@@ -97,6 +161,7 @@ jobs:
         if: steps.release-info.outputs.is_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.release-info.outputs.version }}
           generate_release_notes: true
           prerelease: ${{ steps.release-info.outputs.is_prerelease == 'true' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual dispatch — prerelease only, no tags
-            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo 'v0.0.0')
-            CURRENT_VERSION=$(echo "${LATEST_TAG#v}" | sed 's/-.*//')
+            CURRENT_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
             
             BUMP_INPUT="${{ github.event.inputs.bump }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,10 @@ on:
         required: true
         type: choice
         options:
-          - 'stable'
           - 'alpha'
           - 'beta'
           - 'rc'
-        default: 'stable'
-      create_tag:
-        description: 'Create a release tag'
-        required: true
-        type: boolean
-        default: true
+        default: 'beta'
   push:
     tags:
       - 'v*'  # Stable and prerelease tags, e.g. v1.0.0 or v1.0.0-beta.1
@@ -45,10 +39,8 @@ jobs:
   release:
     name: Build and Publish
     runs-on: ubuntu-latest
-    # Skip: (1) manual dispatch not on main, (2) tag pushes by github-actions[bot] (avoids double-run from manual dispatch)
-    if: |
-      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') &&
-      !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.actor == 'github-actions[bot]')
+    # Skip manual dispatch if not on main branch
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,9 +58,6 @@ jobs:
           check-latest: true
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -91,7 +80,7 @@ jobs:
         id: release-info
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Manual dispatch — bump version based on latest git tag (not package.json)
+            # Manual dispatch — prerelease only, no tags
             LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo 'v0.0.0')
             CURRENT_VERSION=$(echo "${LATEST_TAG#v}" | sed 's/-.*//')
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
@@ -106,17 +95,10 @@ jobs:
             fi
             
             PRERELEASE="${{ github.event.inputs.prerelease }}"
-            if [[ "$PRERELEASE" != "stable" ]]; then
-              VERSION="${VERSION}-${PRERELEASE}.1"
-              NPM_TAG=next
-              IS_PRERELEASE=true
-            else
-              NPM_TAG=latest
-              IS_PRERELEASE=false
-            fi
-            
-            CREATE_TAG="${{ github.event.inputs.create_tag }}"
-            IS_TAG=$CREATE_TAG
+            VERSION="${VERSION}-${PRERELEASE}.1"
+            NPM_TAG=next
+            IS_PRERELEASE=true
+            IS_TAG=false
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             # Tag-based release (stable or tagged prerelease)
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -142,8 +124,7 @@ jobs:
           echo "npm_tag=$NPM_TAG" >> $GITHUB_OUTPUT
           echo "is_tag=$IS_TAG" >> $GITHUB_OUTPUT
           echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
-          echo "create_tag=$CREATE_TAG" >> $GITHUB_OUTPUT
-          echo "IS_TAG=$IS_TAG  version=$VERSION  npm_tag=$NPM_TAG  create_tag=$CREATE_TAG"
+          echo "IS_TAG=$IS_TAG  version=$VERSION  npm_tag=$NPM_TAG"
 
       - name: Set package version
         run: |
@@ -152,19 +133,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --tag ${{ steps.release-info.outputs.npm_tag }}
-
-      - name: Create and push tag
-        if: steps.release-info.outputs.create_tag == 'true'
-        run: |
-          TAG="v${{ steps.release-info.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Error: tag ${TAG} already exists on origin. This usually means a previous release attempt partially succeeded. Aborting to keep reruns predictable."
-            exit 1
-          fi
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "${TAG}"
 
       - name: Create GitHub Release
         if: steps.release-info.outputs.is_tag == 'true'


### PR DESCRIPTION
## Overview

This PR introduces a manual prerelease path to the release workflow via `workflow_dispatch`, allowing controlled prerelease publishing without affecting stable release flows.

The goal is to make prerelease testing and validation easier directly from GitHub Actions, while keeping stable releases strictly tied to git tags.

* Also, this provides a way to test the npm Trusted Publishing changes I made on the npm side.

## What Changed

### Added manual dispatch support to `.github/workflows/release.yml`

The release workflow now supports manual execution through GitHub Actions with two inputs:

* **Version bump**

  * `patch (0.0.x)`
  * `minor (0.x.0)`
  * `major (x.0.0)`
  * Default: `patch`

* **Prerelease type**

  * `alpha`
  * `beta`
  * `rc`
  * Default: `beta`

## Release Behavior

### Manual dispatch (prerelease only)

When manually triggered, the workflow:

* Reads the current version from `package.json`
* Bumps the selected version segment
* Appends prerelease suffix `-{type}.1`
* Example: `1.2.0-beta.1`
* Publishes to the **`next`** npm tag

**Important:**

* No git tag is created
* No GitHub Release is created
* No commits are made

This ensures no version mismatch between the repository and npm.

### Tag push (`v*`) — stable + tagged prereleases

* Uses the version from the git tag
* Publishes:

  * `latest` for stable versions
  * `next` for prereleases (e.g., `-rc`)
* Creates GitHub Release (existing behavior)

### Main branch push — dev builds

* Generates versions like: `1.1.0-dev.42`
* Publishes to **`next`**
* No git tag or GitHub Release

## Versioning Rules

* `patch` → `0.0.x`
* `minor` → `0.x.0`
* `major` → `x.0.0`

## Key Decisions

* **Prerelease-only manual dispatch**

  * Avoids accidental stable releases
  * Prevents git/npm version drift

* **`package.json` as source of truth**

  * Ensures consistent versioning across all flows

* **Stable releases via git tags**

  * Explicit and intentional release control:

    ```bash
    git tag v1.2.0
    git push origin v1.2.0
    ```

* **Removed npm upgrade step**

  * Node 22 includes a sufficient npm version

## Why

* Enables controlled prerelease testing without polluting git history
* Keeps stable releases explicit and predictable
* Simplifies release mental model (3 clear paths)
* Provides a reliable way to validate npm Trusted Publishing (OIDC) changes

## Install

```bash
npm install @mieweb/ui        # latest stable
npm install @mieweb/ui@next   # prerelease / dev
```

## Notes

* Existing triggers for tag pushes and `main` branch pushes remain unchanged
* Manual dispatch is strictly scoped to prerelease workflows
* No repository state is modified during manual runs

## Testing / Validation

Validated expected workflow behavior for:

* manual version bump + prerelease generation
* correct npm tag routing (`next`)
* no git tag / GitHub Release creation in manual flow
* compatibility with existing tag-based releases
* compatibility with dev releases from `main`
* successful npm Trusted Publishing execution via manual dispatch
