### PR TITLE
feat: replace Dashboard Recent Orders table with DataVis NITRO grid

### DIFF
--- a/.storybook/public/sample-orders.json
+++ b/.storybook/public/sample-orders.json
@@ -3,14 +3,14 @@
     { "field": "id", "type": "string", "displayText": "Order ID" },
     { "field": "customer", "type": "string", "displayText": "Customer" },
     { "field": "status", "type": "string", "displayText": "Status" },
-    { "field": "amount", "type": "string", "displayText": "Amount" },
+    { "field": "amount", "type": "number", "displayText": "Amount" },
     { "field": "date", "type": "string", "displayText": "Date" }
   ],
   "data": [
-    { "id": "ORD-001", "customer": "John Doe", "status": "completed", "amount": "$250.00", "date": "2024-01-15" },
-    { "id": "ORD-002", "customer": "Jane Smith", "status": "pending", "amount": "$150.00", "date": "2024-01-14" },
-    { "id": "ORD-003", "customer": "Bob Johnson", "status": "cancelled", "amount": "$75.00", "date": "2024-01-13" },
-    { "id": "ORD-004", "customer": "Alice Brown", "status": "completed", "amount": "$320.00", "date": "2024-01-12" },
-    { "id": "ORD-005", "customer": "Charlie Wilson", "status": "processing", "amount": "$180.00", "date": "2024-01-11" }
+    { "id": "ORD-001", "customer": "John Doe", "status": "completed", "amount": 250.00, "date": "2024-01-15" },
+    { "id": "ORD-002", "customer": "Jane Smith", "status": "pending", "amount": 150.00, "date": "2024-01-14" },
+    { "id": "ORD-003", "customer": "Bob Johnson", "status": "cancelled", "amount": 75.00, "date": "2024-01-13" },
+    { "id": "ORD-004", "customer": "Alice Brown", "status": "completed", "amount": 320.00, "date": "2024-01-12" },
+    { "id": "ORD-005", "customer": "Charlie Wilson", "status": "processing", "amount": 180.00, "date": "2024-01-11" }
   ]
 }

--- a/.storybook/public/sample-orders.json
+++ b/.storybook/public/sample-orders.json
@@ -1,0 +1,16 @@
+{
+  "typeInfo": [
+    { "field": "id", "type": "string", "displayText": "Order ID" },
+    { "field": "customer", "type": "string", "displayText": "Customer" },
+    { "field": "status", "type": "string", "displayText": "Status" },
+    { "field": "amount", "type": "string", "displayText": "Amount" },
+    { "field": "date", "type": "string", "displayText": "Date" }
+  ],
+  "data": [
+    { "id": "ORD-001", "customer": "John Doe", "status": "completed", "amount": "$250.00", "date": "2024-01-15" },
+    { "id": "ORD-002", "customer": "Jane Smith", "status": "pending", "amount": "$150.00", "date": "2024-01-14" },
+    { "id": "ORD-003", "customer": "Bob Johnson", "status": "cancelled", "amount": "$75.00", "date": "2024-01-13" },
+    { "id": "ORD-004", "customer": "Alice Brown", "status": "completed", "amount": "$320.00", "date": "2024-01-12" },
+    { "id": "ORD-005", "customer": "Charlie Wilson", "status": "processing", "amount": "$180.00", "date": "2024-01-11" }
+  ]
+}

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -54,10 +54,7 @@ import { Text } from '../Text';
 import { Tooltip } from '../Tooltip';
 import { QuickAction, QuickActionGroup } from '../QuickAction';
 import { PhoneInput } from '../PhoneInput';
