### PR TITLE
refactor: move DataVis NITRO to correct Storybook nav location

### DIFF
--- a/src/components/DataVisNITRO/DataVisNITRO.stories.tsx
+++ b/src/components/DataVisNITRO/DataVisNITRO.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DataVisNitroGrid, DataVisNitroSource } from './DataVisNITRO';
 
 const meta: Meta<typeof DataVisNitroGrid> = {
-  title: 'Data Display/DataVis NITRO',
+  title: 'Components/Text & Data Display/DataVis NITRO',
   component: DataVisNitroGrid,
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
Update the story title path for DataVisNITRO to place it in the correct position in the Storybook sidebar navigation tree.