### PR TITLE
feat: add DataVis NITRO dark mode overrides

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import './condensed-view.css';
+@import './datavis-dark.css';
 @custom-variant dark (&:where(.dark, [data-theme=dark], .dark *, [data-theme=dark] *));
 
 /**

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,6 +3,11 @@
 @import './datavis-dark.css';
 @custom-variant dark (&:where(.dark, [data-theme=dark], .dark *, [data-theme=dark] *));
 
+/* Hide DataVis slider from layout when closed to prevent horizontal overflow */
+.wcdv-slider[aria-hidden='true'] {
+  display: none;
+}
+
 /**
  * BlueHive Brand Theme
  * Primary color: #27aae1 (BlueHive Blue)

--- a/src/styles/datavis-dark.css
+++ b/src/styles/datavis-dark.css
@@ -14,7 +14,7 @@
 
 /* ── Grid container ──────────────────────────────────────────────────── */
 .dark .wcdv-grid,
-[data-theme="dark"] .wcdv-grid {
+[data-theme='dark'] .wcdv-grid {
   background-color: var(--color-background) !important;
   color: var(--color-foreground) !important;
   border-color: var(--color-border) !important;
@@ -22,60 +22,64 @@
 
 /* ── Title bar ───────────────────────────────────────────────────────── */
 .dark .wcdv-title-bar,
-[data-theme="dark"] .wcdv-title-bar {
+[data-theme='dark'] .wcdv-title-bar {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
 }
 
 .dark .wcdv-title,
-[data-theme="dark"] .wcdv-title {
+[data-theme='dark'] .wcdv-title {
   color: var(--color-foreground) !important;
 }
 
 .dark .wcdv-status-info,
-[data-theme="dark"] .wcdv-status-info {
+[data-theme='dark'] .wcdv-status-info {
   color: var(--color-muted-foreground) !important;
 }
 
 /* ── Table headers ───────────────────────────────────────────────────── */
 .dark .wcdv-th,
-[data-theme="dark"] .wcdv-th {
+[data-theme='dark'] .wcdv-th {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
   color: var(--color-muted-foreground) !important;
 }
 
 .dark .wcdv-grid thead,
-[data-theme="dark"] .wcdv-grid thead {
+[data-theme='dark'] .wcdv-grid thead {
   background-color: var(--color-card) !important;
 }
 
 /* ── Table rows & cells ──────────────────────────────────────────────── */
 .dark .wcdv-tr,
-[data-theme="dark"] .wcdv-tr {
+[data-theme='dark'] .wcdv-tr {
   border-color: var(--color-border) !important;
 }
 
 .dark .wcdv-tr:nth-child(even),
-[data-theme="dark"] .wcdv-tr:nth-child(even) {
+[data-theme='dark'] .wcdv-tr:nth-child(even) {
   background-color: var(--color-card) !important;
-  background-color: color-mix(in srgb, var(--color-card) 50%, transparent) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--color-card) 50%,
+    transparent
+  ) !important;
 }
 
 .dark .wcdv-td,
-[data-theme="dark"] .wcdv-td {
+[data-theme='dark'] .wcdv-td {
   border-color: var(--color-border) !important;
   color: var(--color-foreground) !important;
 }
 
 .dark .wcdv-grid table,
-[data-theme="dark"] .wcdv-grid table {
+[data-theme='dark'] .wcdv-grid table {
   color: var(--color-foreground) !important;
 }
 
 /* ── Table footer ────────────────────────────────────────────────────── */
 .dark .wcdv-table-footer,
-[data-theme="dark"] .wcdv-table-footer {
+[data-theme='dark'] .wcdv-table-footer {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
   color: var(--color-muted-foreground) !important;
@@ -83,49 +87,49 @@
 
 /* ── Aggregate footer ────────────────────────────────────────────────── */
 .dark .wcdv-agg-footer,
-[data-theme="dark"] .wcdv-agg-footer {
+[data-theme='dark'] .wcdv-agg-footer {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Control panel ───────────────────────────────────────────────────── */
 .dark .wcdv-control-panel,
-[data-theme="dark"] .wcdv-control-panel {
+[data-theme='dark'] .wcdv-control-panel {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Filter bar ──────────────────────────────────────────────────────── */
 .dark .wcdv-filter-bar,
-[data-theme="dark"] .wcdv-filter-bar {
+[data-theme='dark'] .wcdv-filter-bar {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Toolbar ─────────────────────────────────────────────────────────── */
 .dark .wcdv-toolbar,
-[data-theme="dark"] .wcdv-toolbar {
+[data-theme='dark'] .wcdv-toolbar {
   background-color: var(--color-background) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Slider (detail panel) ───────────────────────────────────────────── */
 .dark .wcdv-slider,
-[data-theme="dark"] .wcdv-slider {
+[data-theme='dark'] .wcdv-slider {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
   color: var(--color-foreground) !important;
 }
 
 .dark .wcdv-slider-header,
-[data-theme="dark"] .wcdv-slider-header {
+[data-theme='dark'] .wcdv-slider-header {
   background-color: var(--color-muted) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Group headers ───────────────────────────────────────────────────── */
 .dark .wcdv-group-header,
-[data-theme="dark"] .wcdv-group-header {
+[data-theme='dark'] .wcdv-group-header {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
   color: var(--color-foreground) !important;
@@ -133,7 +137,7 @@
 
 /* ── Field pills (controls) ──────────────────────────────────────────── */
 .dark .wcdv-field-pill,
-[data-theme="dark"] .wcdv-field-pill {
+[data-theme='dark'] .wcdv-field-pill {
   background-color: var(--color-muted) !important;
   border-color: var(--color-border) !important;
   color: var(--color-foreground) !important;
@@ -141,21 +145,25 @@
 
 /* ── Aggregate entries ───────────────────────────────────────────────── */
 .dark .wcdv-aggregate-entry,
-[data-theme="dark"] .wcdv-aggregate-entry {
+[data-theme='dark'] .wcdv-aggregate-entry {
   background-color: var(--color-muted) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Loading overlay ─────────────────────────────────────────────────── */
 .dark .wcdv-loading-overlay,
-[data-theme="dark"] .wcdv-loading-overlay {
+[data-theme='dark'] .wcdv-loading-overlay {
   background-color: var(--color-background) !important;
-  background-color: color-mix(in srgb, var(--color-background) 70%, transparent) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--color-background) 70%,
+    transparent
+  ) !important;
 }
 
 /* ── Pivot table specifics ───────────────────────────────────────────── */
 .dark .wcdv-pivot-table thead th,
-[data-theme="dark"] .wcdv-pivot-table thead th {
+[data-theme='dark'] .wcdv-pivot-table thead th {
   background-color: var(--color-card) !important;
   border-color: var(--color-border) !important;
   color: var(--color-muted-foreground) !important;
@@ -163,16 +171,24 @@
 
 /* ── Operations palette ──────────────────────────────────────────────── */
 .dark .wcdv-operations-palette,
-[data-theme="dark"] .wcdv-operations-palette {
+[data-theme='dark'] .wcdv-operations-palette {
   background-color: var(--color-background) !important;
   border-color: var(--color-border) !important;
 }
 
 /* ── Progress bar ────────────────────────────────────────────────────── */
 .dark .wcdv-table-progress,
-[data-theme="dark"] .wcdv-table-progress {
+[data-theme='dark'] .wcdv-table-progress {
   background-color: var(--color-background) !important;
-  background-color: color-mix(in srgb, var(--color-primary) 10%, var(--color-background)) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--color-primary) 10%,
+    var(--color-background)
+  ) !important;
   border-color: var(--color-border) !important;
-  border-color: color-mix(in srgb, var(--color-primary) 20%, var(--color-border)) !important;
+  border-color: color-mix(
+    in srgb,
+    var(--color-primary) 20%,
+    var(--color-border)
+  ) !important;
 }

--- a/src/styles/datavis-dark.css
+++ b/src/styles/datavis-dark.css
@@ -10,6 +10,10 @@
  *   neutral-900: #171717  →  --color-background
  *   neutral-800: #262626  →  --color-card
  *   neutral-700: #404040  →  --color-border / --color-muted
+ *
+ * NOTE: These overrides are included via base.css (the full styles.css
+ * entrypoint). Consumers using only init.css (tokens-only) will not
+ * get DataVis dark-mode support.
  */
 
 /* ── Grid container ──────────────────────────────────────────────────── */

--- a/src/styles/datavis-dark.css
+++ b/src/styles/datavis-dark.css
@@ -1,0 +1,180 @@
+/*
+ * DataVis NITRO — Dark Mode Overrides
+ *
+ * The datavis package uses hardcoded Tailwind gray/blue classes.
+ * These overrides remap them to semantic design tokens in dark mode
+ * so the grid matches the rest of the UI without modifying the
+ * datavis submodule.
+ *
+ * Prod reference colors (Tailwind neutral scale):
+ *   neutral-900: #171717  →  --color-background
+ *   neutral-800: #262626  →  --color-card
+ *   neutral-700: #404040  →  --color-border / --color-muted
+ */
+
+/* ── Grid container ──────────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light):not([data-theme="light"]) {
+    /* only applies if the user hasn't forced light mode */
+  }
+}
+
+.dark .wcdv-grid,
+[data-theme="dark"] .wcdv-grid {
+  background-color: var(--color-background) !important;
+  color: var(--color-foreground) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Title bar ───────────────────────────────────────────────────────── */
+.dark .wcdv-title-bar,
+[data-theme="dark"] .wcdv-title-bar {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+}
+
+.dark .wcdv-title,
+[data-theme="dark"] .wcdv-title {
+  color: var(--color-foreground) !important;
+}
+
+.dark .wcdv-status-info,
+[data-theme="dark"] .wcdv-status-info {
+  color: var(--color-muted-foreground) !important;
+}
+
+/* ── Table headers ───────────────────────────────────────────────────── */
+.dark .wcdv-th,
+[data-theme="dark"] .wcdv-th {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-muted-foreground) !important;
+}
+
+.dark .wcdv-grid thead,
+[data-theme="dark"] .wcdv-grid thead {
+  background-color: var(--color-card) !important;
+}
+
+/* ── Table rows & cells ──────────────────────────────────────────────── */
+.dark .wcdv-tr,
+[data-theme="dark"] .wcdv-tr {
+  border-color: var(--color-border) !important;
+}
+
+.dark .wcdv-tr:nth-child(even),
+[data-theme="dark"] .wcdv-tr:nth-child(even) {
+  background-color: color-mix(in srgb, var(--color-card) 50%, transparent) !important;
+}
+
+.dark .wcdv-td,
+[data-theme="dark"] .wcdv-td {
+  border-color: var(--color-border) !important;
+  color: var(--color-foreground) !important;
+}
+
+.dark .wcdv-grid table,
+[data-theme="dark"] .wcdv-grid table {
+  color: var(--color-foreground) !important;
+}
+
+/* ── Table footer ────────────────────────────────────────────────────── */
+.dark .wcdv-table-footer,
+[data-theme="dark"] .wcdv-table-footer {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-muted-foreground) !important;
+}
+
+/* ── Aggregate footer ────────────────────────────────────────────────── */
+.dark .wcdv-agg-footer,
+[data-theme="dark"] .wcdv-agg-footer {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Control panel ───────────────────────────────────────────────────── */
+.dark .wcdv-control-panel,
+[data-theme="dark"] .wcdv-control-panel {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Filter bar ──────────────────────────────────────────────────────── */
+.dark .wcdv-filter-bar,
+[data-theme="dark"] .wcdv-filter-bar {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Toolbar ─────────────────────────────────────────────────────────── */
+.dark .wcdv-toolbar,
+[data-theme="dark"] .wcdv-toolbar {
+  background-color: var(--color-background) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Slider (detail panel) ───────────────────────────────────────────── */
+.dark .wcdv-slider,
+[data-theme="dark"] .wcdv-slider {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-foreground) !important;
+}
+
+.dark .wcdv-slider-header,
+[data-theme="dark"] .wcdv-slider-header {
+  background-color: var(--color-muted) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Group headers ───────────────────────────────────────────────────── */
+.dark .wcdv-group-header,
+[data-theme="dark"] .wcdv-group-header {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-foreground) !important;
+}
+
+/* ── Field pills (controls) ──────────────────────────────────────────── */
+.dark .wcdv-field-pill,
+[data-theme="dark"] .wcdv-field-pill {
+  background-color: var(--color-muted) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-foreground) !important;
+}
+
+/* ── Aggregate entries ───────────────────────────────────────────────── */
+.dark .wcdv-aggregate-entry,
+[data-theme="dark"] .wcdv-aggregate-entry {
+  background-color: var(--color-muted) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Loading overlay ─────────────────────────────────────────────────── */
+.dark .wcdv-loading-overlay,
+[data-theme="dark"] .wcdv-loading-overlay {
+  background-color: color-mix(in srgb, var(--color-background) 70%, transparent) !important;
+}
+
+/* ── Pivot table specifics ───────────────────────────────────────────── */
+.dark .wcdv-pivot-table thead th,
+[data-theme="dark"] .wcdv-pivot-table thead th {
+  background-color: var(--color-card) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-muted-foreground) !important;
+}
+
+/* ── Operations palette ──────────────────────────────────────────────── */
+.dark .wcdv-operations-palette,
+[data-theme="dark"] .wcdv-operations-palette {
+  background-color: var(--color-background) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* ── Progress bar ────────────────────────────────────────────────────── */
+.dark .wcdv-table-progress,
+[data-theme="dark"] .wcdv-table-progress {
+  background-color: color-mix(in srgb, var(--color-primary) 10%, var(--color-background)) !important;
+  border-color: color-mix(in srgb, var(--color-primary) 20%, var(--color-border)) !important;
+}

--- a/src/styles/datavis-dark.css
+++ b/src/styles/datavis-dark.css
@@ -118,11 +118,6 @@
 }
 
 /* ── Slider (detail panel) ───────────────────────────────────────────── */
-/* Hide slider from layout when closed to prevent horizontal overflow */
-.wcdv-slider[aria-hidden='true'] {
-  display: none;
-}
-
 .dark .wcdv-slider,
 [data-theme='dark'] .wcdv-slider {
   background-color: var(--color-card) !important;

--- a/src/styles/datavis-dark.css
+++ b/src/styles/datavis-dark.css
@@ -118,6 +118,11 @@
 }
 
 /* ── Slider (detail panel) ───────────────────────────────────────────── */
+/* Hide slider from layout when closed to prevent horizontal overflow */
+.wcdv-slider[aria-hidden='true'] {
+  display: none;
+}
+
 .dark .wcdv-slider,
 [data-theme='dark'] .wcdv-slider {
   background-color: var(--color-card) !important;

--- a/src/styles/datavis-dark.css
+++ b/src/styles/datavis-dark.css
@@ -13,12 +13,6 @@
  */
 
 /* ── Grid container ──────────────────────────────────────────────────── */
-@media (prefers-color-scheme: dark) {
-  :root:not(.light):not([data-theme="light"]) {
-    /* only applies if the user hasn't forced light mode */
-  }
-}
-
 .dark .wcdv-grid,
 [data-theme="dark"] .wcdv-grid {
   background-color: var(--color-background) !important;
@@ -64,6 +58,7 @@
 
 .dark .wcdv-tr:nth-child(even),
 [data-theme="dark"] .wcdv-tr:nth-child(even) {
+  background-color: var(--color-card) !important;
   background-color: color-mix(in srgb, var(--color-card) 50%, transparent) !important;
 }
 
@@ -154,6 +149,7 @@
 /* ── Loading overlay ─────────────────────────────────────────────────── */
 .dark .wcdv-loading-overlay,
 [data-theme="dark"] .wcdv-loading-overlay {
+  background-color: var(--color-background) !important;
   background-color: color-mix(in srgb, var(--color-background) 70%, transparent) !important;
 }
 
@@ -175,6 +171,8 @@
 /* ── Progress bar ────────────────────────────────────────────────────── */
 .dark .wcdv-table-progress,
 [data-theme="dark"] .wcdv-table-progress {
+  background-color: var(--color-background) !important;
   background-color: color-mix(in srgb, var(--color-primary) 10%, var(--color-background)) !important;
+  border-color: var(--color-border) !important;
   border-color: color-mix(in srgb, var(--color-primary) 20%, var(--color-border)) !important;
 }


### PR DESCRIPTION
Add CSS-only dark mode support for the DataVis NITRO grid component by overriding hardcoded gray/blue Tailwind classes with semantic design tokens (.dark/.wcdv-* selectors).

Resolves #180
<img width="1819" height="996" alt="image" src="https://github.com/user-attachments/assets/be4328fc-f07c-49df-b13a-883c15cb7283" />