-import {
-  DataVisNitroGrid,
-  DataVisNitroSource,
-} from '../DataVisNITRO/DataVisNITRO';
+import { DataVisNitroGrid, DataVisNitroSource } from '../DataVisNITRO';
 import {
   Sidebar as SidebarComponent,
   SidebarHeader,
@@ -81,6 +78,22 @@ const meta: Meta = {
 };
 
 export default meta;
+
+/**
+ * Tailwind overrides to remap DataVis NITRO's hardcoded light-mode colors
+ * to the design system's semantic tokens for dark mode compatibility.
+ * See https://github.com/mieweb/ui/issues/180 for proper dark mode support.
+ */
+const dataVisThemeOverrides = [
+  '[&_.wcdv-grid]:border-border [&_.wcdv-grid]:bg-card [&_.wcdv-grid]:shadow-none',
+  '[&_.wcdv-title-bar]:bg-muted [&_.wcdv-title-bar]:border-border',
+  '[&_.wcdv-title]:text-foreground [&_.wcdv-status-info]:text-muted-foreground',
+  '[&_.wcdv-th]:bg-muted [&_.wcdv-th]:border-border [&_.wcdv-th]:text-muted-foreground',
+  '[&_.wcdv-tr]:border-border [&_.wcdv-td]:border-border',
+  '[&_.wcdv-table-footer]:bg-muted [&_.wcdv-table-footer]:border-border [&_.wcdv-table-footer]:text-muted-foreground',
+  '[&_.wcdv-agg-footer]:bg-muted [&_.wcdv-agg-footer]:border-border',
+  '[&_table]:text-foreground',
+].join(' ');
 
 // ============================================================================
 // Icons
@@ -919,7 +932,7 @@ function DashboardPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="[&_.wcdv-grid]:border-border [&_.wcdv-grid]:bg-card [&_.wcdv-grid]:shadow-none [&_.wcdv-title-bar]:bg-muted [&_.wcdv-title-bar]:border-border [&_.wcdv-title]:text-foreground [&_.wcdv-status-info]:text-muted-foreground [&_.wcdv-th]:bg-muted [&_.wcdv-th]:border-border [&_.wcdv-th]:text-muted-foreground [&_.wcdv-tr]:border-border [&_.wcdv-td]:border-border [&_.wcdv-table-footer]:bg-muted [&_.wcdv-table-footer]:border-border [&_.wcdv-table-footer]:text-muted-foreground [&_.wcdv-agg-footer]:bg-muted [&_.wcdv-agg-footer]:border-border [&_table]:text-foreground">
+            <div className={dataVisThemeOverrides}>
               <DataVisNitroSource type="http" url="/sample-orders.json">
                 <DataVisNitroGrid
                   columns={['id', 'customer', 'status', 'amount', 'date']}

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -936,7 +936,6 @@ function DashboardPage() {
               <DataVisNitroSource type="http" url="/sample-orders.json">
                 <DataVisNitroGrid
                   columns={['id', 'customer', 'status', 'amount', 'date']}
-                  height="280px"
                 />
               </DataVisNitroSource>
             </div>

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -55,6 +55,10 @@ import { Tooltip } from '../Tooltip';
 import { QuickAction, QuickActionGroup } from '../QuickAction';
 import { PhoneInput } from '../PhoneInput';
 import {
+  DataVisNitroGrid,
+  DataVisNitroSource,
+} from '../DataVisNITRO/DataVisNITRO';
+import {
   Sidebar as SidebarComponent,
   SidebarHeader,
   SidebarContent,
@@ -915,40 +919,14 @@ function DashboardPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Order ID</TableHead>
-                  <TableHead>Customer</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead className="text-right">Amount</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {mockOrders.slice(0, 4).map((order) => (
-                  <TableRow key={order.id}>
-                    <TableCell className="font-medium">{order.id}</TableCell>
-                    <TableCell>{order.customer}</TableCell>
-                    <TableCell>
-                      <Badge
-                        variant={
-                          order.status === 'completed'
-                            ? 'success'
-                            : order.status === 'pending'
-                              ? 'warning'
-                              : order.status === 'processing'
-                                ? 'secondary'
-                                : 'danger'
-                        }
-                      >
-                        {order.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">{order.amount}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            <div className="[&_.wcdv-grid]:border-border [&_.wcdv-grid]:bg-card [&_.wcdv-grid]:shadow-none [&_.wcdv-title-bar]:bg-muted [&_.wcdv-title-bar]:border-border [&_.wcdv-title]:text-foreground [&_.wcdv-status-info]:text-muted-foreground [&_.wcdv-th]:bg-muted [&_.wcdv-th]:border-border [&_.wcdv-th]:text-muted-foreground [&_.wcdv-tr]:border-border [&_.wcdv-td]:border-border [&_.wcdv-table-footer]:bg-muted [&_.wcdv-table-footer]:border-border [&_.wcdv-table-footer]:text-muted-foreground [&_.wcdv-agg-footer]:bg-muted [&_.wcdv-agg-footer]:border-border [&_table]:text-foreground">
+              <DataVisNitroSource type="http" url="/sample-orders.json">
+                <DataVisNitroGrid
+                  columns={['id', 'customer', 'status', 'amount', 'date']}
+                  height="280px"
+                />
+              </DataVisNitroSource>
+            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Replace the hand-built HTML table in the Dashboard example page with a DataVisNitroSource + DataVisNitroGrid component, demonstrating real DataVis NITRO integration in a full application context.

Changes:
- Import DataVisNitroGrid and DataVisNitroSource into Dashboard stories
- Replace Recent Orders <Table> markup with DataVis NITRO grid loading from /sample-orders.json via HTTP source
- Add Tailwind descendant selector overrides to remap DataVis hardcoded colors to design system semantic tokens (bg-card, bg-muted, border-border, text-foreground, text-muted-foreground) for dark mode compatibility
- Add .storybook/public/sample-orders.json with 5 order records and typeInfo matching the existing mockOrders data

Note: DataVis NITRO lacks native dark mode support (hardcoded light-mode colors throughout packages/datavis). The wrapper overrides here are a temporary fix for the Dashboard example only. A separate issue will track adding proper dark: variants to the datavis package.