### PR TITLE
ci(release): enable npm provenance for published packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('./package.json'));p.version='$VERSION';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.release-info.outputs.npm_tag }}
+        run: npm publish --access public --provenance --tag ${{ steps.release-info.outputs.npm_tag }}
 
       - name: Create GitHub Release
         if: steps.release-info.outputs.is_tag == 'true'


### PR DESCRIPTION
## Overview

This PR updates the release workflow to enable **npm provenance** during package publishing.

By adding the `--provenance` flag to `npm publish`, published artifacts now include verifiable build metadata tied to the CI environment. This improves package trust, integrity, and alignment with modern npm security practices.

---

## What Changed

* **Enabled npm provenance in release workflow**

  * Updated publish command in `.github/workflows/release.yml`:

    ```
    npm publish --access public --provenance --tag ${{ steps.release-info.outputs.npm_tag }}
    ```
  * Ensures published packages include signed provenance metadata

---

## How to Test

1. Trigger a release (or simulate locally if using `act`)
2. Confirm the workflow completes successfully
3. After publish, verify on npm:

   * Package shows provenance metadata (if supported in UI)
   * No regressions in publish step

---

## Breaking Changes

No breaking changes.
