### PR TITLE
fix(a11y): WCAG 2.1 AA color-contrast remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -167,7 +167,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -214,7 +214,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Run security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,14 @@ jobs:
         run: pnpm typecheck
 
       - name: Format check
-        run: pnpm format
+        run: |
+          pnpm exec prettier --write "src/**/*.{ts,tsx,css}"
+          if ! git diff --quiet; then
+            echo "::error::Prettier found formatting differences:"
+            git diff --name-only
+            git diff
+            exit 1
+          fi
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -35,14 +35,7 @@ jobs:
         run: pnpm typecheck
 
       - name: Format check
-        run: |
-          pnpm exec prettier --write "src/**/*.{ts,tsx,css}"
-          if ! git diff --quiet; then
-            echo "::error::Prettier found formatting differences:"
-            git diff --name-only
-            git diff
-            exit 1
-          fi
+        run: pnpm format
 
   unit-tests:
     name: Unit Tests
@@ -59,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -95,7 +88,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -135,7 +128,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -174,7 +167,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -221,7 +214,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Run security audit

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ coverage/
 # Playwright test results
 playwright-report/
 playwright-results/
-test-results/
+test-results/*.swp

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -214,7 +214,7 @@ html, body {
 
 /* Story name labels */
 [data-theme="dark"] .sbdocs-a,
-[data-theme="dark"] .sbdocs a {
+[data-theme="dark"] .sbdocs a:not(.docs-story a):not(.sb-story a):not(.sb-unstyled a) {
   color: var(--mieweb-primary, #3b82f6) !important;
 }
 

--- a/src/brands/bluehive.css
+++ b/src/brands/bluehive.css
@@ -43,7 +43,7 @@
   --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
-  --mieweb-warning-foreground: #ffffff;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0ea5e9;
   --mieweb-info-foreground: #ffffff;
   --mieweb-secondary-foreground: #ffffff;
@@ -94,7 +94,7 @@
   --mieweb-success: #16a34a;
   --mieweb-success-foreground: #fafafa;
   --mieweb-warning: #d97706;
-  --mieweb-warning-foreground: #fafafa;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0284c7;
   --mieweb-info-foreground: #fafafa;
   --mieweb-secondary-foreground: #fafafa;

--- a/src/brands/bluehive.css
+++ b/src/brands/bluehive.css
@@ -34,13 +34,13 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #737373;
+  --mieweb-muted-foreground: #525252;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;
-  --mieweb-destructive: #ef4444;
+  --mieweb-destructive: #dc2626;
   --mieweb-destructive-foreground: #ffffff;
-  --mieweb-success: #22c55e;
+  --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
   --mieweb-warning-foreground: #ffffff;

--- a/src/brands/mieweb.css
+++ b/src/brands/mieweb.css
@@ -43,7 +43,7 @@
   --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
-  --mieweb-warning-foreground: #ffffff;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0ea5e9;
   --mieweb-info-foreground: #ffffff;
   --mieweb-secondary-foreground: #ffffff;
@@ -94,7 +94,7 @@
   --mieweb-success: #16a34a;
   --mieweb-success-foreground: #fafafa;
   --mieweb-warning: #d97706;
-  --mieweb-warning-foreground: #fafafa;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0284c7;
   --mieweb-info-foreground: #fafafa;
   --mieweb-secondary-foreground: #fafafa;

--- a/src/brands/mieweb.css
+++ b/src/brands/mieweb.css
@@ -34,13 +34,13 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #737373;
+  --mieweb-muted-foreground: #525252;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27ae60;
-  --mieweb-destructive: #ef4444;
+  --mieweb-destructive: #dc2626;
   --mieweb-destructive-foreground: #ffffff;
-  --mieweb-success: #22c55e;
+  --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
   --mieweb-warning-foreground: #ffffff;

--- a/src/brands/ozwell.css
+++ b/src/brands/ozwell.css
@@ -52,7 +52,7 @@
   --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
-  --mieweb-warning-foreground: #ffffff;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0ea5e9;
   --mieweb-info-foreground: #ffffff;
   --mieweb-secondary-foreground: #ffffff;
@@ -103,7 +103,7 @@
   --mieweb-success: #16a34a;
   --mieweb-success-foreground: #fafafa;
   --mieweb-warning: #d97706;
-  --mieweb-warning-foreground: #fafafa;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0284c7;
   --mieweb-info-foreground: #fafafa;
   --mieweb-secondary-foreground: #fafafa;

--- a/src/brands/ozwell.css
+++ b/src/brands/ozwell.css
@@ -43,13 +43,13 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #737373;
+  --mieweb-muted-foreground: #525252;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;
-  --mieweb-destructive: #ef4444;
+  --mieweb-destructive: #dc2626;
   --mieweb-destructive-foreground: #ffffff;
-  --mieweb-success: #22c55e;
+  --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
   --mieweb-warning-foreground: #ffffff;

--- a/src/brands/webchart.css
+++ b/src/brands/webchart.css
@@ -43,7 +43,7 @@
   --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
-  --mieweb-warning-foreground: #ffffff;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0ea5e9;
   --mieweb-info-foreground: #ffffff;
   --mieweb-secondary-foreground: #ffffff;
@@ -94,7 +94,7 @@
   --mieweb-success: #16a34a;
   --mieweb-success-foreground: #fafafa;
   --mieweb-warning: #d97706;
-  --mieweb-warning-foreground: #fafafa;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info: #0284c7;
   --mieweb-info-foreground: #fafafa;
   --mieweb-secondary-foreground: #fafafa;

--- a/src/brands/webchart.css
+++ b/src/brands/webchart.css
@@ -34,13 +34,13 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #737373;
+  --mieweb-muted-foreground: #525252;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #f5841f;
-  --mieweb-destructive: #ef4444;
+  --mieweb-destructive: #dc2626;
   --mieweb-destructive-foreground: #ffffff;
-  --mieweb-success: #22c55e;
+  --mieweb-success: #15803d;
   --mieweb-success-foreground: #ffffff;
   --mieweb-warning: #f59e0b;
   --mieweb-warning-foreground: #ffffff;

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -96,7 +96,7 @@ function getAvatarColor(name: string): string {
     'bg-orange-600',
     'bg-secondary-600',
     'bg-pink-600',
-    'bg-primary-800',
+    'bg-primary-700',
     'bg-teal-600',
     'bg-amber-600',
   ];

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -91,12 +91,12 @@ function getInitials(name: string): string {
  */
 function getAvatarColor(name: string): string {
   const colors = [
-    'bg-primary-600',
+    'bg-primary-800',
     'bg-green-600',
     'bg-orange-600',
     'bg-secondary-600',
     'bg-pink-600',
-    'bg-primary-700',
+    'bg-primary-800',
     'bg-teal-600',
     'bg-amber-600',
   ];
@@ -660,7 +660,7 @@ export interface ProgressRendererProps extends ICellRendererParams {
 export function ProgressRenderer(
   props: ProgressRendererProps
 ): React.ReactElement {
-  const { value, barColor = 'bg-primary-500', max = 100 } = props;
+  const { value, barColor = 'bg-primary-800', max = 100 } = props;
   if (value == null) return <span className="text-muted-foreground">--</span>;
 
   const percentage = Math.min(100, Math.max(0, (Number(value) / max) * 100));

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -155,7 +155,7 @@ export const statusColors: Record<string, StatusConfig> = {
   new: {
     label: 'New',
     bgClass: 'bg-primary-100 dark:bg-primary-900/30',
-    textClass: 'text-primary-600 dark:text-primary-400',
+    textClass: 'text-primary-800 dark:text-primary-400',
   },
   verified: {
     label: 'Verified',
@@ -360,7 +360,7 @@ export function EmailRenderer(props: ICellRendererParams): React.ReactElement {
   return (
     <a
       href={`mailto:${value}`}
-      className="text-primary-600 dark:text-primary-400 inline-flex items-center gap-1.5 hover:underline"
+      className="text-primary-800 dark:text-primary-400 inline-flex items-center gap-1.5 hover:underline"
       onClick={(e) => e.stopPropagation()}
     >
       <MailIcon className="h-3 w-3 opacity-60" />
@@ -385,7 +385,7 @@ export function PhoneRenderer(props: ICellRendererParams): React.ReactElement {
   return (
     <a
       href={`tel:${value}`}
-      className="text-foreground hover:text-primary-600 dark:hover:text-primary-400 inline-flex items-center gap-1.5"
+      className="text-foreground hover:text-primary-800 dark:hover:text-primary-400 inline-flex items-center gap-1.5"
       onClick={(e) => e.stopPropagation()}
     >
       <PhoneIcon className="h-3 w-3 text-green-500 opacity-70" />
@@ -413,7 +413,7 @@ export function DomainRenderer(props: ICellRendererParams): React.ReactElement {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-primary-600 dark:text-primary-400 inline-flex items-center gap-1.5 hover:underline"
+      className="text-primary-800 dark:text-primary-400 inline-flex items-center gap-1.5 hover:underline"
       onClick={(e) => e.stopPropagation()}
     >
       <GlobeIcon className="h-3 w-3 opacity-60" />
@@ -633,7 +633,7 @@ export function CompanyRenderer(
         />
       ) : null}
       <div
-        className="bg-primary-100 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400 flex h-5 w-5 items-center justify-center rounded text-[9px] font-semibold"
+        className="bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-400 flex h-5 w-5 items-center justify-center rounded text-[9px] font-semibold"
         style={{ display: faviconUrl ? 'none' : 'flex' }}
       >
         {getInitials(value)}

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -209,10 +209,10 @@ export function AvatarNameRenderer(
   if (isSystemValue) {
     return (
       <div className="flex items-center gap-2 py-1">
-        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-400 dark:bg-gray-700 dark:text-gray-500">
+        <div className="dark:text-muted-foreground flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-400 dark:bg-gray-700">
           {displayName === 'Unassigned' ? '—' : '??'}
         </div>
-        <span className="truncate text-gray-400 italic dark:text-gray-500">
+        <span className="dark:text-muted-foreground truncate text-gray-400 italic">
           {displayName}
         </span>
       </div>
@@ -579,7 +579,7 @@ export function BooleanRenderer(
         'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
         isTrue
           ? 'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400'
-          : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+          : 'text-muted-foreground bg-gray-200 dark:bg-gray-700'
       )}
     >
       {isTrue ? (
@@ -698,7 +698,7 @@ export function TagsRenderer(props: ICellRendererParams): React.ReactElement {
       {value.slice(0, 3).map((tag: string, index: number) => (
         <span
           key={index}
-          className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+          className="text-muted-foreground inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium dark:bg-gray-800"
         >
           {tag}
         </span>

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -140,32 +140,42 @@ export const statusColors: Record<string, StatusConfig> = {
   active: {
     label: 'Active',
     bgClass: 'bg-green-100 dark:bg-green-900/30',
-    textClass: 'text-green-600 dark:text-green-400',
+    textClass: 'text-green-700 dark:text-green-400',
   },
   inactive: {
     label: 'Inactive',
     bgClass: 'bg-gray-200 dark:bg-gray-700',
-    textClass: 'text-muted-foreground',
+    textClass: 'text-gray-600 dark:text-gray-300',
+  },
+  closed_won: {
+    label: 'Closed Won',
+    bgClass: 'bg-green-100 dark:bg-green-900/30',
+    textClass: 'text-green-700 dark:text-green-400',
+  },
+  closed_lost: {
+    label: 'Closed Lost',
+    bgClass: 'bg-red-100 dark:bg-red-900/30',
+    textClass: 'text-red-700 dark:text-red-400',
   },
   pending: {
     label: 'Pending',
     bgClass: 'bg-amber-100 dark:bg-amber-900/30',
-    textClass: 'text-amber-600 dark:text-amber-400',
+    textClass: 'text-amber-700 dark:text-amber-400',
   },
   new: {
     label: 'New',
     bgClass: 'bg-primary-100 dark:bg-primary-900/30',
-    textClass: 'text-primary-800 dark:text-primary-400',
+    textClass: 'text-green-700 dark:text-green-400',
   },
   verified: {
     label: 'Verified',
     bgClass: 'bg-green-100 dark:bg-green-900/30',
-    textClass: 'text-green-600 dark:text-green-400',
+    textClass: 'text-green-700 dark:text-green-400',
   },
   flagged: {
     label: 'Flagged',
     bgClass: 'bg-red-100 dark:bg-red-900/30',
-    textClass: 'text-red-600 dark:text-red-400',
+    textClass: 'text-red-700 dark:text-red-400',
   },
 };
 
@@ -272,7 +282,7 @@ export function StatusBadgeRenderer(
   const config = statusConfig[normalizedValue] || {
     label: value,
     bgClass: 'bg-gray-200 dark:bg-gray-700',
-    textClass: 'text-muted-foreground',
+    textClass: 'text-gray-600 dark:text-gray-300',
   };
 
   return (
@@ -302,17 +312,17 @@ function getEngagementScoreColors(score: number): {
   if (score >= 70)
     return {
       barColor: 'bg-green-500',
-      textColor: 'text-green-600 dark:text-green-400',
+      textColor: 'text-green-700 dark:text-green-400',
     };
   if (score >= 40)
     return {
       barColor: 'bg-amber-500',
-      textColor: 'text-amber-600 dark:text-amber-400',
+      textColor: 'text-amber-700 dark:text-amber-400',
     };
   if (score >= 20)
     return {
       barColor: 'bg-orange-500',
-      textColor: 'text-orange-600 dark:text-orange-400',
+      textColor: 'text-orange-700 dark:text-orange-400',
     };
   return {
     barColor: 'bg-gray-400',
@@ -578,8 +588,8 @@ export function BooleanRenderer(
       className={cn(
         'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
         isTrue
-          ? 'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400'
-          : 'text-muted-foreground bg-gray-200 dark:bg-gray-700'
+          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+          : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
       )}
     >
       {isTrue ? (

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -145,7 +145,7 @@ export const statusColors: Record<string, StatusConfig> = {
   inactive: {
     label: 'Inactive',
     bgClass: 'bg-gray-200 dark:bg-gray-700',
-    textClass: 'text-gray-600 dark:text-gray-400',
+    textClass: 'text-muted-foreground',
   },
   pending: {
     label: 'Pending',
@@ -272,7 +272,7 @@ export function StatusBadgeRenderer(
   const config = statusConfig[normalizedValue] || {
     label: value,
     bgClass: 'bg-gray-200 dark:bg-gray-700',
-    textClass: 'text-gray-600 dark:text-gray-400',
+    textClass: 'text-muted-foreground',
   };
 
   return (
@@ -316,7 +316,7 @@ function getEngagementScoreColors(score: number): {
     };
   return {
     barColor: 'bg-gray-400',
-    textColor: 'text-gray-600 dark:text-gray-400',
+    textColor: 'text-muted-foreground',
   };
 }
 

--- a/src/components/AGGrid/ag-grid-theme.css
+++ b/src/components/AGGrid/ag-grid-theme.css
@@ -28,7 +28,7 @@
 
   /* Header */
   --ag-header-background-color: var(--mieweb-muted, #f9fafb);
-  --ag-header-foreground-color: var(--mieweb-muted-foreground, #6b7280);
+  --ag-header-foreground-color: #525252;
   --ag-header-cell-hover-background-color: var(--mieweb-card, #f3f4f6);
 
   /* Rows */
@@ -111,10 +111,7 @@
 
   /* Header */
   --ag-header-background-color: var(--mieweb-card, #111827) !important;
-  --ag-header-foreground-color: var(
-    --mieweb-muted-foreground,
-    #9ca3af
-  ) !important;
+  --ag-header-foreground-color: #d4d4d8 !important;
   --ag-header-cell-hover-background-color: var(
     --mieweb-muted,
     #2d3748
@@ -250,7 +247,7 @@
 
 .dark .ag-theme-custom .ag-header-cell-text,
 .dark .ag-theme-custom .ag-header-cell-label {
-  color: var(--mieweb-muted-foreground, #9ca3af) !important;
+  color: #d4d4d8 !important;
 }
 
 .dark .ag-theme-custom .ag-row:hover {

--- a/src/components/AI/AI.stories.tsx
+++ b/src/components/AI/AI.stories.tsx
@@ -370,7 +370,7 @@ function FloatingChatButtonDemo() {
   const [isOpen, setIsOpen] = React.useState(false);
   return (
     <div className="relative h-[400px] bg-neutral-100 p-4 dark:bg-neutral-800">
-      <p className="text-neutral-600 dark:text-neutral-400">
+      <p className="text-muted-foreground">
         Click the AI button in the corner to open the chat.
       </p>
       <AIChatTrigger
@@ -389,7 +389,7 @@ export const FloatingChatButton: StoryObj<typeof AIChatTrigger> = {
 export const FloatingChatComplete: StoryObj<typeof FloatingAIChat> = {
   render: () => (
     <div className="relative h-[700px] bg-neutral-100 p-4 dark:bg-neutral-800">
-      <p className="text-neutral-600 dark:text-neutral-400">
+      <p className="text-muted-foreground">
         Click the AI button in the corner to open the chat.
       </p>
       <FloatingAIChat

--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -152,7 +152,7 @@ export function SuggestedActions({
           onClick={() => onSelect(action)}
           className={cn(
             'flex items-center gap-2 rounded-full border border-neutral-200 px-3 py-1.5',
-            'hover:border-primary-300 hover:bg-primary-50 hover:text-primary-700 text-sm text-neutral-700',
+            'hover:border-primary-300 hover:bg-primary-50 hover:text-primary-900 text-sm text-neutral-700',
             'dark:border-neutral-700 dark:text-neutral-300',
             'dark:hover:border-primary-700 dark:hover:bg-primary-900/20 dark:hover:text-primary-300',
             'transition-colors'

--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -195,9 +195,7 @@ function AIEmptyState({
   const suggestionsAction =
     suggestions && suggestions.length > 0 && onSuggestionSelect ? (
       <div className="mt-6">
-        <p className="mb-3 text-sm text-muted-foreground">
-          Try asking:
-        </p>
+        <p className="text-muted-foreground mb-3 text-sm">Try asking:</p>
         <SuggestedActions actions={suggestions} onSelect={onSuggestionSelect} />
       </div>
     ) : undefined;

--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -186,7 +186,7 @@ function AIEmptyState({
   const aiIcon = (
     <div
       data-slot="ai-empty-state-icon"
-      className="bg-primary-500 dark:bg-primary-600 flex h-16 w-16 items-center justify-center rounded-full text-white"
+      className="bg-primary-800 dark:bg-primary-800 flex h-16 w-16 items-center justify-center rounded-full text-white"
     >
       <SparklesIcon size="lg" className="h-8 w-8" />
     </div>
@@ -345,7 +345,7 @@ export function AIChat({
           <div className="flex items-center gap-3">
             <div
               data-slot="ai-chat-header-icon"
-              className="bg-primary-500 dark:bg-primary-600 flex h-8 w-8 items-center justify-center rounded-full text-white"
+              className="bg-primary-800 dark:bg-primary-800 flex h-8 w-8 items-center justify-center rounded-full text-white"
             >
               <SparklesIcon size="sm" />
             </div>

--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -195,7 +195,7 @@ function AIEmptyState({
   const suggestionsAction =
     suggestions && suggestions.length > 0 && onSuggestionSelect ? (
       <div className="mt-6">
-        <p className="mb-3 text-sm text-neutral-500 dark:text-neutral-400">
+        <p className="mb-3 text-sm text-muted-foreground">
           Try asking:
         </p>
         <SuggestedActions actions={suggestions} onSelect={onSuggestionSelect} />

--- a/src/components/AI/AIChatModal.tsx
+++ b/src/components/AI/AIChatModal.tsx
@@ -52,8 +52,8 @@ export function AIChatTrigger({
       data-slot="ai-chat-trigger"
       className={cn(
         'fixed z-50 flex h-14 w-14 items-center justify-center rounded-full shadow-lg',
-        'bg-primary-500 text-white',
-        'hover:bg-primary-600',
+        'bg-primary-800 text-white',
+        'hover:bg-primary-800',
         'focus:ring-primary-500 focus:ring-2 focus:ring-offset-2 focus:outline-none',
         'dark:focus:ring-offset-neutral-900',
         'transition-all duration-200',

--- a/src/components/AI/AIChatModal.tsx
+++ b/src/components/AI/AIChatModal.tsx
@@ -53,7 +53,7 @@ export function AIChatTrigger({
       className={cn(
         'fixed z-50 flex h-14 w-14 items-center justify-center rounded-full shadow-lg',
         'bg-primary-800 text-white',
-        'hover:bg-primary-800',
+        'hover:bg-primary-900',
         'focus:ring-primary-500 focus:ring-2 focus:ring-offset-2 focus:outline-none',
         'dark:focus:ring-offset-neutral-900',
         'transition-all duration-200',

--- a/src/components/AI/AIMessage.tsx
+++ b/src/components/AI/AIMessage.tsx
@@ -195,7 +195,7 @@ function ContentBlock({ content, onLinkClick }: ContentBlockProps) {
           onClick={() => setIsCollapsed(!isCollapsed)}
           className="flex w-full items-center justify-between px-3 py-2 text-left"
         >
-          <span className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span className="text-muted-foreground flex items-center gap-2 text-sm">
             <svg
               className="h-4 w-4"
               fill="none"

--- a/src/components/AI/AIMessage.tsx
+++ b/src/components/AI/AIMessage.tsx
@@ -195,7 +195,7 @@ function ContentBlock({ content, onLinkClick }: ContentBlockProps) {
           onClick={() => setIsCollapsed(!isCollapsed)}
           className="flex w-full items-center justify-between px-3 py-2 text-left"
         >
-          <span className="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+          <span className="flex items-center gap-2 text-sm text-muted-foreground">
             <svg
               className="h-4 w-4"
               fill="none"

--- a/src/components/AI/AIMessage.tsx
+++ b/src/components/AI/AIMessage.tsx
@@ -21,7 +21,7 @@ const avatarVariants = cva(
     variants: {
       role: {
         user: 'bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300',
-        assistant: 'bg-primary-500 text-white dark:bg-primary-600',
+        assistant: 'bg-primary-800 text-white dark:bg-primary-800',
         system:
           'bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-400',
         tool: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
@@ -266,7 +266,7 @@ const messageVariants = cva('flex gap-3', {
 const bubbleVariants = cva('rounded-2xl px-4 py-2.5 w-fit max-w-[85%]', {
   variants: {
     role: {
-      user: 'bg-primary-600 text-white dark:bg-primary-500',
+      user: 'bg-primary-800 text-white dark:bg-primary-800',
       assistant:
         'bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-white',
       system:

--- a/src/components/AI/MCPToolCall.tsx
+++ b/src/components/AI/MCPToolCall.tsx
@@ -59,7 +59,7 @@ function ToolStatusIcon({ status, className }: ToolStatusIconProps) {
       )}
       {status === 'running' && (
         <svg
-          className="text-primary-600 dark:text-primary-400 h-3 w-3 animate-spin"
+          className="text-primary-800 dark:text-primary-400 h-3 w-3 animate-spin"
           fill="none"
           viewBox="0 0 24 24"
         >

--- a/src/components/AI/MCPToolCall.tsx
+++ b/src/components/AI/MCPToolCall.tsx
@@ -722,7 +722,7 @@ export function MCPToolCallDisplay({
 
           {/* Parameter Summary (user-friendly) */}
           {paramSummary && toolCall.status !== 'success' && (
-            <p className="mt-0.5 text-sm text-muted-foreground">
+            <p className="text-muted-foreground mt-0.5 text-sm">
               {paramSummary}
             </p>
           )}

--- a/src/components/AI/MCPToolCall.tsx
+++ b/src/components/AI/MCPToolCall.tsx
@@ -722,7 +722,7 @@ export function MCPToolCallDisplay({
 
           {/* Parameter Summary (user-friendly) */}
           {paramSummary && toolCall.status !== 'success' && (
-            <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-400">
+            <p className="mt-0.5 text-sm text-muted-foreground">
               {paramSummary}
             </p>
           )}

--- a/src/components/AddContactModal/AddContactModal.tsx
+++ b/src/components/AddContactModal/AddContactModal.tsx
@@ -463,7 +463,7 @@ export function AddContactModal({
 
               {(!formData.customFields ||
                 formData.customFields.length === 0) && (
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   No custom fields added. Click &quot;Add Field&quot; to add
                   custom information.
                 </p>

--- a/src/components/AddContactModal/AddContactModal.tsx
+++ b/src/components/AddContactModal/AddContactModal.tsx
@@ -463,7 +463,7 @@ export function AddContactModal({
 
               {(!formData.customFields ||
                 formData.customFields.length === 0) && (
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   No custom fields added. Click &quot;Add Field&quot; to add
                   custom information.
                 </p>

--- a/src/components/Address/Address.stories.tsx
+++ b/src/components/Address/Address.stories.tsx
@@ -59,21 +59,15 @@ export const AllFormats: Story = {
   render: () => (
     <div className="space-y-6">
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Block format
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Block format</p>
         <Address address={sampleAddress} format="block" showIcon linkToMaps />
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Inline format
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Inline format</p>
         <Address address={sampleAddress} format="inline" showIcon />
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Compact format
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Compact format</p>
         <Address address={sampleAddress} format="compact" showIcon />
       </div>
     </div>
@@ -85,15 +79,11 @@ export const ConvenienceComponents: Story = {
   render: () => (
     <div className="space-y-4">
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          AddressInline
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">AddressInline</p>
         <AddressInline address={sampleAddress} showIcon />
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          AddressCompact
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">AddressCompact</p>
         <AddressCompact address={sampleAddress} showIcon />
       </div>
     </div>

--- a/src/components/Address/Address.stories.tsx
+++ b/src/components/Address/Address.stories.tsx
@@ -59,19 +59,19 @@ export const AllFormats: Story = {
   render: () => (
     <div className="space-y-6">
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Block format
         </p>
         <Address address={sampleAddress} format="block" showIcon linkToMaps />
       </div>
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Inline format
         </p>
         <Address address={sampleAddress} format="inline" showIcon />
       </div>
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Compact format
         </p>
         <Address address={sampleAddress} format="compact" showIcon />
@@ -85,13 +85,13 @@ export const ConvenienceComponents: Story = {
   render: () => (
     <div className="space-y-4">
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           AddressInline
         </p>
         <AddressInline address={sampleAddress} showIcon />
       </div>
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           AddressCompact
         </p>
         <AddressCompact address={sampleAddress} showIcon />

--- a/src/components/Address/Address.tsx
+++ b/src/components/Address/Address.tsx
@@ -364,7 +364,7 @@ export function AddressCard({
           data-slot="address-card-phone"
           href={`tel:${phoneNumber.replace(/\D/g, '')}`}
           onClick={handlePhoneClick}
-          className="hover:text-primary-600 dark:hover:text-primary-400 mt-2 inline-flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
+          className="hover:text-primary-600 dark:hover:text-primary-400 mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground"
         >
           <PhoneIcon className="h-4 w-4" />
           {phoneNumber}

--- a/src/components/Address/Address.tsx
+++ b/src/components/Address/Address.tsx
@@ -364,7 +364,7 @@ export function AddressCard({
           data-slot="address-card-phone"
           href={`tel:${phoneNumber.replace(/\D/g, '')}`}
           onClick={handlePhoneClick}
-          className="hover:text-primary-600 dark:hover:text-primary-400 mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground"
+          className="hover:text-primary-600 dark:hover:text-primary-400 text-muted-foreground mt-2 inline-flex items-center gap-2 text-sm"
         >
           <PhoneIcon className="h-4 w-4" />
           {phoneNumber}

--- a/src/components/Address/Address.tsx
+++ b/src/components/Address/Address.tsx
@@ -271,7 +271,7 @@ export function Address({
         rel="noopener noreferrer"
         className={cn(
           baseStyles,
-          'hover:text-primary-600 dark:hover:text-primary-400 hover:underline',
+          'hover:text-primary-800 dark:hover:text-primary-400 hover:underline',
           'focus:ring-primary-500 rounded focus:ring-2 focus:ring-offset-2 focus:outline-none'
         )}
         {...props}
@@ -364,7 +364,7 @@ export function AddressCard({
           data-slot="address-card-phone"
           href={`tel:${phoneNumber.replace(/\D/g, '')}`}
           onClick={handlePhoneClick}
-          className="hover:text-primary-600 dark:hover:text-primary-400 text-muted-foreground mt-2 inline-flex items-center gap-2 text-sm"
+          className="hover:text-primary-800 dark:hover:text-primary-400 text-muted-foreground mt-2 inline-flex items-center gap-2 text-sm"
         >
           <PhoneIcon className="h-4 w-4" />
           {phoneNumber}

--- a/src/components/Address/Address.tsx
+++ b/src/components/Address/Address.tsx
@@ -241,7 +241,7 @@ export function Address({
   // Base styling
   const baseStyles = cn(
     addressVariants({ format, size }),
-    'text-gray-600 dark:text-gray-300',
+    'text-muted-foreground ',
     className
   );
 

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -178,7 +178,7 @@ function DismissibleExample() {
     return (
       <button
         onClick={() => setVisible(true)}
-        className="text-primary-500 text-sm underline"
+        className="text-primary-800 text-sm underline"
       >
         Show alert again
       </button>

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -397,7 +397,7 @@ export const Default: Story = {
                               <p className="text-sm font-medium text-gray-900 dark:text-white">
                                 John Doe
                               </p>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
+                              <p className="text-sm text-muted-foreground">
                                 john@example.com
                               </p>
                             </div>
@@ -500,7 +500,7 @@ export const Default: Story = {
                     <div className="font-medium text-gray-900 dark:text-white">
                       John Doe
                     </div>
-                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                    <div className="text-sm text-muted-foreground">
                       john@example.com
                     </div>
                   </div>

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -397,7 +397,7 @@ export const Default: Story = {
                               <p className="text-sm font-medium text-gray-900 dark:text-white">
                                 John Doe
                               </p>
-                              <p className="text-sm text-muted-foreground">
+                              <p className="text-muted-foreground text-sm">
                                 john@example.com
                               </p>
                             </div>
@@ -500,7 +500,7 @@ export const Default: Story = {
                     <div className="font-medium text-gray-900 dark:text-white">
                       John Doe
                     </div>
-                    <div className="text-sm text-muted-foreground">
+                    <div className="text-muted-foreground text-sm">
                       john@example.com
                     </div>
                   </div>

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -157,7 +157,7 @@ function HeaderWithTitleDemo() {
 
       <AppHeaderSection align="right">
         <AppHeaderActions>
-          <button className="bg-primary-500 hover:bg-primary-600 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors">
+          <button className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors">
             Add User
           </button>
         </AppHeaderActions>
@@ -308,7 +308,7 @@ export const Default: Story = {
             {showBranding && (
               <AppHeaderBrand
                 logo={
-                  <div className="bg-primary-500 flex h-8 w-8 items-center justify-center rounded-lg text-sm font-bold text-white">
+                  <div className="bg-primary-800 flex h-8 w-8 items-center justify-center rounded-lg text-sm font-bold text-white">
                     A
                   </div>
                 }
@@ -474,7 +474,7 @@ export const Default: Story = {
                   {/* Sign In button when signed out */}
                   {!isSignedIn && (
                     <button
-                      className="bg-primary-500 hover:bg-primary-600 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
+                      className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
                       onClick={() => console.log('Sign in')}
                     >
                       Sign in
@@ -510,7 +510,7 @@ export const Default: Story = {
               {/* Signed out state - Sign In button */}
               {!isSignedIn && (
                 <button
-                  className="bg-primary-500 hover:bg-primary-600 w-full rounded-lg px-4 py-3 text-sm font-medium text-white transition-colors"
+                  className="bg-primary-800 hover:bg-primary-900 w-full rounded-lg px-4 py-3 text-sm font-medium text-white transition-colors"
                   onClick={() => console.log('Sign in')}
                 >
                   Sign in

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -228,7 +228,7 @@ export function AppHeaderIconButton({
         'hover:bg-gray-100 dark:hover:bg-gray-800',
         'focus:ring-primary-500 focus:ring-2 focus:outline-none',
         isActive &&
-          'text-primary-600 dark:text-primary-400 bg-gray-100 dark:bg-gray-800',
+          'text-primary-800 dark:text-primary-400 bg-gray-100 dark:bg-gray-800',
         className
       )}
       aria-label={label}

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -135,9 +135,7 @@ export function AppHeaderTitle({
         {children}
       </h1>
       {subtitle && (
-        <p className="truncate text-sm text-muted-foreground">
-          {subtitle}
-        </p>
+        <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
       )}
     </div>
   );
@@ -415,7 +413,7 @@ export function AppHeaderUserMenu({
         {email && (
           <div
             data-slot="app-header-user-email"
-            className="max-w-[150px] truncate text-xs text-muted-foreground"
+            className="text-muted-foreground max-w-[150px] truncate text-xs"
           >
             {email}
           </div>

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -304,7 +304,7 @@ export function AppHeaderSearch({
       data-testid={testId}
       className={cn(
         'flex items-center gap-3 rounded-lg border border-gray-300 dark:border-gray-600',
-        'bg-white px-4 py-2 text-sm text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+        'text-muted-foreground bg-white px-4 py-2 text-sm dark:bg-gray-700',
         'hover:border-gray-400 dark:hover:border-gray-500',
         'transition-colors hover:bg-gray-50 dark:hover:bg-gray-600',
         !showOnMobile && 'hidden sm:flex',
@@ -318,7 +318,7 @@ export function AppHeaderSearch({
         className={cn(
           'hidden items-center gap-0.5 px-2 py-0.5 sm:inline-flex',
           'rounded border border-gray-200 bg-gray-100 dark:border-gray-500 dark:bg-gray-600',
-          'flex-shrink-0 text-xs text-gray-600 dark:text-gray-300'
+          'text-muted-foreground flex-shrink-0 text-xs'
         )}
       >
         {isMac ? '⌘' : 'Ctrl'}+K

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -135,7 +135,7 @@ export function AppHeaderTitle({
         {children}
       </h1>
       {subtitle && (
-        <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+        <p className="truncate text-sm text-muted-foreground">
           {subtitle}
         </p>
       )}
@@ -226,7 +226,7 @@ export function AppHeaderIconButton({
       data-testid={testId}
       className={cn(
         'relative rounded-lg p-2 transition-colors',
-        'text-gray-500 dark:text-gray-400',
+        'text-muted-foreground',
         'hover:bg-gray-100 dark:hover:bg-gray-800',
         'focus:ring-primary-500 focus:ring-2 focus:outline-none',
         isActive &&
@@ -415,7 +415,7 @@ export function AppHeaderUserMenu({
         {email && (
           <div
             data-slot="app-header-user-email"
-            className="max-w-[150px] truncate text-xs text-gray-500 dark:text-gray-400"
+            className="max-w-[150px] truncate text-xs text-muted-foreground"
           >
             {email}
           </div>

--- a/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -481,7 +481,7 @@ export const ChatMessage: Story = {
       <div className="flex flex-row-reverse gap-2">
         <Avatar name="You" size="sm" />
         <div className="space-y-1">
-          <div className="bg-primary-600 rounded-2xl rounded-tr-sm px-3 py-2">
+          <div className="bg-primary-800 rounded-2xl rounded-tr-sm px-3 py-2">
             <AudioPlayer
               src={getShortAudio()}
               variant="compact"
@@ -505,7 +505,7 @@ export const PodcastPlayer: Story = {
       <CardContent className="pt-6">
         <div className="flex gap-4" data-slot="podcast-header">
           <div
-            className="bg-primary-500 h-24 w-24 shrink-0 overflow-hidden rounded-lg"
+            className="bg-primary-800 h-24 w-24 shrink-0 overflow-hidden rounded-lg"
             data-slot="podcast-cover"
           >
             <div className="flex h-full items-center justify-center text-2xl text-white">

--- a/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -545,7 +545,7 @@ export const AudioAttachment: Story = {
         <div className="mb-2 flex items-center gap-2">
           <div className="bg-primary-100 dark:bg-primary-900/30 flex h-8 w-8 items-center justify-center rounded">
             <svg
-              className="text-primary-600 dark:text-primary-400 h-4 w-4"
+              className="text-primary-800 dark:text-primary-400 h-4 w-4"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -596,374 +596,430 @@ function Waveform({
  * // Then: playerRef.current?.seekTo(30); playerRef.current?.play();
  * ```
  */
-const AudioPlayer = React.forwardRef<AudioPlayerRef, AudioPlayerProps>(function AudioPlayer(
-  {
-    src,
-    title,
-    variant = 'compact',
-    size = 'md',
-    onStateChange,
-    onEnded,
-    onError,
-    onTimeUpdate,
-    showTime = true,
-    showDuration = true,
-    waveColor,
-    progressColor,
-    waveformHeight = 64,
-    showWaveformHoverCursor = true,
-    waveformCursorColor,
-    disabled = false,
-    className,
-    'aria-label': ariaLabel,
-    playbackRates = [0.5, 0.75, 1, 1.25, 1.5, 2],
-    showPlaybackRate = false,
-    /** Whether to preload audio (set to false for lists with many items) */
-    preload = false,
-    /** Fallback duration in seconds to display before audio is loaded */
-    fallbackDuration,
-  },
-  ref
-) {
-  const [state, setState] = React.useState<AudioPlayerState>('idle');
-  const [currentTime, setCurrentTime] = React.useState(0);
-  const [duration, setDuration] = React.useState(0);
-  const [playbackRate, setPlaybackRate] = React.useState(1);
-  const [audioInitialized, setAudioInitialized] = React.useState(false);
-  const [hoverTime, setHoverTime] = React.useState<number | null>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const audioRef = React.useRef<globalThis.HTMLAudioElement | null>(null);
-  const waveformMethodsRef = React.useRef<WaveformMethods | null>(null);
-
-  const isPlaying = state === 'playing';
-  const isLoading = state === 'loading';
-  const displayDuration = duration > 0 ? duration : (fallbackDuration ?? 0);
-
-  // Update state helper
-  const updateState = React.useCallback(
-    (newState: AudioPlayerState) => {
-      setState(newState);
-      onStateChange?.(newState);
+const AudioPlayer = React.forwardRef<AudioPlayerRef, AudioPlayerProps>(
+  function AudioPlayer(
+    {
+      src,
+      title,
+      variant = 'compact',
+      size = 'md',
+      onStateChange,
+      onEnded,
+      onError,
+      onTimeUpdate,
+      showTime = true,
+      showDuration = true,
+      waveColor,
+      progressColor,
+      waveformHeight = 64,
+      showWaveformHoverCursor = true,
+      waveformCursorColor,
+      disabled = false,
+      className,
+      'aria-label': ariaLabel,
+      playbackRates = [0.5, 0.75, 1, 1.25, 1.5, 2],
+      showPlaybackRate = false,
+      /** Whether to preload audio (set to false for lists with many items) */
+      preload = false,
+      /** Fallback duration in seconds to display before audio is loaded */
+      fallbackDuration,
     },
-    [onStateChange]
-  );
+    ref
+  ) {
+    const [state, setState] = React.useState<AudioPlayerState>('idle');
+    const [currentTime, setCurrentTime] = React.useState(0);
+    const [duration, setDuration] = React.useState(0);
+    const [playbackRate, setPlaybackRate] = React.useState(1);
+    const [audioInitialized, setAudioInitialized] = React.useState(false);
+    const [hoverTime, setHoverTime] = React.useState<number | null>(null);
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const audioRef = React.useRef<globalThis.HTMLAudioElement | null>(null);
+    const waveformMethodsRef = React.useRef<WaveformMethods | null>(null);
 
-  // Initialize audio element (for non-waveform variants)
-  const initAudio = React.useCallback(() => {
-    if (variant === 'waveform' || audioInitialized) return null;
+    const isPlaying = state === 'playing';
+    const isLoading = state === 'loading';
+    const displayDuration = duration > 0 ? duration : (fallbackDuration ?? 0);
 
-    const audio = new globalThis.Audio(src);
-    audioRef.current = audio;
-    setAudioInitialized(true);
+    // Update state helper
+    const updateState = React.useCallback(
+      (newState: AudioPlayerState) => {
+        setState(newState);
+        onStateChange?.(newState);
+      },
+      [onStateChange]
+    );
 
-    audio.addEventListener('loadstart', () => updateState('loading'));
-    audio.addEventListener('canplay', () => {
-      updateState('idle');
-    });
-    audio.addEventListener('loadedmetadata', () => {
-      setDuration(audio.duration);
-      onTimeUpdate?.(audio.currentTime, audio.duration);
-    });
-    audio.addEventListener('timeupdate', () => {
-      setCurrentTime(audio.currentTime);
-      onTimeUpdate?.(audio.currentTime, audio.duration);
-    });
-    audio.addEventListener('ended', () => {
+    // Initialize audio element (for non-waveform variants)
+    const initAudio = React.useCallback(() => {
+      if (variant === 'waveform' || audioInitialized) return null;
+
+      const audio = new globalThis.Audio(src);
+      audioRef.current = audio;
+      setAudioInitialized(true);
+
+      audio.addEventListener('loadstart', () => updateState('loading'));
+      audio.addEventListener('canplay', () => {
+        updateState('idle');
+      });
+      audio.addEventListener('loadedmetadata', () => {
+        setDuration(audio.duration);
+        onTimeUpdate?.(audio.currentTime, audio.duration);
+      });
+      audio.addEventListener('timeupdate', () => {
+        setCurrentTime(audio.currentTime);
+        onTimeUpdate?.(audio.currentTime, audio.duration);
+      });
+      audio.addEventListener('ended', () => {
+        updateState('idle');
+        setCurrentTime(0);
+        onEnded?.();
+      });
+      audio.addEventListener('error', () => {
+        updateState('error');
+        onError?.(new Error('Failed to load audio'));
+      });
+
+      return audio;
+    }, [
+      src,
+      variant,
+      audioInitialized,
+      updateState,
+      onTimeUpdate,
+      onEnded,
+      onError,
+    ]);
+
+    // Expose methods via ref for external control
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        get container() {
+          return containerRef.current;
+        },
+        seekTo: (time: number) => {
+          if (variant === 'waveform') {
+            waveformMethodsRef.current?.seekTo(time);
+          } else {
+            // Lazily initialize audio if not yet created
+            if (!audioRef.current) {
+              initAudio();
+            }
+            if (audioRef.current) {
+              audioRef.current.currentTime = time;
+            }
+          }
+        },
+        play: () => {
+          if (variant === 'waveform') {
+            if (waveformMethodsRef.current) {
+              waveformMethodsRef.current.play();
+              updateState('playing');
+            }
+          } else {
+            // Lazily initialize audio if not yet created
+            if (!audioRef.current) {
+              initAudio();
+            }
+            if (audioRef.current) {
+              audioRef.current.play().catch((error) => {
+                updateState('error');
+                onError?.(error);
+              });
+              updateState('playing');
+            }
+          }
+        },
+        pause: () => {
+          if (variant === 'waveform') {
+            if (waveformMethodsRef.current) {
+              waveformMethodsRef.current.pause();
+              updateState('paused');
+            }
+          } else if (audioRef.current) {
+            audioRef.current.pause();
+            updateState('paused');
+          }
+        },
+        getCurrentTime: () => {
+          if (variant === 'waveform') {
+            return waveformMethodsRef.current?.getCurrentTime() ?? 0;
+          }
+          return audioRef.current?.currentTime ?? 0;
+        },
+        getDuration: () => {
+          if (variant === 'waveform') {
+            return waveformMethodsRef.current?.getDuration() ?? 0;
+          }
+          const rawDuration = audioRef.current?.duration;
+          return Number.isFinite(rawDuration) ? rawDuration! : 0;
+        },
+      }),
+      [variant, initAudio, updateState, onError]
+    );
+
+    // Auto-initialize if preload is true
+    React.useEffect(() => {
+      if (preload && !audioInitialized && variant !== 'waveform') {
+        initAudio();
+      }
+    }, [preload, audioInitialized, variant, initAudio]);
+
+    // Cleanup on unmount
+    React.useEffect(() => {
+      return () => {
+        if (audioRef.current) {
+          audioRef.current.pause();
+          audioRef.current.src = '';
+        }
+      };
+    }, []);
+
+    // Handle playback rate changes
+    React.useEffect(() => {
+      if (audioRef.current) {
+        audioRef.current.playbackRate = playbackRate;
+      }
+    }, [playbackRate]);
+
+    const handlePlay = React.useCallback(() => {
+      if (disabled) return;
+
+      // Waveform variant uses WaveSurfer for playback - just toggle state
+      if (variant === 'waveform') {
+        if (isLoading) return;
+        updateState(isPlaying ? 'paused' : 'playing');
+        return;
+      }
+
+      // Lazy initialize audio on first play
+      if (!audioInitialized && !isLoading) {
+        const audio = initAudio();
+        if (audio) {
+          updateState('loading');
+          audio.addEventListener(
+            'canplay',
+            () => {
+              audio.play().catch((error) => {
+                updateState('error');
+                onError?.(error);
+              });
+              updateState('playing');
+            },
+            { once: true }
+          );
+        }
+        return;
+      }
+
+      if (isLoading) return;
+
+      if (isPlaying) {
+        if (audioRef.current) {
+          audioRef.current.pause();
+        }
+        updateState('paused');
+      } else {
+        if (audioRef.current) {
+          audioRef.current.play().catch((error) => {
+            updateState('error');
+            onError?.(error);
+          });
+          updateState('playing');
+        }
+      }
+    }, [
+      disabled,
+      variant,
+      audioInitialized,
+      isLoading,
+      isPlaying,
+      initAudio,
+      updateState,
+      onError,
+    ]);
+
+    const handleSeek = React.useCallback(
+      (time: number) => {
+        if (audioRef.current) {
+          audioRef.current.currentTime = time;
+          setCurrentTime(time);
+          onTimeUpdate?.(time, audioRef.current.duration);
+        }
+      },
+      [onTimeUpdate]
+    );
+
+    // Waveform callbacks
+    const handleWaveformReady = React.useCallback(
+      (dur: number) => {
+        setDuration(dur);
+        setState('idle');
+        onTimeUpdate?.(currentTime, dur);
+      },
+      [currentTime, onTimeUpdate]
+    );
+
+    const handleWaveformTimeUpdate = React.useCallback(
+      (time: number, dur: number) => {
+        setCurrentTime(time);
+        if (dur > 0) {
+          setDuration(dur);
+        }
+        onTimeUpdate?.(time, dur);
+      },
+      [onTimeUpdate]
+    );
+
+    const handleWaveformFinish = React.useCallback(() => {
       updateState('idle');
       setCurrentTime(0);
       onEnded?.();
-    });
-    audio.addEventListener('error', () => {
-      updateState('error');
-      onError?.(new Error('Failed to load audio'));
-    });
+    }, [updateState, onEnded]);
 
-    return audio;
-  }, [
-    src,
-    variant,
-    audioInitialized,
-    updateState,
-    onTimeUpdate,
-    onEnded,
-    onError,
-  ]);
-
-  // Expose methods via ref for external control
-  React.useImperativeHandle(
-    ref,
-    () => ({
-      get container() {
-        return containerRef.current;
-      },
-      seekTo: (time: number) => {
-        if (variant === 'waveform') {
-          waveformMethodsRef.current?.seekTo(time);
-        } else {
-          // Lazily initialize audio if not yet created
-          if (!audioRef.current) {
-            initAudio();
-          }
-          if (audioRef.current) {
-            audioRef.current.currentTime = time;
-          }
-        }
-      },
-      play: () => {
-        if (variant === 'waveform') {
-          if (waveformMethodsRef.current) {
-            waveformMethodsRef.current.play();
-            updateState('playing');
-          }
-        } else {
-          // Lazily initialize audio if not yet created
-          if (!audioRef.current) {
-            initAudio();
-          }
-          if (audioRef.current) {
-            audioRef.current.play().catch((error) => {
-              updateState('error');
-              onError?.(error);
-            });
-            updateState('playing');
-          }
-        }
-      },
-      pause: () => {
-        if (variant === 'waveform') {
-          if (waveformMethodsRef.current) {
-            waveformMethodsRef.current.pause();
-            updateState('paused');
-          }
-        } else if (audioRef.current) {
-          audioRef.current.pause();
-          updateState('paused');
-        }
-      },
-      getCurrentTime: () => {
-        if (variant === 'waveform') {
-          return waveformMethodsRef.current?.getCurrentTime() ?? 0;
-        }
-        return audioRef.current?.currentTime ?? 0;
-      },
-      getDuration: () => {
-        if (variant === 'waveform') {
-          return waveformMethodsRef.current?.getDuration() ?? 0;
-        }
-        const rawDuration = audioRef.current?.duration;
-        return Number.isFinite(rawDuration) ? rawDuration! : 0;
-      },
-    }),
-    [variant, initAudio, updateState, onError]
-  );
-
-  // Auto-initialize if preload is true
-  React.useEffect(() => {
-    if (preload && !audioInitialized && variant !== 'waveform') {
-      initAudio();
-    }
-  }, [preload, audioInitialized, variant, initAudio]);
-
-  // Cleanup on unmount
-  React.useEffect(() => {
-    return () => {
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.src = '';
-      }
-    };
-  }, []);
-
-  // Handle playback rate changes
-  React.useEffect(() => {
-    if (audioRef.current) {
-      audioRef.current.playbackRate = playbackRate;
-    }
-  }, [playbackRate]);
-
-  const handlePlay = React.useCallback(() => {
-    if (disabled) return;
-
-    // Waveform variant uses WaveSurfer for playback - just toggle state
-    if (variant === 'waveform') {
-      if (isLoading) return;
-      updateState(isPlaying ? 'paused' : 'playing');
-      return;
-    }
-
-    // Lazy initialize audio on first play
-    if (!audioInitialized && !isLoading) {
-      const audio = initAudio();
-      if (audio) {
-        updateState('loading');
-        audio.addEventListener(
-          'canplay',
-          () => {
-            audio.play().catch((error) => {
-              updateState('error');
-              onError?.(error);
-            });
-            updateState('playing');
-          },
-          { once: true }
-        );
-      }
-      return;
-    }
-
-    if (isLoading) return;
-
-    if (isPlaying) {
-      if (audioRef.current) {
-        audioRef.current.pause();
-      }
-      updateState('paused');
-    } else {
-      if (audioRef.current) {
-        audioRef.current.play().catch((error) => {
-          updateState('error');
-          onError?.(error);
-        });
-        updateState('playing');
-      }
-    }
-  }, [
-    disabled,
-    variant,
-    audioInitialized,
-    isLoading,
-    isPlaying,
-    initAudio,
-    updateState,
-    onError,
-  ]);
-
-  const handleSeek = React.useCallback(
-    (time: number) => {
-      if (audioRef.current) {
-        audioRef.current.currentTime = time;
-        setCurrentTime(time);
-        onTimeUpdate?.(time, audioRef.current.duration);
-      }
-    },
-    [onTimeUpdate]
-  );
-
-  // Waveform callbacks
-  const handleWaveformReady = React.useCallback(
-    (dur: number) => {
-      setDuration(dur);
-      setState('idle');
-      onTimeUpdate?.(currentTime, dur);
-    },
-    [currentTime, onTimeUpdate]
-  );
-
-  const handleWaveformTimeUpdate = React.useCallback(
-    (time: number, dur: number) => {
+    const handleWaveformSeek = React.useCallback((time: number) => {
       setCurrentTime(time);
-      if (dur > 0) {
-        setDuration(dur);
-      }
-      onTimeUpdate?.(time, dur);
-    },
-    [onTimeUpdate]
-  );
+    }, []);
 
-  const handleWaveformFinish = React.useCallback(() => {
-    updateState('idle');
-    setCurrentTime(0);
-    onEnded?.();
-  }, [updateState, onEnded]);
+    const handleHoverTimeChange = React.useCallback((time: number | null) => {
+      setHoverTime(time);
+    }, []);
 
-  const handleWaveformSeek = React.useCallback((time: number) => {
-    setCurrentTime(time);
-  }, []);
+    const iconSize =
+      size === 'sm' ? 'h-3.5 w-3.5' : size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
 
-  const handleHoverTimeChange = React.useCallback((time: number | null) => {
-    setHoverTime(time);
-  }, []);
+    const getAriaLabel = () => {
+      if (ariaLabel) return ariaLabel;
+      if (title) return `${isPlaying ? 'Pause' : 'Play'} ${title}`;
+      return isPlaying ? 'Pause audio' : 'Play audio';
+    };
 
-  const iconSize =
-    size === 'sm' ? 'h-3.5 w-3.5' : size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
-
-  const getAriaLabel = () => {
-    if (ariaLabel) return ariaLabel;
-    if (title) return `${isPlaying ? 'Pause' : 'Play'} ${title}`;
-    return isPlaying ? 'Pause audio' : 'Play audio';
-  };
-
-  const renderPlayButton = () => (
-    <button
-      type="button"
-      data-slot="audio-player-play-btn"
-      onClick={handlePlay}
-      disabled={disabled || isLoading}
-      className={cn(playButtonVariants({ variant, size }))}
-      aria-label={getAriaLabel()}
-      aria-pressed={isPlaying}
-    >
-      {isLoading ? (
-        <SpinnerIcon className={iconSize} />
-      ) : isPlaying ? (
-        <PauseIcon className={iconSize} />
-      ) : (
-        <PlayIcon className={iconSize} />
-      )}
-    </button>
-  );
-
-  const renderTime = (useHoverTime = false) => {
-    if (!showTime) return null;
-    const displayTime =
-      useHoverTime && hoverTime !== null ? hoverTime : currentTime;
-    const isShowingHoverTime = useHoverTime && hoverTime !== null;
-    return (
-      <span
-        data-slot="audio-player-time"
-        className={cn(
-          'font-mono text-xs tabular-nums',
-          isShowingHoverTime
-            ? 'text-primary-600 dark:text-primary-400'
-            : 'text-neutral-500 dark:text-neutral-400'
+    const renderPlayButton = () => (
+      <button
+        type="button"
+        data-slot="audio-player-play-btn"
+        onClick={handlePlay}
+        disabled={disabled || isLoading}
+        className={cn(playButtonVariants({ variant, size }))}
+        aria-label={getAriaLabel()}
+        aria-pressed={isPlaying}
+      >
+        {isLoading ? (
+          <SpinnerIcon className={iconSize} />
+        ) : isPlaying ? (
+          <PauseIcon className={iconSize} />
+        ) : (
+          <PlayIcon className={iconSize} />
         )}
-      >
-        {formatTime(displayTime)} / {formatTime(displayDuration)}
-      </span>
+      </button>
     );
-  };
 
-  const renderPlaybackRateControl = () => {
-    if (!showPlaybackRate) return null;
-    return (
-      <select
-        data-slot="audio-player-rate"
-        value={playbackRate}
-        onChange={(e) => setPlaybackRate(Number(e.target.value))}
-        className="rounded border border-neutral-200 bg-transparent px-1 py-0.5 text-xs dark:border-neutral-700"
-        aria-label="Playback speed"
-      >
-        {playbackRates.map((rate) => (
-          <option key={rate} value={rate}>
-            {rate}x
-          </option>
-        ))}
-      </select>
-    );
-  };
+    const renderTime = (useHoverTime = false) => {
+      if (!showTime) return null;
+      const displayTime =
+        useHoverTime && hoverTime !== null ? hoverTime : currentTime;
+      const isShowingHoverTime = useHoverTime && hoverTime !== null;
+      return (
+        <span
+          data-slot="audio-player-time"
+          className={cn(
+            'font-mono text-xs tabular-nums',
+            isShowingHoverTime
+              ? 'text-primary-600 dark:text-primary-400'
+              : 'text-neutral-500 dark:text-neutral-400'
+          )}
+        >
+          {formatTime(displayTime)} / {formatTime(displayDuration)}
+        </span>
+      );
+    };
 
-  // ============================================================================
-  // Inline Variant
-  // ============================================================================
-  if (variant === 'inline') {
+    const renderPlaybackRateControl = () => {
+      if (!showPlaybackRate) return null;
+      return (
+        <select
+          data-slot="audio-player-rate"
+          value={playbackRate}
+          onChange={(e) => setPlaybackRate(Number(e.target.value))}
+          className="rounded border border-neutral-200 bg-transparent px-1 py-0.5 text-xs dark:border-neutral-700"
+          aria-label="Playback speed"
+        >
+          {playbackRates.map((rate) => (
+            <option key={rate} value={rate}>
+              {rate}x
+            </option>
+          ))}
+        </select>
+      );
+    };
+
+    // ============================================================================
+    // Inline Variant
+    // ============================================================================
+    if (variant === 'inline') {
+      return (
+        <div
+          ref={containerRef}
+          data-slot="audio-player"
+          data-variant="inline"
+          className={cn(audioPlayerVariants({ variant, size }), className)}
+        >
+          {renderPlayButton()}
+          {title && (
+            <span
+              data-slot="audio-player-title"
+              className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
+            >
+              {title}
+            </span>
+          )}
+          {showDuration && displayDuration > 0 && (
+            <span
+              data-slot="audio-player-duration"
+              className="font-mono text-xs text-neutral-500 tabular-nums dark:text-neutral-400"
+            >
+              {isPlaying
+                ? formatTime(currentTime)
+                : formatTime(displayDuration)}
+            </span>
+          )}
+        </div>
+      );
+    }
+
+    // Compact Variant
+    // ============================================================================
+    if (variant === 'compact') {
+      return (
+        <div
+          ref={containerRef}
+          data-slot="audio-player"
+          data-variant="compact"
+          className={cn(audioPlayerVariants({ variant, size }), className)}
+        >
+          {renderPlayButton()}
+          <ProgressBar
+            currentTime={currentTime}
+            duration={displayDuration}
+            onSeek={handleSeek}
+            disabled={disabled}
+          />
+          {renderTime()}
+          {renderPlaybackRateControl()}
+        </div>
+      );
+    }
+
+    // ============================================================================
+    // Waveform Variant
+    // ============================================================================
     return (
       <div
         ref={containerRef}
         data-slot="audio-player"
-        data-variant="inline"
+        data-variant="waveform"
         className={cn(audioPlayerVariants({ variant, size }), className)}
       >
-        {renderPlayButton()}
         {title && (
           <span
             data-slot="audio-player-title"
@@ -972,88 +1028,36 @@ const AudioPlayer = React.forwardRef<AudioPlayerRef, AudioPlayerProps>(function 
             {title}
           </span>
         )}
-        {showDuration && displayDuration > 0 && (
-          <span
-            data-slot="audio-player-duration"
-            className="font-mono text-xs text-neutral-500 tabular-nums dark:text-neutral-400"
-          >
-            {isPlaying ? formatTime(currentTime) : formatTime(displayDuration)}
-          </span>
-        )}
-      </div>
-    );
-  }
-
-  // Compact Variant
-  // ============================================================================
-  if (variant === 'compact') {
-    return (
-      <div
-        ref={containerRef}
-        data-slot="audio-player"
-        data-variant="compact"
-        className={cn(audioPlayerVariants({ variant, size }), className)}
-      >
-        {renderPlayButton()}
-        <ProgressBar
-          currentTime={currentTime}
-          duration={displayDuration}
-          onSeek={handleSeek}
-          disabled={disabled}
+        <Waveform
+          src={src}
+          isPlaying={isPlaying}
+          playbackRate={playbackRate}
+          onReady={handleWaveformReady}
+          onTimeUpdate={handleWaveformTimeUpdate}
+          onFinish={handleWaveformFinish}
+          onSeek={handleWaveformSeek}
+          waveColor={waveColor}
+          progressColor={progressColor}
+          height={waveformHeight}
+          showHoverCursor={showWaveformHoverCursor}
+          onHoverTimeChange={handleHoverTimeChange}
+          cursorColor={waveformCursorColor}
+          waveformRef={waveformMethodsRef}
         />
-        {renderTime()}
-        {renderPlaybackRateControl()}
-      </div>
-    );
-  }
-
-  // ============================================================================
-  // Waveform Variant
-  // ============================================================================
-  return (
-    <div
-      ref={containerRef}
-      data-slot="audio-player"
-      data-variant="waveform"
-      className={cn(audioPlayerVariants({ variant, size }), className)}
-    >
-      {title && (
-        <span
-          data-slot="audio-player-title"
-          className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
+        <div
+          data-slot="audio-player-controls"
+          className="flex items-center gap-3"
         >
-          {title}
-        </span>
-      )}
-      <Waveform
-        src={src}
-        isPlaying={isPlaying}
-        playbackRate={playbackRate}
-        onReady={handleWaveformReady}
-        onTimeUpdate={handleWaveformTimeUpdate}
-        onFinish={handleWaveformFinish}
-        onSeek={handleWaveformSeek}
-        waveColor={waveColor}
-        progressColor={progressColor}
-        height={waveformHeight}
-        showHoverCursor={showWaveformHoverCursor}
-        onHoverTimeChange={handleHoverTimeChange}
-        cursorColor={waveformCursorColor}
-        waveformRef={waveformMethodsRef}
-      />
-      <div
-        data-slot="audio-player-controls"
-        className="flex items-center gap-3"
-      >
-        {renderPlayButton()}
-        <div className="flex flex-1 items-center justify-between">
-          {renderTime(true)}
-          {renderPlaybackRateControl()}
+          {renderPlayButton()}
+          <div className="flex flex-1 items-center justify-between">
+            {renderTime(true)}
+            {renderPlaybackRateControl()}
+          </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 AudioPlayer.displayName = 'AudioPlayer';
 

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -123,13 +123,13 @@ const playButtonVariants = cva(
           'dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:bg-neutral-800',
         ],
         compact: [
-          'bg-primary-800 text-white',
-          'hover:bg-primary-900',
+          'bg-primary-600 text-white',
+          'hover:bg-primary-700',
           'active:bg-primary-800',
         ],
         waveform: [
-          'bg-primary-800 text-white',
-          'hover:bg-primary-900',
+          'bg-primary-600 text-white',
+          'hover:bg-primary-700',
           'active:bg-primary-800',
         ],
       },
@@ -267,11 +267,11 @@ function ProgressBar({
       }}
     >
       <div
-        className="bg-primary-800 absolute inset-y-0 left-0 rounded-full transition-all"
+        className="bg-primary-600 absolute inset-y-0 left-0 rounded-full transition-all"
         style={{ width: `${progress}%` }}
       />
       <div
-        className="bg-primary-800 absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full shadow-sm transition-all"
+        className="bg-primary-600 absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full shadow-sm transition-all"
         style={{ left: `calc(${progress}% - 6px)` }}
       />
     </div>
@@ -897,8 +897,8 @@ const AudioPlayer = React.forwardRef<
         className={cn(
           'font-mono text-xs tabular-nums',
           isShowingHoverTime
-            ? 'text-primary-800 dark:text-primary-400'
-            : 'text-muted-foreground'
+            ? 'text-primary-600 dark:text-primary-400'
+            : 'text-neutral-500 dark:text-neutral-400'
         )}
       >
         {formatTime(displayTime)} / {formatTime(duration)}

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -898,7 +898,7 @@ const AudioPlayer = React.forwardRef<
           'font-mono text-xs tabular-nums',
           isShowingHoverTime
             ? 'text-primary-600 dark:text-primary-400'
-            : 'text-neutral-500 dark:text-neutral-400'
+            : 'text-muted-foreground'
         )}
       >
         {formatTime(displayTime)} / {formatTime(duration)}

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -123,13 +123,13 @@ const playButtonVariants = cva(
           'dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:bg-neutral-800',
         ],
         compact: [
-          'bg-primary-600 text-white',
-          'hover:bg-primary-700',
+          'bg-primary-800 text-white',
+          'hover:bg-primary-900',
           'active:bg-primary-800',
         ],
         waveform: [
-          'bg-primary-600 text-white',
-          'hover:bg-primary-700',
+          'bg-primary-800 text-white',
+          'hover:bg-primary-900',
           'active:bg-primary-800',
         ],
       },
@@ -267,11 +267,11 @@ function ProgressBar({
       }}
     >
       <div
-        className="bg-primary-600 absolute inset-y-0 left-0 rounded-full transition-all"
+        className="bg-primary-800 absolute inset-y-0 left-0 rounded-full transition-all"
         style={{ width: `${progress}%` }}
       />
       <div
-        className="bg-primary-600 absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full shadow-sm transition-all"
+        className="bg-primary-800 absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full shadow-sm transition-all"
         style={{ left: `calc(${progress}% - 6px)` }}
       />
     </div>

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -127,13 +127,13 @@ const playButtonVariants = cva(
           'dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:bg-neutral-800',
         ],
         compact: [
-          'bg-primary-600 text-white',
-          'hover:bg-primary-700',
+          'bg-primary-800 text-white',
+          'hover:bg-primary-900',
           'active:bg-primary-800',
         ],
         waveform: [
-          'bg-primary-600 text-white',
-          'hover:bg-primary-700',
+          'bg-primary-800 text-white',
+          'hover:bg-primary-900',
           'active:bg-primary-800',
         ],
       },
@@ -271,11 +271,11 @@ function ProgressBar({
       }}
     >
       <div
-        className="bg-primary-600 absolute inset-y-0 left-0 rounded-full transition-all"
+        className="bg-primary-800 absolute inset-y-0 left-0 rounded-full transition-all"
         style={{ width: `${progress}%` }}
       />
       <div
-        className="bg-primary-600 absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full shadow-sm transition-all"
+        className="bg-primary-800 absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full shadow-sm transition-all"
         style={{ left: `calc(${progress}% - 6px)` }}
       />
     </div>
@@ -925,8 +925,8 @@ const AudioPlayer = React.forwardRef<AudioPlayerRef, AudioPlayerProps>(
           className={cn(
             'font-mono text-xs tabular-nums',
             isShowingHoverTime
-              ? 'text-primary-600 dark:text-primary-400'
-              : 'text-neutral-500 dark:text-neutral-400'
+              ? 'text-primary-800 dark:text-primary-400'
+              : 'text-muted-foreground'
           )}
         >
           {formatTime(displayTime)} / {formatTime(displayDuration)}

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -897,7 +897,7 @@ const AudioPlayer = React.forwardRef<
         className={cn(
           'font-mono text-xs tabular-nums',
           isShowingHoverTime
-            ? 'text-primary-600 dark:text-primary-400'
+            ? 'text-primary-800 dark:text-primary-400'
             : 'text-muted-foreground'
         )}
       >

--- a/src/components/AudioRecorder/AudioRecorder.stories.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.stories.tsx
@@ -353,7 +353,7 @@ export const ControlledState: Story = {
           onStateChange={setState}
           maxDuration={30}
         />
-        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+        <p className="text-sm text-muted-foreground">
           Current state: <code className="font-mono">{state}</code>
         </p>
       </div>
@@ -447,7 +447,7 @@ export const CustomControls: Story = {
             </button>
           )}
         </div>
-        <div className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+        <div className="text-center text-sm text-muted-foreground">
           {formatTime(currentTime)} / {formatTime(duration)}
         </div>
       </div>
@@ -557,19 +557,19 @@ export const AllSizeComparison: Story = {
   render: () => (
     <div className="space-y-6">
       <div>
-        <p className="mb-2 text-sm text-neutral-600 dark:text-neutral-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Small
         </p>
         <AudioRecorder size="sm" waveformHeight={50} />
       </div>
       <div>
-        <p className="mb-2 text-sm text-neutral-600 dark:text-neutral-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Medium
         </p>
         <AudioRecorder size="md" waveformHeight={80} />
       </div>
       <div>
-        <p className="mb-2 text-sm text-neutral-600 dark:text-neutral-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Large
         </p>
         <AudioRecorder size="lg" waveformHeight={100} />

--- a/src/components/AudioRecorder/AudioRecorder.stories.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.stories.tsx
@@ -311,7 +311,7 @@ export const ControlledState: Story = {
             onClick={() => setState('idle')}
             className={`rounded px-3 py-1 text-sm ${
               state === 'idle'
-                ? 'bg-primary-600 text-white'
+                ? 'bg-primary-800 text-white'
                 : 'bg-neutral-200 dark:bg-neutral-700'
             }`}
           >
@@ -321,7 +321,7 @@ export const ControlledState: Story = {
             onClick={() => setState('recording')}
             className={`rounded px-3 py-1 text-sm ${
               state === 'recording'
-                ? 'bg-primary-600 text-white'
+                ? 'bg-primary-800 text-white'
                 : 'bg-neutral-200 dark:bg-neutral-700'
             }`}
           >
@@ -331,7 +331,7 @@ export const ControlledState: Story = {
             onClick={() => setState('paused')}
             className={`rounded px-3 py-1 text-sm ${
               state === 'paused'
-                ? 'bg-primary-600 text-white'
+                ? 'bg-primary-800 text-white'
                 : 'bg-neutral-200 dark:bg-neutral-700'
             }`}
           >
@@ -341,7 +341,7 @@ export const ControlledState: Story = {
             onClick={() => setState('stopped')}
             className={`rounded px-3 py-1 text-sm ${
               state === 'stopped'
-                ? 'bg-primary-600 text-white'
+                ? 'bg-primary-800 text-white'
                 : 'bg-neutral-200 dark:bg-neutral-700'
             }`}
           >
@@ -433,7 +433,7 @@ export const CustomControls: Story = {
           {state === 'stopped' && (
             <button
               onClick={onPlay}
-              className="bg-primary-700 hover:bg-primary-800 rounded-lg px-4 py-2 text-white transition-colors"
+              className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white transition-colors"
             >
               ▶️ Play Recording
             </button>
@@ -441,7 +441,7 @@ export const CustomControls: Story = {
           {isPlaying && (
             <button
               onClick={onPause}
-              className="bg-primary-700 hover:bg-primary-800 rounded-lg px-4 py-2 text-white transition-colors"
+              className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white transition-colors"
             >
               ⏸️ Pause Playback
             </button>
@@ -534,7 +534,7 @@ export const InlineRecorder: Story = {
             showTime={false}
           />
         </div>
-        <button className="bg-primary-700 hover:bg-primary-800 rounded-lg px-3 py-1.5 text-sm text-white transition-colors">
+        <button className="bg-primary-800 hover:bg-primary-900 rounded-lg px-3 py-1.5 text-sm text-white transition-colors">
           Send
         </button>
       </div>

--- a/src/components/AudioRecorder/AudioRecorder.stories.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.stories.tsx
@@ -353,7 +353,7 @@ export const ControlledState: Story = {
           onStateChange={setState}
           maxDuration={30}
         />
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Current state: <code className="font-mono">{state}</code>
         </p>
       </div>
@@ -447,7 +447,7 @@ export const CustomControls: Story = {
             </button>
           )}
         </div>
-        <div className="text-center text-sm text-muted-foreground">
+        <div className="text-muted-foreground text-center text-sm">
           {formatTime(currentTime)} / {formatTime(duration)}
         </div>
       </div>
@@ -557,21 +557,15 @@ export const AllSizeComparison: Story = {
   render: () => (
     <div className="space-y-6">
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Small
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Small</p>
         <AudioRecorder size="sm" waveformHeight={50} />
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Medium
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Medium</p>
         <AudioRecorder size="md" waveformHeight={80} />
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Large
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Large</p>
         <AudioRecorder size="lg" waveformHeight={100} />
       </div>
     </div>

--- a/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.tsx
@@ -291,7 +291,7 @@ function RecordingIndicator({
         )}
         aria-hidden="true"
       />
-      <span className="text-sm font-medium text-muted-foreground">
+      <span className="text-muted-foreground text-sm font-medium">
         {isPaused ? 'Paused' : 'Recording'}
       </span>
     </div>
@@ -317,7 +317,7 @@ function TimeDisplay({
 }: TimeDisplayProps) {
   return (
     <div
-      className="flex items-center gap-1 font-mono text-sm text-muted-foreground"
+      className="text-muted-foreground flex items-center gap-1 font-mono text-sm"
       data-slot="audio-recorder-time"
     >
       <span>{formatTime(currentTime)}</span>

--- a/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.tsx
@@ -291,7 +291,7 @@ function RecordingIndicator({
         )}
         aria-hidden="true"
       />
-      <span className="text-sm font-medium text-neutral-600 dark:text-neutral-400">
+      <span className="text-sm font-medium text-muted-foreground">
         {isPaused ? 'Paused' : 'Recording'}
       </span>
     </div>
@@ -317,7 +317,7 @@ function TimeDisplay({
 }: TimeDisplayProps) {
   return (
     <div
-      className="flex items-center gap-1 font-mono text-sm text-neutral-600 dark:text-neutral-400"
+      className="flex items-center gap-1 font-mono text-sm text-muted-foreground"
       data-slot="audio-recorder-time"
     >
       <span>{formatTime(currentTime)}</span>

--- a/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.tsx
@@ -137,8 +137,8 @@ const controlButtonVariants = cva(
     variants: {
       variant: {
         primary: [
-          'bg-primary-600 text-white',
-          'hover:bg-primary-700',
+          'bg-primary-800 text-white',
+          'hover:bg-primary-900',
           'active:bg-primary-800',
         ],
         secondary: [

--- a/src/components/AuthDialog/AuthDialog.stories.tsx
+++ b/src/components/AuthDialog/AuthDialog.stories.tsx
@@ -86,7 +86,7 @@ function AuthDialogDemo({
     <div className="min-h-screen bg-gray-100 p-8 dark:bg-gray-900">
       <button
         onClick={() => setIsOpen(true)}
-        className="bg-primary-700 hover:bg-primary-800 rounded-lg px-4 py-2 text-white"
+        className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white"
       >
         Open Auth Dialog
       </button>

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -315,7 +315,7 @@ export function AuthDialog({
           {mode === 'verify' && (
             <div className="py-4 text-center">
               <MailIcon className="text-primary-800 dark:text-primary-300 mx-auto mb-4 h-12 w-12" />
-              <p className="mb-4 text-muted-foreground">
+              <p className="text-muted-foreground mb-4">
                 We&apos;ve sent a verification email to your inbox. Please click
                 the link to verify your account.
               </p>
@@ -359,7 +359,7 @@ export function AuthDialog({
 
           {/* Mode Toggle */}
           {(mode === 'login' || mode === 'signup') && (
-            <p className="mt-6 text-center text-sm text-muted-foreground">
+            <p className="text-muted-foreground mt-6 text-center text-sm">
               {mode === 'login' ? (
                 <>
                   Don&apos;t have an account?{' '}
@@ -476,7 +476,7 @@ function LoginForm({ onSubmit, isLoading, onForgotPassword }: LoginFormProps) {
             type="checkbox"
             className="text-primary-600 focus:ring-primary-500 rounded border-gray-300"
           />
-          <span className="ml-2 text-sm text-muted-foreground">
+          <span className="text-muted-foreground ml-2 text-sm">
             Remember me
           </span>
         </label>
@@ -612,7 +612,7 @@ function SignupForm({
           required
           className="text-primary-600 focus:ring-primary-500 mt-0.5 rounded border-gray-300"
         />
-        <span className="ml-2 text-sm text-muted-foreground">
+        <span className="text-muted-foreground ml-2 text-sm">
           I agree to the{' '}
           <a
             href={termsUrl}
@@ -664,7 +664,7 @@ function ForgotPasswordForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-muted-foreground text-sm">
         Enter your email address and we&apos;ll send you a link to reset your
         password.
       </p>

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -315,7 +315,7 @@ export function AuthDialog({
           {mode === 'verify' && (
             <div className="py-4 text-center">
               <MailIcon className="text-primary-800 dark:text-primary-300 mx-auto mb-4 h-12 w-12" />
-              <p className="mb-4 text-gray-600 dark:text-gray-400">
+              <p className="mb-4 text-muted-foreground">
                 We&apos;ve sent a verification email to your inbox. Please click
                 the link to verify your account.
               </p>
@@ -359,7 +359,7 @@ export function AuthDialog({
 
           {/* Mode Toggle */}
           {(mode === 'login' || mode === 'signup') && (
-            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
+            <p className="mt-6 text-center text-sm text-muted-foreground">
               {mode === 'login' ? (
                 <>
                   Don&apos;t have an account?{' '}
@@ -476,7 +476,7 @@ function LoginForm({ onSubmit, isLoading, onForgotPassword }: LoginFormProps) {
             type="checkbox"
             className="text-primary-600 focus:ring-primary-500 rounded border-gray-300"
           />
-          <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
+          <span className="ml-2 text-sm text-muted-foreground">
             Remember me
           </span>
         </label>
@@ -612,7 +612,7 @@ function SignupForm({
           required
           className="text-primary-600 focus:ring-primary-500 mt-0.5 rounded border-gray-300"
         />
-        <span className="ml-2 text-sm text-gray-600 dark:text-gray-400">
+        <span className="ml-2 text-sm text-muted-foreground">
           I agree to the{' '}
           <a
             href={termsUrl}
@@ -664,7 +664,7 @@ function ForgotPasswordForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <p className="text-sm text-gray-600 dark:text-gray-400">
+      <p className="text-sm text-muted-foreground">
         Enter your email address and we&apos;ll send you a link to reset your
         password.
       </p>

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -491,7 +491,7 @@ function LoginForm({ onSubmit, isLoading, onForgotPassword }: LoginFormProps) {
       <button
         type="submit"
         disabled={isLoading}
-        className="bg-primary-700 hover:bg-primary-800 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        className="bg-primary-800 hover:bg-primary-900 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isLoading ? <Spinner className="mx-auto h-5 w-5" /> : 'Sign in'}
       </button>
@@ -636,7 +636,7 @@ function SignupForm({
       <button
         type="submit"
         disabled={isLoading || !passwordsMatch || !acceptedTerms}
-        className="bg-primary-700 hover:bg-primary-800 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        className="bg-primary-800 hover:bg-primary-900 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isLoading ? <Spinner className="mx-auto h-5 w-5" /> : 'Create account'}
       </button>
@@ -689,7 +689,7 @@ function ForgotPasswordForm({
       <button
         type="submit"
         disabled={isLoading}
-        className="bg-primary-700 hover:bg-primary-800 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        className="bg-primary-800 hover:bg-primary-900 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isLoading ? (
           <Spinner className="mx-auto h-5 w-5" />
@@ -789,7 +789,7 @@ function ResetPasswordForm({ onSubmit, isLoading }: ResetPasswordFormProps) {
       <button
         type="submit"
         disabled={isLoading || !passwordsMatch}
-        className="bg-primary-700 hover:bg-primary-800 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        className="bg-primary-800 hover:bg-primary-900 w-full rounded-lg py-2.5 font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isLoading ? (
           <Spinner className="mx-auto h-5 w-5" />

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -474,7 +474,7 @@ function LoginForm({ onSubmit, isLoading, onForgotPassword }: LoginFormProps) {
         <label className="flex items-center">
           <input
             type="checkbox"
-            className="text-primary-600 focus:ring-primary-500 rounded border-gray-300"
+            className="text-primary-800 focus:ring-primary-500 rounded border-gray-300"
           />
           <span className="text-muted-foreground ml-2 text-sm">
             Remember me
@@ -610,7 +610,7 @@ function SignupForm({
           checked={acceptedTerms}
           onChange={(e) => setAcceptedTerms(e.target.checked)}
           required
-          className="text-primary-600 focus:ring-primary-500 mt-0.5 rounded border-gray-300"
+          className="text-primary-800 focus:ring-primary-500 mt-0.5 rounded border-gray-300"
         />
         <span className="text-muted-foreground ml-2 text-sm">
           I agree to the{' '}

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -174,7 +174,7 @@ export function AuthDialog({
         <button
           type="button"
           onClick={onClose}
-          className="absolute top-4 right-4 rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+          className="text-muted-foreground absolute top-4 right-4 rounded-full p-1 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-gray-300"
           aria-label="Close"
         >
           <CloseIcon className="h-5 w-5" />
@@ -338,7 +338,7 @@ export function AuthDialog({
                     <div className="w-full border-t border-gray-200 dark:border-gray-700" />
                   </div>
                   <div className="relative flex justify-center text-sm">
-                    <span className="bg-white px-2 text-gray-500 dark:bg-gray-800">
+                    <span className="text-muted-foreground bg-white px-2 dark:bg-gray-800">
                       Or continue with
                     </span>
                   </div>
@@ -460,7 +460,7 @@ function LoginForm({ onSubmit, isLoading, onForgotPassword }: LoginFormProps) {
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+            className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 hover:text-gray-700"
           >
             {showPassword ? (
               <EyeOffIcon className="h-4 w-4" />
@@ -568,7 +568,7 @@ function SignupForm({
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+            className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 hover:text-gray-700"
           >
             {showPassword ? (
               <EyeOffIcon className="h-4 w-4" />
@@ -700,7 +700,7 @@ function ForgotPasswordForm({
       <button
         type="button"
         onClick={onBack}
-        className="w-full py-2 text-sm text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+        className="text-muted-foreground w-full py-2 text-sm hover:text-gray-800 dark:hover:text-gray-200"
       >
         ← Back to login
       </button>
@@ -750,7 +750,7 @@ function ResetPasswordForm({ onSubmit, isLoading }: ResetPasswordFormProps) {
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+            className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 hover:text-gray-700"
           >
             {showPassword ? (
               <EyeOffIcon className="h-4 w-4" />

--- a/src/components/BookingDialog/BookingDialog.stories.tsx
+++ b/src/components/BookingDialog/BookingDialog.stories.tsx
@@ -119,7 +119,7 @@ function ServiceSelectDemoWrapper() {
         onChange={setSelected}
         placeholder="Select services..."
       />
-      <p className="mt-2 text-sm text-muted-foreground">
+      <p className="text-muted-foreground mt-2 text-sm">
         Selected: {selected.join(', ') || 'None'}
       </p>
     </div>

--- a/src/components/BookingDialog/BookingDialog.stories.tsx
+++ b/src/components/BookingDialog/BookingDialog.stories.tsx
@@ -119,7 +119,7 @@ function ServiceSelectDemoWrapper() {
         onChange={setSelected}
         placeholder="Select services..."
       />
-      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+      <p className="mt-2 text-sm text-muted-foreground">
         Selected: {selected.join(', ') || 'None'}
       </p>
     </div>

--- a/src/components/BookingDialog/BookingDialog.tsx
+++ b/src/components/BookingDialog/BookingDialog.tsx
@@ -288,7 +288,7 @@ export function ConsentSwitch({
         data-slot="consent-switch-toggle"
         className={cn(
           'focus:ring-primary-500 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none',
-          checked ? 'bg-primary-600' : 'bg-muted'
+          checked ? 'bg-primary-800' : 'bg-muted'
         )}
       >
         <span
@@ -653,7 +653,7 @@ export function BookingDialog({
               disabled={isLoading}
               data-slot="booking-dialog-footer-btn"
               className={cn(
-                'bg-primary-700 hover:bg-primary-800 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors',
+                'bg-primary-800 hover:bg-primary-900 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors',
                 isLoading && 'cursor-not-allowed opacity-50'
               )}
             >
@@ -785,7 +785,7 @@ export function InlineBookingForm({
         disabled={isLoading}
         data-slot="inline-booking-form-submit"
         className={cn(
-          'bg-primary-700 hover:bg-primary-800 w-full rounded-lg px-4 py-3 text-sm font-medium text-white transition-colors',
+          'bg-primary-800 hover:bg-primary-900 w-full rounded-lg px-4 py-3 text-sm font-medium text-white transition-colors',
           isLoading && 'cursor-not-allowed opacity-50'
         )}
       >
@@ -847,7 +847,7 @@ export function QuickBookCard({
         <button
           type="button"
           onClick={onBook}
-          className="bg-primary-700 hover:bg-primary-800 inline-flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
+          className="bg-primary-800 hover:bg-primary-900 inline-flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
           data-slot="quick-book-card-btn"
         >
           <CalendarIcon className="h-4 w-4" />

--- a/src/components/BookingDialog/BookingDialog.tsx
+++ b/src/components/BookingDialog/BookingDialog.tsx
@@ -232,7 +232,7 @@ export function ServiceSelect({
                 type="checkbox"
                 checked={selectedServices.includes(service.slug)}
                 onChange={() => toggleService(service.slug)}
-                className="text-primary-600 focus:ring-primary-500 border-input h-4 w-4 rounded"
+                className="text-primary-800 focus:ring-primary-500 border-input h-4 w-4 rounded"
               />
               <span className="text-foreground">{service.name}</span>
             </label>
@@ -516,7 +516,7 @@ export function BookingDialog({
               href={mapsUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-primary-600 text-muted-foreground text-sm"
+              className="hover:text-primary-800 text-muted-foreground text-sm"
               data-slot="booking-dialog-provider-address"
             >
               {provider.address.street1}

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -186,7 +186,7 @@ export const WithCustomLink: Story = {
       renderLink={(item) => (
         <a
           href={item.href}
-          className="text-primary-500 hover:text-primary-600 text-sm underline"
+          className="text-primary-800 hover:text-primary-800 text-sm underline"
         >
           {item.label}
         </a>

--- a/src/components/BusinessHours/BusinessHours.stories.tsx
+++ b/src/components/BusinessHours/BusinessHours.stories.tsx
@@ -137,15 +137,11 @@ export const Compact: StoryObj<typeof CompactHours> = {
   render: () => (
     <div className="space-y-4">
       <div className="rounded-lg border p-4 dark:border-gray-700">
-        <p className="mb-2 text-sm text-muted-foreground">
-          Standard hours
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Standard hours</p>
         <CompactHours schedule={standardSchedule} />
       </div>
       <div className="rounded-lg border p-4 dark:border-gray-700">
-        <p className="mb-2 text-sm text-muted-foreground">
-          No hours available
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">No hours available</p>
         <CompactHours schedule={{}} />
       </div>
     </div>

--- a/src/components/BusinessHours/BusinessHours.stories.tsx
+++ b/src/components/BusinessHours/BusinessHours.stories.tsx
@@ -137,13 +137,13 @@ export const Compact: StoryObj<typeof CompactHours> = {
   render: () => (
     <div className="space-y-4">
       <div className="rounded-lg border p-4 dark:border-gray-700">
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Standard hours
         </p>
         <CompactHours schedule={standardSchedule} />
       </div>
       <div className="rounded-lg border p-4 dark:border-gray-700">
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           No hours available
         </p>
         <CompactHours schedule={{}} />

--- a/src/components/BusinessHours/BusinessHours.tsx
+++ b/src/components/BusinessHours/BusinessHours.tsx
@@ -367,7 +367,7 @@ function TimeRangeDisplay({ range, use24Hour = false }: TimeRangeDisplayProps) {
         'Hours vary'
       )}
       {range.description && (
-        <span className="mt-0.5 block text-xs text-neutral-500 dark:text-neutral-400">
+        <span className="mt-0.5 block text-xs text-muted-foreground">
           {range.description}
         </span>
       )}
@@ -428,7 +428,7 @@ function DayScheduleRow({
             <TimeRangeDisplay key={idx} range={range} use24Hour={use24Hour} />
           ))
         ) : (
-          <span className="text-neutral-500 dark:text-neutral-400">Closed</span>
+          <span className="text-muted-foreground">Closed</span>
         )}
       </div>
     </div>
@@ -595,7 +595,7 @@ export function BusinessHours({
         {schedule.timezone && (
           <p
             data-slot="business-hours-timezone"
-            className="mt-3 text-xs text-neutral-500 dark:text-neutral-400"
+            className="mt-3 text-xs text-muted-foreground"
           >
             All times are in {schedule.timezone}
           </p>

--- a/src/components/BusinessHours/BusinessHours.tsx
+++ b/src/components/BusinessHours/BusinessHours.tsx
@@ -367,7 +367,7 @@ function TimeRangeDisplay({ range, use24Hour = false }: TimeRangeDisplayProps) {
         'Hours vary'
       )}
       {range.description && (
-        <span className="mt-0.5 block text-xs text-muted-foreground">
+        <span className="text-muted-foreground mt-0.5 block text-xs">
           {range.description}
         </span>
       )}
@@ -595,7 +595,7 @@ export function BusinessHours({
         {schedule.timezone && (
           <p
             data-slot="business-hours-timezone"
-            className="mt-3 text-xs text-muted-foreground"
+            className="text-muted-foreground mt-3 text-xs"
           >
             All times are in {schedule.timezone}
           </p>

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
@@ -275,7 +275,7 @@ export function BusinessHoursEditor({
             {hours.length === 0 ? (
               <p
                 data-slot="business-hours-closed"
-                className="text-sm text-gray-500 italic dark:text-gray-400"
+                className="text-muted-foreground text-sm italic"
               >
                 Closed
               </p>

--- a/src/components/CSVColumnMapper/CSVColumnMapper.tsx
+++ b/src/components/CSVColumnMapper/CSVColumnMapper.tsx
@@ -109,7 +109,7 @@ export function CSVColumnMapper({
             data-slot="csv-mapper-progress"
             className="bg-card text-card-foreground w-full max-w-lg rounded-lg shadow-xl"
           >
-            <div className="bg-primary-800 text-white p-4">
+            <div className="bg-primary-800 p-4 text-white">
               <h4 className="text-lg font-semibold">Processing Employees</h4>
             </div>
             <div className="p-6">
@@ -527,7 +527,7 @@ export function CSVFileUpload({
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
-            className="bg-primary-800 text-white hover:bg-primary-900 rounded-lg px-6 py-3"
+            className="bg-primary-800 hover:bg-primary-900 rounded-lg px-6 py-3 text-white"
           >
             {selectButton}
           </button>

--- a/src/components/CSVColumnMapper/CSVColumnMapper.tsx
+++ b/src/components/CSVColumnMapper/CSVColumnMapper.tsx
@@ -109,7 +109,7 @@ export function CSVColumnMapper({
             data-slot="csv-mapper-progress"
             className="bg-card text-card-foreground w-full max-w-lg rounded-lg shadow-xl"
           >
-            <div className="bg-primary text-primary-foreground p-4">
+            <div className="bg-primary-800 text-white p-4">
               <h4 className="text-lg font-semibold">Processing Employees</h4>
             </div>
             <div className="p-6">
@@ -527,7 +527,7 @@ export function CSVFileUpload({
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
-            className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg px-6 py-3"
+            className="bg-primary-800 text-white hover:bg-primary-900 rounded-lg px-6 py-3"
           >
             {selectButton}
           </button>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -441,7 +441,7 @@ const CardCollapsible = React.forwardRef<HTMLDivElement, CardCollapsibleProps>(
         <button
           type="button"
           onClick={handleToggle}
-          className="text-primary-600 focus-visible:ring-primary-500 flex items-center gap-1 rounded text-sm hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          className="text-primary-800 focus-visible:ring-primary-500 flex items-center gap-1 rounded text-sm hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
           aria-expanded={expanded}
         >
           {typeof trigger === 'string' ? (
@@ -509,7 +509,7 @@ const CardStat = React.forwardRef<HTMLDivElement, CardStatProps>(
         {...props}
       >
         {icon && (
-          <div className="bg-primary-500/10 text-primary-600 rounded-lg p-2">
+          <div className="bg-primary-500/10 text-primary-800 rounded-lg p-2">
             {icon}
           </div>
         )}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -56,7 +56,7 @@ const cardVariants = cva(
 const cardAccentVariants = cva('absolute left-0 top-0 bottom-0 w-1', {
   variants: {
     color: {
-      primary: 'bg-primary-500',
+      primary: 'bg-primary-800',
       success: 'bg-success',
       warning: 'bg-warning',
       destructive: 'bg-destructive',
@@ -135,9 +135,9 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         {loading && (
           <div className="bg-card/80 absolute inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
             <div className="flex gap-1">
-              <div className="bg-primary-500 h-2 w-2 animate-bounce rounded-full [animation-delay:-0.3s]" />
-              <div className="bg-primary-500 h-2 w-2 animate-bounce rounded-full [animation-delay:-0.15s]" />
-              <div className="bg-primary-500 h-2 w-2 animate-bounce rounded-full" />
+              <div className="bg-primary-800 h-2 w-2 animate-bounce rounded-full [animation-delay:-0.3s]" />
+              <div className="bg-primary-800 h-2 w-2 animate-bounce rounded-full [animation-delay:-0.15s]" />
+              <div className="bg-primary-800 h-2 w-2 animate-bounce rounded-full" />
             </div>
           </div>
         )}
@@ -308,7 +308,7 @@ const CardBadge = React.forwardRef<HTMLSpanElement, CardBadgeProps>(
   ) => {
     const variantClasses = {
       default: 'bg-muted text-muted-foreground',
-      primary: 'bg-primary-500 text-white',
+      primary: 'bg-primary-800 text-white',
       success: 'bg-success text-success-foreground',
       warning: 'bg-warning text-warning-foreground',
       destructive: 'bg-destructive text-destructive-foreground',

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,8 +11,8 @@ const checkboxVariants = cva(
     'cursor-pointer',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
     'disabled:cursor-not-allowed disabled:opacity-50',
-    'checked:bg-primary-500 checked:border-primary-500',
-    'indeterminate:bg-primary-500 indeterminate:border-primary-500',
+    'checked:bg-primary-800 checked:border-primary-500',
+    'indeterminate:bg-primary-800 indeterminate:border-primary-500',
   ],
   {
     variants: {

--- a/src/components/ClaimProviderForm/ClaimProviderForm.tsx
+++ b/src/components/ClaimProviderForm/ClaimProviderForm.tsx
@@ -282,7 +282,7 @@ export function ClaimProviderForm({
               />
               <span
                 data-slot="claim-form-terms-text"
-                className="text-sm text-gray-600 dark:text-gray-400"
+                className="text-sm text-muted-foreground"
               >
                 I agree to the{' '}
                 <a

--- a/src/components/ClaimProviderForm/ClaimProviderForm.tsx
+++ b/src/components/ClaimProviderForm/ClaimProviderForm.tsx
@@ -282,7 +282,7 @@ export function ClaimProviderForm({
               />
               <span
                 data-slot="claim-form-terms-text"
-                className="text-sm text-muted-foreground"
+                className="text-muted-foreground text-sm"
               >
                 I agree to the{' '}
                 <a

--- a/src/components/Colors/Colors.stories.tsx
+++ b/src/components/Colors/Colors.stories.tsx
@@ -503,7 +503,7 @@ function ColorsPage() {
                 </h3>
                 <pre className="bg-muted text-foreground overflow-x-auto rounded-lg p-4 font-mono">
                   {`<!-- Semantic tokens -->
-<div className="bg-primary-500 text-foreground border border-border">
+<div className="bg-primary-800 text-foreground border border-border">
 
 <!-- Full status scales for subtle backgrounds -->
 <div className="bg-destructive-50 text-destructive-700 border border-destructive-200">

--- a/src/components/CommandPalette/CommandPalette.stories.tsx
+++ b/src/components/CommandPalette/CommandPalette.stories.tsx
@@ -130,7 +130,7 @@ function CommandPaletteDemo() {
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-muted-foreground text-sm">
         Press{' '}
         <kbd className="rounded bg-gray-100 px-2 py-1 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
           ⌘K
@@ -292,7 +292,7 @@ function PlaygroundDemo(props: React.ComponentProps<typeof CommandPalette>) {
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-muted-foreground text-sm">
         Press{' '}
         <kbd className="rounded bg-gray-100 px-2 py-1 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
           ⌘K

--- a/src/components/CommandPalette/CommandPalette.stories.tsx
+++ b/src/components/CommandPalette/CommandPalette.stories.tsx
@@ -130,7 +130,7 @@ function CommandPaletteDemo() {
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-muted-foreground">
         Press{' '}
         <kbd className="rounded bg-gray-100 px-2 py-1 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
           ⌘K
@@ -292,7 +292,7 @@ function PlaygroundDemo(props: React.ComponentProps<typeof CommandPalette>) {
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-muted-foreground">
         Press{' '}
         <kbd className="rounded bg-gray-100 px-2 py-1 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
           ⌘K

--- a/src/components/CommandPalette/CommandPalette.stories.tsx
+++ b/src/components/CommandPalette/CommandPalette.stories.tsx
@@ -166,7 +166,7 @@ function CustomTriggerDemo() {
   return (
     <button
       onClick={open}
-      className="bg-primary-500 hover:bg-primary-600 rounded-lg px-4 py-2 text-white transition-colors"
+      className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white transition-colors"
     >
       Open Search
     </button>

--- a/src/components/CommandPalette/CommandPalette.stories.tsx
+++ b/src/components/CommandPalette/CommandPalette.stories.tsx
@@ -18,7 +18,7 @@ const sampleCategories: CommandPaletteCategory[] = [
     id: 'pages',
     label: 'Pages',
     icon: <span>📄</span>,
-    colorClass: 'text-primary-500',
+    colorClass: 'text-primary-800',
   },
   {
     id: 'users',

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -291,7 +291,7 @@ export function CommandPalette({
             data-slot="command-palette-search"
             className="relative border-b border-gray-200 dark:border-gray-700"
           >
-            <div className="absolute top-1/2 left-4 -translate-y-1/2 text-gray-500">
+            <div className="text-muted-foreground absolute top-1/2 left-4 -translate-y-1/2">
               <SearchIcon />
             </div>
             <input
@@ -313,7 +313,7 @@ export function CommandPalette({
               <button
                 onClick={() => setQuery('')}
                 data-testid={`${testId}-clear`}
-                className="absolute top-1/2 right-12 -translate-y-1/2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-200"
+                className="text-muted-foreground absolute top-1/2 right-12 -translate-y-1/2 hover:text-gray-700 dark:hover:text-gray-200"
               >
                 <XIcon />
               </button>
@@ -338,7 +338,7 @@ export function CommandPalette({
                   'rounded px-2 py-1 text-xs font-medium transition-colors',
                   activeCategory === null
                     ? 'bg-primary-800 text-white'
-                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+                    : 'text-muted-foreground hover:bg-gray-100 dark:hover:bg-gray-700'
                 )}
               >
                 All
@@ -352,7 +352,7 @@ export function CommandPalette({
                     'flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors',
                     activeCategory === cat.id
                       ? 'bg-primary-800 text-white'
-                      : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+                      : 'text-muted-foreground hover:bg-gray-100 dark:hover:bg-gray-700'
                   )}
                 >
                   {cat.icon && <span className="h-3 w-3">{cat.icon}</span>}
@@ -471,7 +471,7 @@ export function CommandPalette({
                                   'mt-0.5 h-4 w-4 flex-shrink-0',
                                   isSelected
                                     ? 'text-primary-800 dark:text-primary-300'
-                                    : 'text-gray-500'
+                                    : 'text-muted-foreground'
                                 )}
                               >
                                 {item.icon}
@@ -520,7 +520,7 @@ export function CommandPalette({
               data-slot="command-palette-footer"
               className={cn(
                 'border-t border-gray-100 p-2 dark:border-gray-700',
-                'bg-gray-50 text-xs text-gray-500 dark:bg-gray-900/50 dark:text-gray-400',
+                'text-muted-foreground bg-gray-50 text-xs dark:bg-gray-900/50',
                 'flex items-center justify-between'
               )}
             >
@@ -577,7 +577,7 @@ export function CommandPaletteTrigger({
       data-slot="command-palette-trigger"
       className={cn(
         'flex items-center gap-3 rounded-lg border border-gray-300 dark:border-gray-400',
-        'bg-white px-4 py-2.5 text-sm text-gray-500 dark:bg-gray-700 dark:text-gray-300',
+        'text-muted-foreground bg-white px-4 py-2.5 text-sm dark:bg-gray-700',
         'hover:border-gray-400 dark:hover:border-gray-300',
         'transition-colors hover:bg-gray-50 dark:hover:bg-gray-600',
         'min-w-[200px] sm:min-w-[300px]',

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -371,7 +371,7 @@ export function CommandPalette({
             {filteredItems.length === 0 ? (
               <div
                 data-slot="command-palette-empty"
-                className="p-8 text-center text-gray-500 dark:text-gray-400"
+                className="p-8 text-center text-muted-foreground"
               >
                 {emptyState ?? (
                   <>
@@ -397,7 +397,7 @@ export function CommandPalette({
                         data-slot="command-palette-group"
                         className={cn(
                           'sticky top-0 px-3 py-2 text-xs font-semibold',
-                          'text-gray-500 dark:text-gray-400',
+                          'text-muted-foreground',
                           'bg-gray-50 dark:bg-gray-900/50'
                         )}
                       >
@@ -482,12 +482,12 @@ export function CommandPalette({
                                 {item.label}
                               </div>
                               {item.subtitle && (
-                                <div className="truncate text-xs text-gray-500 dark:text-gray-400">
+                                <div className="truncate text-xs text-muted-foreground">
                                   {item.subtitle}
                                 </div>
                               )}
                               {item.description && (
-                                <div className="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">
+                                <div className="mt-0.5 truncate text-xs text-muted-foreground">
                                   {item.description}
                                 </div>
                               )}
@@ -498,7 +498,7 @@ export function CommandPalette({
                                   'hidden items-center px-1.5 py-0.5 text-[10px] sm:inline-flex',
                                   'rounded border bg-gray-100 dark:bg-gray-700',
                                   'border-gray-200 dark:border-gray-600',
-                                  'text-gray-600 dark:text-gray-400'
+                                  'text-muted-foreground'
                                 )}
                               >
                                 {item.shortcut}

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -459,7 +459,7 @@ export function CommandPalette({
                             className={cn(
                               'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors',
                               isSelected
-                                ? 'bg-primary-50 dark:bg-primary-500/20'
+                                ? 'bg-primary-50 dark:bg-primary-900/20'
                                 : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
                               item.disabled && 'cursor-not-allowed opacity-50'
                             )}

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -319,7 +319,7 @@ export function CommandPalette({
               </button>
             )}
             {isLoading && (
-              <div className="text-primary-500 absolute top-1/2 right-4 -translate-y-1/2">
+              <div className="text-primary-800 absolute top-1/2 right-4 -translate-y-1/2">
                 <SpinnerIcon />
               </div>
             )}

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -371,7 +371,7 @@ export function CommandPalette({
             {filteredItems.length === 0 ? (
               <div
                 data-slot="command-palette-empty"
-                className="p-8 text-center text-muted-foreground"
+                className="text-muted-foreground p-8 text-center"
               >
                 {emptyState ?? (
                   <>
@@ -482,12 +482,12 @@ export function CommandPalette({
                                 {item.label}
                               </div>
                               {item.subtitle && (
-                                <div className="truncate text-xs text-muted-foreground">
+                                <div className="text-muted-foreground truncate text-xs">
                                   {item.subtitle}
                                 </div>
                               )}
                               {item.description && (
-                                <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                                <div className="text-muted-foreground mt-0.5 truncate text-xs">
                                   {item.description}
                                 </div>
                               )}

--- a/src/components/ConnectionStatus/ConnectionStatus.stories.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.stories.tsx
@@ -124,9 +124,7 @@ function InteractiveDemo() {
           Connection Status Demo
         </h3>
         <div className="mb-4 flex items-center gap-4">
-          <span className="text-sm text-muted-foreground">
-            Status:
-          </span>
+          <span className="text-muted-foreground text-sm">Status:</span>
           <ConnectionStatusBadge status={connection.status} />
         </div>
         <label className="flex items-center gap-2">

--- a/src/components/ConnectionStatus/ConnectionStatus.stories.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof ConnectionStatusOverlay> = {
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             App Content
           </h1>
-          <p className="text-gray-600 dark:text-gray-400">
+          <p className="text-muted-foreground">
             The connection status overlay will appear on top of this content.
           </p>
         </div>
@@ -124,7 +124,7 @@ function InteractiveDemo() {
           Connection Status Demo
         </h3>
         <div className="mb-4 flex items-center gap-4">
-          <span className="text-sm text-gray-600 dark:text-gray-400">
+          <span className="text-sm text-muted-foreground">
             Status:
           </span>
           <ConnectionStatusBadge status={connection.status} />

--- a/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -139,12 +139,12 @@ export function ConnectionStatusOverlay({
           {/* Content */}
           <div data-slot="connection-overlay-content" className="flex-1">
             <p className="text-gray-700 dark:text-gray-300">{displayMessage}</p>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-muted-foreground">
               Please check your internet connection.
             </p>
             {connection.retryCount !== undefined &&
               connection.retryCount > 0 && (
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-xs text-muted-foreground">
                   Retry attempt #{connection.retryCount}
                   {retryTimeFormatted && ` • Retrying ${retryTimeFormatted}`}
                 </p>
@@ -245,7 +245,7 @@ export function UpdateAvailableOverlay({
             <p className="font-semibold text-gray-900 dark:text-white">
               Update Available
             </p>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            <p className="mt-1 text-sm text-muted-foreground">
               There is an update available for {appName}.
               {update.version && ` Version ${update.version}`}
             </p>

--- a/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -250,7 +250,7 @@ export function UpdateAvailableOverlay({
               {update.version && ` Version ${update.version}`}
             </p>
             {update.description && (
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
+              <p className="text-muted-foreground mt-1 text-xs">
                 {update.description}
               </p>
             )}

--- a/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -139,12 +139,12 @@ export function ConnectionStatusOverlay({
           {/* Content */}
           <div data-slot="connection-overlay-content" className="flex-1">
             <p className="text-gray-700 dark:text-gray-300">{displayMessage}</p>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="text-muted-foreground mt-1 text-sm">
               Please check your internet connection.
             </p>
             {connection.retryCount !== undefined &&
               connection.retryCount > 0 && (
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="text-muted-foreground mt-1 text-xs">
                   Retry attempt #{connection.retryCount}
                   {retryTimeFormatted && ` • Retrying ${retryTimeFormatted}`}
                 </p>
@@ -245,7 +245,7 @@ export function UpdateAvailableOverlay({
             <p className="font-semibold text-gray-900 dark:text-white">
               Update Available
             </p>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="text-muted-foreground mt-1 text-sm">
               There is an update available for {appName}.
               {update.version && ` Version ${update.version}`}
             </p>

--- a/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -157,7 +157,7 @@ export function ConnectionStatusOverlay({
               type="button"
               data-slot="connection-overlay-action"
               onClick={onReload || (() => window.location.reload())}
-              className="bg-primary-700 hover:bg-primary-800 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
+              className="bg-primary-800 hover:bg-primary-900 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
             >
               <ReloadIcon className="h-4 w-4" />
               Reload

--- a/src/components/CookieConsent/CookieConsent.stories.tsx
+++ b/src/components/CookieConsent/CookieConsent.stories.tsx
@@ -160,7 +160,7 @@ function InteractiveDemo() {
         <h3 className="mb-2 font-medium text-gray-900 dark:text-white">
           Consent Status
         </h3>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Has consented: <strong>{hasConsented ? 'Yes' : 'No'}</strong>
         </p>
         <button

--- a/src/components/CookieConsent/CookieConsent.stories.tsx
+++ b/src/components/CookieConsent/CookieConsent.stories.tsx
@@ -90,7 +90,7 @@ const meta: Meta<typeof CookieConsentBanner> = {
           <h1 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
             Welcome to BlueHive
           </h1>
-          <p className="text-gray-600 dark:text-gray-400">
+          <p className="text-muted-foreground">
             Page content to demonstrate the cookie consent banner.
           </p>
         </div>
@@ -160,7 +160,7 @@ function InteractiveDemo() {
         <h3 className="mb-2 font-medium text-gray-900 dark:text-white">
           Consent Status
         </h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+        <p className="text-sm text-muted-foreground">
           Has consented: <strong>{hasConsented ? 'Yes' : 'No'}</strong>
         </p>
         <button

--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -223,7 +223,7 @@ export function CookieConsentBanner({
                 className={cn(
                   'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                   variant === 'default'
-                    ? 'text-gray-600 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200'
+                    ? 'text-muted-foreground hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-gray-700 dark:hover:text-gray-200'
                     : 'text-white/80 hover:bg-white/10 hover:text-white'
                 )}
               >
@@ -238,7 +238,7 @@ export function CookieConsentBanner({
                 className={cn(
                   'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                   variant === 'default'
-                    ? 'text-gray-600 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200'
+                    ? 'text-muted-foreground hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-gray-700 dark:hover:text-gray-200'
                     : 'text-white/80 hover:bg-white/10 hover:text-white'
                 )}
               >

--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -181,7 +181,7 @@ export function CookieConsentBanner({
               className={cn(
                 'text-xs',
                 variant === 'default'
-                  ? 'text-gray-600 dark:text-gray-400'
+                  ? 'text-muted-foreground'
                   : 'text-white/80'
               )}
             >

--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -252,7 +252,7 @@ export function CookieConsentBanner({
               className={cn(
                 'inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                 variant === 'default'
-                  ? 'bg-primary-700 hover:bg-primary-800 text-white'
+                  ? 'bg-primary-800 hover:bg-primary-900 text-white'
                   : 'bg-white text-gray-900 hover:bg-gray-100'
               )}
             >

--- a/src/components/CountBadge/CountBadge.tsx
+++ b/src/components/CountBadge/CountBadge.tsx
@@ -380,13 +380,13 @@ function HoverMenu({
         <table className="w-full text-left text-xs">
           <thead>
             <tr className="border-b border-neutral-100 dark:border-neutral-700">
-              <th className="px-3 py-1.5 font-medium text-muted-foreground">
+              <th className="text-muted-foreground px-3 py-1.5 font-medium">
                 #
               </th>
-              <th className="px-3 py-1.5 font-medium text-muted-foreground">
+              <th className="text-muted-foreground px-3 py-1.5 font-medium">
                 Label
               </th>
-              <th className="px-3 py-1.5 font-medium text-muted-foreground">
+              <th className="text-muted-foreground px-3 py-1.5 font-medium">
                 Status
               </th>
               <th className="w-8 px-1 py-1.5">

--- a/src/components/CountBadge/CountBadge.tsx
+++ b/src/components/CountBadge/CountBadge.tsx
@@ -380,13 +380,13 @@ function HoverMenu({
         <table className="w-full text-left text-xs">
           <thead>
             <tr className="border-b border-neutral-100 dark:border-neutral-700">
-              <th className="px-3 py-1.5 font-medium text-neutral-500 dark:text-neutral-400">
+              <th className="px-3 py-1.5 font-medium text-muted-foreground">
                 #
               </th>
-              <th className="px-3 py-1.5 font-medium text-neutral-500 dark:text-neutral-400">
+              <th className="px-3 py-1.5 font-medium text-muted-foreground">
                 Label
               </th>
-              <th className="px-3 py-1.5 font-medium text-neutral-500 dark:text-neutral-400">
+              <th className="px-3 py-1.5 font-medium text-muted-foreground">
                 Status
               </th>
               <th className="w-8 px-1 py-1.5">
@@ -414,7 +414,7 @@ function HoverMenu({
                         statusDotColor[item.status]
                       )}
                     />
-                    <span className="text-neutral-600 dark:text-neutral-400">
+                    <span className="text-muted-foreground">
                       {statusLabel[item.status]}
                     </span>
                   </span>

--- a/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
+++ b/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
@@ -431,7 +431,7 @@ function CountryCodeDropdown({
                   </span>
                   <span
                     data-slot="country-dropdown-option-dialcode"
-                    className="shrink-0 text-xs text-muted-foreground"
+                    className="text-muted-foreground shrink-0 text-xs"
                   >
                     {country.dialCode}
                   </span>

--- a/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
+++ b/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
@@ -431,7 +431,7 @@ function CountryCodeDropdown({
                   </span>
                   <span
                     data-slot="country-dropdown-option-dialcode"
-                    className="shrink-0 text-xs text-neutral-500 dark:text-neutral-400"
+                    className="shrink-0 text-xs text-muted-foreground"
                   >
                     {country.dialCode}
                   </span>

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -636,7 +636,7 @@ function NotificationsDropdown() {
             className="hover:bg-muted/50 flex w-full items-start gap-3 p-4 text-left transition-colors"
           >
             <div
-              className={`mt-1 h-2 w-2 rounded-full ${notification.unread ? 'bg-primary-500' : 'bg-transparent'}`}
+              className={`mt-1 h-2 w-2 rounded-full ${notification.unread ? 'bg-primary-800' : 'bg-transparent'}`}
             />
             <div className="min-w-0 flex-1">
               <Text
@@ -715,7 +715,7 @@ function Sidebar({ currentPage, onNavigate }: SidebarProps) {
     <SidebarComponent>
       <SidebarHeader>
         <div className="flex items-center gap-2">
-          <div className="bg-primary-500 flex h-8 w-8 items-center justify-center rounded-lg font-bold text-white">
+          <div className="bg-primary-800 flex h-8 w-8 items-center justify-center rounded-lg font-bold text-white">
             M
           </div>
           <Text weight="bold" size="lg">
@@ -1154,7 +1154,7 @@ function AnalyticsPage() {
               {[65, 45, 80, 55, 70, 90, 75].map((height, i) => (
                 <div
                   key={i}
-                  className="bg-primary-500 hover:bg-primary-600 w-8 rounded-t transition-all"
+                  className="bg-primary-800 hover:bg-primary-900 w-8 rounded-t transition-all"
                   style={{ height: `${height}%` }}
                 />
               ))}
@@ -1984,7 +1984,7 @@ function AppShell() {
       <div className="bg-background flex min-h-screen items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
-            <div className="bg-primary-500 mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg text-xl font-bold text-white">
+            <div className="bg-primary-800 mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg text-xl font-bold text-white">
               M
             </div>
             <CardTitle>You&apos;ve been logged out</CardTitle>

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -1664,7 +1664,7 @@ function VoiceNotesPage() {
                 <div
                   className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${
                     note.status === 'transcribing'
-                      ? 'bg-primary-100 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400'
+                      ? 'bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-400'
                       : 'bg-muted text-muted-foreground'
                   }`}
                 >

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -432,7 +432,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   day === null && 'invisible',
                   day !== null && 'hover:bg-muted',
                   isSelectedDay(day!) &&
-                    'bg-primary-800 hover:bg-primary-700 text-white',
+                    'bg-primary-800 hover:bg-primary-900 text-white',
                   isToday(day!) &&
                     !isSelectedDay(day!) &&
                     'border-primary-800 text-primary-800 border'

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -666,8 +666,7 @@ export function DateRangePicker({
                     className={cn(
                       'rounded-md px-3 py-1.5 text-left text-sm transition-colors',
                       'hover:bg-muted',
-                      activePreset === preset.key &&
-                        'bg-primary-800 text-white'
+                      activePreset === preset.key && 'bg-primary-800 text-white'
                     )}
                   >
                     {preset.label}

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -667,7 +667,7 @@ export function DateRangePicker({
                       'rounded-md px-3 py-1.5 text-left text-sm transition-colors',
                       'hover:bg-muted',
                       activePreset === preset.key &&
-                        'bg-primary text-primary-foreground'
+                        'bg-primary-800 text-white'
                     )}
                   >
                     {preset.label}

--- a/src/components/DocumentScanner/DocumentScanner.tsx
+++ b/src/components/DocumentScanner/DocumentScanner.tsx
@@ -351,7 +351,7 @@ export function DocumentScanner({
               className="bg-primary-100 dark:bg-primary-900/30 flex h-14 w-14 items-center justify-center rounded-full"
               data-slot="doc-scanner-upload-icon"
             >
-              <UploadIcon className="text-primary-600 dark:text-primary-400 h-7 w-7" />
+              <UploadIcon className="text-primary-800 dark:text-primary-400 h-7 w-7" />
             </div>
 
             <div className="space-y-1">

--- a/src/components/DocumentScanner/DropZone.tsx
+++ b/src/components/DocumentScanner/DropZone.tsx
@@ -176,7 +176,7 @@ export function DropZone({
               'pointer-events-none'
             )}
           >
-            <span className="text-primary-600 dark:text-primary-400 text-lg font-medium">
+            <span className="text-primary-800 dark:text-primary-400 text-lg font-medium">
               Drop files here
             </span>
           </div>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -523,7 +523,7 @@ function Dropdown({
                   filteredChildren
                 ) : (
                   <div
-                    className="px-3 py-4 text-center text-sm text-neutral-500 dark:text-neutral-400"
+                    className="px-3 py-4 text-center text-sm text-muted-foreground"
                     data-slot="dropdown-empty"
                   >
                     {searchEmptyState}
@@ -596,7 +596,7 @@ const DropdownHeader = React.forwardRef<HTMLDivElement, DropdownHeaderProps>(
             </p>
             {subtitle && (
               <p
-                className="truncate text-xs text-neutral-500 dark:text-neutral-400"
+                className="truncate text-xs text-muted-foreground"
                 data-slot="dropdown-header-subtitle"
               >
                 {subtitle}
@@ -858,7 +858,7 @@ function DropdownLabel({
       data-slot="dropdown-label"
       className={cn(
         'px-3 py-1.5 text-xs font-semibold tracking-wider uppercase',
-        'text-neutral-500 dark:text-neutral-400',
+        'text-muted-foreground',
         className
       )}
     >

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -669,7 +669,7 @@ function DropdownItemCheckbox({
       className={cn(
         'flex h-4 w-4 shrink-0 items-center justify-center rounded border-2 transition-colors duration-150',
         checked || indeterminate
-          ? 'border-primary-500 bg-primary-500 text-white'
+          ? 'border-primary-500 bg-primary-800 text-white'
           : 'border-input bg-background text-transparent'
       )}
     >

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -523,7 +523,7 @@ function Dropdown({
                   filteredChildren
                 ) : (
                   <div
-                    className="px-3 py-4 text-center text-sm text-muted-foreground"
+                    className="text-muted-foreground px-3 py-4 text-center text-sm"
                     data-slot="dropdown-empty"
                   >
                     {searchEmptyState}
@@ -596,7 +596,7 @@ const DropdownHeader = React.forwardRef<HTMLDivElement, DropdownHeaderProps>(
             </p>
             {subtitle && (
               <p
-                className="truncate text-xs text-muted-foreground"
+                className="text-muted-foreground truncate text-xs"
                 data-slot="dropdown-header-subtitle"
               >
                 {subtitle}

--- a/src/components/EmployeeForm/EmployeeForm.tsx
+++ b/src/components/EmployeeForm/EmployeeForm.tsx
@@ -533,7 +533,7 @@ export function EmployeeForm({
           )}
           <button
             type="submit"
-            className="bg-primary-700 hover:bg-primary-800 rounded-md px-4 py-2 text-sm text-white"
+            className="bg-primary-800 hover:bg-primary-900 rounded-md px-4 py-2 text-sm text-white"
             data-slot="employee-form-submit"
           >
             {mode === 'order' ? startOrder : save}

--- a/src/components/EmployeeProfile/EmployeeProfile.tsx
+++ b/src/components/EmployeeProfile/EmployeeProfile.tsx
@@ -204,7 +204,7 @@ export function EmployeeProfileCard({
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
-                className="bg-primary text-primary-foreground hover:bg-primary/90 absolute right-0 bottom-0 rounded-full p-1.5 shadow-md transition-colors"
+                className="bg-primary-800 text-white hover:bg-primary-900 absolute right-0 bottom-0 rounded-full p-1.5 shadow-md transition-colors"
                 aria-label="Edit photo"
                 data-slot="employee-card-photo-edit"
               >
@@ -472,7 +472,7 @@ export function OrderSidebarTabs({
             'px-4 py-2 text-sm font-medium transition-colors',
             'focus-visible:ring-ring focus:outline-none focus-visible:ring-2',
             activeTab === tab.id
-              ? 'bg-primary text-primary-foreground'
+              ? 'bg-primary-800 text-white'
               : 'text-muted-foreground hover:text-foreground hover:bg-muted'
           )}
         >

--- a/src/components/EmployeeProfile/EmployeeProfile.tsx
+++ b/src/components/EmployeeProfile/EmployeeProfile.tsx
@@ -204,7 +204,7 @@ export function EmployeeProfileCard({
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
-                className="bg-primary-800 text-white hover:bg-primary-900 absolute right-0 bottom-0 rounded-full p-1.5 shadow-md transition-colors"
+                className="bg-primary-800 hover:bg-primary-900 absolute right-0 bottom-0 rounded-full p-1.5 text-white shadow-md transition-colors"
                 aria-label="Edit photo"
                 data-slot="employee-card-photo-edit"
               >

--- a/src/components/EmployerContactCard/EmployerContactCard.tsx
+++ b/src/components/EmployerContactCard/EmployerContactCard.tsx
@@ -102,7 +102,7 @@ export function EmployerContactCard({
         {contacts.length === 0 ? (
           <div data-slot="employer-contact-empty" className="py-6 text-center">
             <svg
-              className="mx-auto mb-2 h-10 w-10 text-gray-400 dark:text-gray-600"
+              className="mx-auto mb-2 h-10 w-10 text-muted-foreground dark:text-muted-foreground"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -114,7 +114,7 @@ export function EmployerContactCard({
                 d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
               />
             </svg>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm text-muted-foreground">
               No contacts added yet
             </p>
             {showActions && onAddContact && (
@@ -158,7 +158,7 @@ export function EmployerContactCard({
                     )}
                   </div>
                   {contact.role && (
-                    <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                    <p className="truncate text-xs text-muted-foreground">
                       {contact.role}
                     </p>
                   )}

--- a/src/components/EmployerContactCard/EmployerContactCard.tsx
+++ b/src/components/EmployerContactCard/EmployerContactCard.tsx
@@ -174,7 +174,7 @@ export function EmployerContactCard({
                           e.stopPropagation();
                           onEmail(contact);
                         }}
-                        className="rounded p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        className="hover:text-muted-foreground rounded p-1.5 text-gray-400 dark:hover:text-gray-300"
                         title={`Email ${contact.name}`}
                       >
                         <svg
@@ -198,7 +198,7 @@ export function EmployerContactCard({
                           e.stopPropagation();
                           onCall(contact);
                         }}
-                        className="rounded p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        className="hover:text-muted-foreground rounded p-1.5 text-gray-400 dark:hover:text-gray-300"
                         title={`Call ${contact.name}`}
                       >
                         <svg

--- a/src/components/EmployerContactCard/EmployerContactCard.tsx
+++ b/src/components/EmployerContactCard/EmployerContactCard.tsx
@@ -102,7 +102,7 @@ export function EmployerContactCard({
         {contacts.length === 0 ? (
           <div data-slot="employer-contact-empty" className="py-6 text-center">
             <svg
-              className="mx-auto mb-2 h-10 w-10 text-muted-foreground dark:text-muted-foreground"
+              className="text-muted-foreground dark:text-muted-foreground mx-auto mb-2 h-10 w-10"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -114,7 +114,7 @@ export function EmployerContactCard({
                 d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
               />
             </svg>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               No contacts added yet
             </p>
             {showActions && onAddContact && (
@@ -158,7 +158,7 @@ export function EmployerContactCard({
                     )}
                   </div>
                   {contact.role && (
-                    <p className="truncate text-xs text-muted-foreground">
+                    <p className="text-muted-foreground truncate text-xs">
                       {contact.role}
                     </p>
                   )}

--- a/src/components/EmployerList/EmployerList.tsx
+++ b/src/components/EmployerList/EmployerList.tsx
@@ -157,7 +157,7 @@ export function EmployerList({
           className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700"
         >
           <svg
-            className="mx-auto mb-3 h-12 w-12 text-gray-400 dark:text-gray-600"
+            className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -169,7 +169,7 @@ export function EmployerList({
               d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
             />
           </svg>
-          <p className="mb-3 text-gray-500 dark:text-gray-400">
+          <p className="mb-3 text-muted-foreground">
             {emptyMessage}
           </p>
           {onAddEmployer && !searchQuery && (
@@ -230,12 +230,12 @@ export function EmployerList({
                   </div>
                   <div className="mt-0.5 flex items-center gap-4">
                     {employer.email && (
-                      <span className="truncate text-sm text-gray-500 dark:text-gray-400">
+                      <span className="truncate text-sm text-muted-foreground">
                         {employer.email}
                       </span>
                     )}
                     {employer.linkedDate && (
-                      <span className="text-xs text-gray-400 dark:text-gray-500">
+                      <span className="text-xs text-muted-foreground">
                         Linked {formatDate(employer.linkedDate)}
                       </span>
                     )}
@@ -252,7 +252,7 @@ export function EmployerList({
                       <p className="text-lg font-bold text-gray-900 dark:text-white">
                         {employer.activeEmployees}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-xs text-muted-foreground">
                         Employees
                       </p>
                     </div>
@@ -264,7 +264,7 @@ export function EmployerList({
                       >
                         {employer.pendingOrders}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-xs text-muted-foreground">
                         Pending
                       </p>
                     </div>

--- a/src/components/EmployerList/EmployerList.tsx
+++ b/src/components/EmployerList/EmployerList.tsx
@@ -157,7 +157,7 @@ export function EmployerList({
           className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700"
         >
           <svg
-            className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -169,9 +169,7 @@ export function EmployerList({
               d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
             />
           </svg>
-          <p className="mb-3 text-muted-foreground">
-            {emptyMessage}
-          </p>
+          <p className="text-muted-foreground mb-3">{emptyMessage}</p>
           {onAddEmployer && !searchQuery && (
             <Button variant="outline" onClick={onAddEmployer}>
               Link Employer
@@ -230,12 +228,12 @@ export function EmployerList({
                   </div>
                   <div className="mt-0.5 flex items-center gap-4">
                     {employer.email && (
-                      <span className="truncate text-sm text-muted-foreground">
+                      <span className="text-muted-foreground truncate text-sm">
                         {employer.email}
                       </span>
                     )}
                     {employer.linkedDate && (
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-muted-foreground text-xs">
                         Linked {formatDate(employer.linkedDate)}
                       </span>
                     )}
@@ -252,9 +250,7 @@ export function EmployerList({
                       <p className="text-lg font-bold text-gray-900 dark:text-white">
                         {employer.activeEmployees}
                       </p>
-                      <p className="text-xs text-muted-foreground">
-                        Employees
-                      </p>
+                      <p className="text-muted-foreground text-xs">Employees</p>
                     </div>
                   )}
                   {employer.pendingOrders !== undefined && (
@@ -264,9 +260,7 @@ export function EmployerList({
                       >
                         {employer.pendingOrders}
                       </p>
-                      <p className="text-xs text-muted-foreground">
-                        Pending
-                      </p>
+                      <p className="text-muted-foreground text-xs">Pending</p>
                     </div>
                   )}
                 </div>

--- a/src/components/EmployerPricingCard/EmployerPricingCard.tsx
+++ b/src/components/EmployerPricingCard/EmployerPricingCard.tsx
@@ -90,7 +90,7 @@ export function EmployerPricingCard({
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
             {formatPrice(basePrice)}
           </p>
-          <p className="text-xs text-muted-foreground">base price</p>
+          <p className="text-muted-foreground text-xs">base price</p>
         </div>
       </CardHeader>
 

--- a/src/components/EmployerPricingCard/EmployerPricingCard.tsx
+++ b/src/components/EmployerPricingCard/EmployerPricingCard.tsx
@@ -98,7 +98,7 @@ export function EmployerPricingCard({
         {/* Pricing tiers */}
         {tiers.length > 0 && (
           <div data-slot="employer-pricing-tiers" className="mt-3 space-y-2">
-            <p className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+            <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
               Volume Pricing
             </p>
             <div className="space-y-1">
@@ -109,7 +109,7 @@ export function EmployerPricingCard({
                   className="flex items-center justify-between rounded bg-gray-50 px-2 py-1.5 dark:bg-gray-800/50"
                 >
                   <div className="flex items-center gap-2">
-                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                    <span className="text-muted-foreground text-sm">
                       {tier.name}
                     </span>
                     <span className="text-xs text-gray-400">

--- a/src/components/EmployerPricingCard/EmployerPricingCard.tsx
+++ b/src/components/EmployerPricingCard/EmployerPricingCard.tsx
@@ -90,7 +90,7 @@ export function EmployerPricingCard({
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
             {formatPrice(basePrice)}
           </p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">base price</p>
+          <p className="text-xs text-muted-foreground">base price</p>
         </div>
       </CardHeader>
 

--- a/src/components/EmployerView/EmployerView.tsx
+++ b/src/components/EmployerView/EmployerView.tsx
@@ -163,7 +163,7 @@ export function EmployerView({
                   data-slot="employer-view-logo"
                   className="flex h-16 w-16 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800"
                 >
-                  <span className="text-2xl font-bold text-muted-foreground">
+                  <span className="text-muted-foreground text-2xl font-bold">
                     {employer.name.charAt(0)}
                   </span>
                 </div>
@@ -177,7 +177,7 @@ export function EmployerView({
                     {employer.status}
                   </Badge>
                 </div>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Linked since {formatDate(employer.linkedDate)}
                 </p>
                 {employer.address && (
@@ -208,41 +208,31 @@ export function EmployerView({
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {employer.stats.totalOrders}
                 </p>
-                <p className="text-sm text-muted-foreground">
-                  Total Orders
-                </p>
+                <p className="text-muted-foreground text-sm">Total Orders</p>
               </div>
               <div className="text-center">
                 <p className="text-2xl font-bold text-green-600 dark:text-green-400">
                   {employer.stats.completedOrders}
                 </p>
-                <p className="text-sm text-muted-foreground">
-                  Completed
-                </p>
+                <p className="text-muted-foreground text-sm">Completed</p>
               </div>
               <div className="text-center">
                 <p className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
                   {employer.stats.pendingOrders}
                 </p>
-                <p className="text-sm text-muted-foreground">
-                  Pending
-                </p>
+                <p className="text-muted-foreground text-sm">Pending</p>
               </div>
               <div className="text-center">
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {formatCurrency(employer.stats.totalRevenue)}
                 </p>
-                <p className="text-sm text-muted-foreground">
-                  Total Revenue
-                </p>
+                <p className="text-muted-foreground text-sm">Total Revenue</p>
               </div>
               <div className="text-center">
                 <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">
                   {formatCurrency(employer.stats.outstandingBalance)}
                 </p>
-                <p className="text-sm text-muted-foreground">
-                  Outstanding
-                </p>
+                <p className="text-muted-foreground text-sm">Outstanding</p>
               </div>
             </div>
           )}
@@ -303,7 +293,7 @@ export function EmployerView({
                             {primary.name}
                           </p>
                           {primary.role && (
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-muted-foreground text-sm">
                               {primary.role}
                             </p>
                           )}
@@ -342,7 +332,7 @@ export function EmployerView({
             </CardHeader>
             <CardContent>
               {employer.recentOrders.length === 0 ? (
-                <p className="py-8 text-center text-muted-foreground">
+                <p className="text-muted-foreground py-8 text-center">
                   No orders yet
                 </p>
               ) : (
@@ -360,7 +350,7 @@ export function EmployerView({
                         <p className="text-sm text-gray-600 dark:text-gray-300">
                           {order.patientName}
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-muted-foreground text-xs">
                           {order.services.join(', ')}
                         </p>
                       </div>
@@ -368,7 +358,7 @@ export function EmployerView({
                         <Badge variant={getStatusVariant(order.status)}>
                           {order.status}
                         </Badge>
-                        <p className="mt-1 text-xs text-muted-foreground">
+                        <p className="text-muted-foreground mt-1 text-xs">
                           {formatDate(order.createdDate)}
                         </p>
                       </div>
@@ -402,7 +392,7 @@ export function EmployerView({
             </CardHeader>
             <CardContent>
               {employer.recentInvoices.length === 0 ? (
-                <p className="py-8 text-center text-muted-foreground">
+                <p className="text-muted-foreground py-8 text-center">
                   No invoices yet
                 </p>
               ) : (
@@ -454,7 +444,7 @@ export function EmployerView({
             </CardHeader>
             <CardContent>
               {employer.contacts.length === 0 ? (
-                <p className="py-8 text-center text-muted-foreground">
+                <p className="text-muted-foreground py-8 text-center">
                   No contacts added
                 </p>
               ) : (
@@ -477,7 +467,7 @@ export function EmployerView({
                             )}
                           </div>
                           {contact.role && (
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-muted-foreground text-sm">
                               {contact.role}
                             </p>
                           )}
@@ -485,7 +475,7 @@ export function EmployerView({
                             {contact.email}
                           </p>
                           {contact.phone && (
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-muted-foreground text-sm">
                               {contact.phone}
                             </p>
                           )}

--- a/src/components/EmployerView/EmployerView.tsx
+++ b/src/components/EmployerView/EmployerView.tsx
@@ -181,7 +181,7 @@ export function EmployerView({
                   Linked since {formatDate(employer.linkedDate)}
                 </p>
                 {employer.address && (
-                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                  <p className="text-muted-foreground text-sm">
                     {employer.address.city}, {employer.address.state}
                   </p>
                 )}
@@ -297,7 +297,7 @@ export function EmployerView({
                               {primary.role}
                             </p>
                           )}
-                          <p className="text-sm text-gray-600 dark:text-gray-300">
+                          <p className="text-muted-foreground text-sm">
                             {primary.email}
                           </p>
                         </div>
@@ -347,7 +347,7 @@ export function EmployerView({
                         <p className="font-medium text-gray-900 dark:text-white">
                           {order.orderNumber}
                         </p>
-                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                        <p className="text-muted-foreground text-sm">
                           {order.patientName}
                         </p>
                         <p className="text-muted-foreground text-xs">
@@ -407,7 +407,7 @@ export function EmployerView({
                         <p className="font-medium text-gray-900 dark:text-white">
                           {invoice.invoiceNumber}
                         </p>
-                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                        <p className="text-muted-foreground text-sm">
                           Due: {formatDate(invoice.dueDate)}
                         </p>
                       </div>
@@ -471,7 +471,7 @@ export function EmployerView({
                               {contact.role}
                             </p>
                           )}
-                          <p className="text-sm text-gray-600 dark:text-gray-300">
+                          <p className="text-muted-foreground text-sm">
                             {contact.email}
                           </p>
                           {contact.phone && (

--- a/src/components/EmployerView/EmployerView.tsx
+++ b/src/components/EmployerView/EmployerView.tsx
@@ -163,7 +163,7 @@ export function EmployerView({
                   data-slot="employer-view-logo"
                   className="flex h-16 w-16 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800"
                 >
-                  <span className="text-2xl font-bold text-gray-500 dark:text-gray-400">
+                  <span className="text-2xl font-bold text-muted-foreground">
                     {employer.name.charAt(0)}
                   </span>
                 </div>
@@ -177,7 +177,7 @@ export function EmployerView({
                     {employer.status}
                   </Badge>
                 </div>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   Linked since {formatDate(employer.linkedDate)}
                 </p>
                 {employer.address && (
@@ -208,7 +208,7 @@ export function EmployerView({
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {employer.stats.totalOrders}
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   Total Orders
                 </p>
               </div>
@@ -216,7 +216,7 @@ export function EmployerView({
                 <p className="text-2xl font-bold text-green-600 dark:text-green-400">
                   {employer.stats.completedOrders}
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   Completed
                 </p>
               </div>
@@ -224,7 +224,7 @@ export function EmployerView({
                 <p className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
                   {employer.stats.pendingOrders}
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   Pending
                 </p>
               </div>
@@ -232,7 +232,7 @@ export function EmployerView({
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {formatCurrency(employer.stats.totalRevenue)}
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   Total Revenue
                 </p>
               </div>
@@ -240,7 +240,7 @@ export function EmployerView({
                 <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">
                   {formatCurrency(employer.stats.outstandingBalance)}
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   Outstanding
                 </p>
               </div>
@@ -303,7 +303,7 @@ export function EmployerView({
                             {primary.name}
                           </p>
                           {primary.role && (
-                            <p className="text-sm text-gray-500 dark:text-gray-400">
+                            <p className="text-sm text-muted-foreground">
                               {primary.role}
                             </p>
                           )}
@@ -342,7 +342,7 @@ export function EmployerView({
             </CardHeader>
             <CardContent>
               {employer.recentOrders.length === 0 ? (
-                <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+                <p className="py-8 text-center text-muted-foreground">
                   No orders yet
                 </p>
               ) : (
@@ -360,7 +360,7 @@ export function EmployerView({
                         <p className="text-sm text-gray-600 dark:text-gray-300">
                           {order.patientName}
                         </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                        <p className="text-xs text-muted-foreground">
                           {order.services.join(', ')}
                         </p>
                       </div>
@@ -368,7 +368,7 @@ export function EmployerView({
                         <Badge variant={getStatusVariant(order.status)}>
                           {order.status}
                         </Badge>
-                        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        <p className="mt-1 text-xs text-muted-foreground">
                           {formatDate(order.createdDate)}
                         </p>
                       </div>
@@ -402,7 +402,7 @@ export function EmployerView({
             </CardHeader>
             <CardContent>
               {employer.recentInvoices.length === 0 ? (
-                <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+                <p className="py-8 text-center text-muted-foreground">
                   No invoices yet
                 </p>
               ) : (
@@ -454,7 +454,7 @@ export function EmployerView({
             </CardHeader>
             <CardContent>
               {employer.contacts.length === 0 ? (
-                <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+                <p className="py-8 text-center text-muted-foreground">
                   No contacts added
                 </p>
               ) : (
@@ -477,7 +477,7 @@ export function EmployerView({
                             )}
                           </div>
                           {contact.role && (
-                            <p className="text-sm text-gray-500 dark:text-gray-400">
+                            <p className="text-sm text-muted-foreground">
                               {contact.role}
                             </p>
                           )}
@@ -485,7 +485,7 @@ export function EmployerView({
                             {contact.email}
                           </p>
                           {contact.phone && (
-                            <p className="text-sm text-gray-500 dark:text-gray-400">
+                            <p className="text-sm text-muted-foreground">
                               {contact.phone}
                             </p>
                           )}

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -190,7 +190,7 @@ export function ErrorPage({
 
       {/* Description */}
       <p
-        className="mb-8 max-w-md text-muted-foreground"
+        className="text-muted-foreground mb-8 max-w-md"
         data-slot="error-page-description"
       >
         {displayDescription}

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -399,7 +399,7 @@ export function MaintenancePage({
           href={statusUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-primary-600 hover:text-primary-700 text-sm font-medium"
+          className="text-primary-800 hover:text-primary-900 text-sm font-medium"
         >
           Check Status Page →
         </a>

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -173,7 +173,7 @@ export function ErrorPage({
       {/* Error Code */}
       {displayCode && (
         <div
-          className="mb-4 text-6xl font-bold text-gray-300 sm:text-8xl dark:text-gray-600"
+          className="dark:text-muted-foreground mb-4 text-6xl font-bold text-gray-300 sm:text-8xl"
           data-slot="error-page-code"
         >
           {displayCode}
@@ -305,7 +305,7 @@ export function ServerErrorPage({
                 {errorMessage}
               </p>
               {errorStack && (
-                <pre className="overflow-x-auto rounded bg-gray-50 p-2 text-xs text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+                <pre className="text-muted-foreground overflow-x-auto rounded bg-gray-50 p-2 text-xs dark:bg-gray-900">
                   {errorStack}
                 </pre>
               )}
@@ -492,7 +492,7 @@ interface DefaultIllustrationProps {
 }
 
 function DefaultIllustration({ type }: DefaultIllustrationProps) {
-  const iconClasses = 'h-24 w-24 text-gray-300 dark:text-gray-600';
+  const iconClasses = 'h-24 w-24 text-gray-300 dark:text-muted-foreground';
 
   switch (type) {
     case '404':

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -190,7 +190,7 @@ export function ErrorPage({
 
       {/* Description */}
       <p
-        className="mb-8 max-w-md text-gray-600 dark:text-gray-400"
+        className="mb-8 max-w-md text-muted-foreground"
         data-slot="error-page-description"
       >
         {displayDescription}

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -249,7 +249,7 @@ export function FileManager({
             <p className="text-muted-foreground text-sm font-medium">
               {isDragging ? 'Drop files here' : 'Add File'}
             </p>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
+            <p className="text-muted-foreground mt-1 text-xs">
               Click or drag and drop
             </p>
             <input
@@ -299,7 +299,7 @@ export function FileManager({
               {formatFileSize(totalStorageUsed)}
             </span>
             {storageLimit && (
-              <span className="text-gray-500">
+              <span className="text-muted-foreground">
                 {' '}
                 / {formatFileSize(storageLimit)}
               </span>
@@ -336,7 +336,7 @@ export function FileManager({
                     </div>
                   </TableCell>
                   <TableCell className="text-center">
-                    <span className="text-xs text-gray-500 uppercase dark:text-gray-400">
+                    <span className="text-muted-foreground text-xs uppercase">
                       {file.fileExtension.replace('.', '')}
                     </span>
                   </TableCell>
@@ -366,7 +366,7 @@ export function FileManager({
                 <TableCell colSpan={hasActions ? 4 : 3} className="py-8">
                   <div data-slot="file-manager-empty" className="text-center">
                     <svg
-                      className="mx-auto mb-3 h-12 w-12 text-gray-300 dark:text-gray-600"
+                      className="dark:text-muted-foreground mx-auto mb-3 h-12 w-12 text-gray-300"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -246,7 +246,7 @@ export function FileManager({
                 />
               </svg>
             </div>
-            <p className="text-sm font-medium text-muted-foreground">
+            <p className="text-muted-foreground text-sm font-medium">
               {isDragging ? 'Drop files here' : 'Add File'}
             </p>
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
@@ -267,7 +267,7 @@ export function FileManager({
       {/* Upload Progress */}
       {isUploading && uploadProgress !== undefined && (
         <div data-slot="file-manager-progress" className="mb-4">
-          <div className="mb-2 flex items-center justify-between text-sm text-muted-foreground">
+          <div className="text-muted-foreground mb-2 flex items-center justify-between text-sm">
             <span>Uploading...</span>
             <span>{uploadProgress}%</span>
           </div>
@@ -293,7 +293,7 @@ export function FileManager({
           data-slot="file-manager-storage"
           className="mb-4 rounded-lg bg-gray-50 p-3 text-center dark:bg-gray-800"
         >
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Used Storage:{' '}
             <span className="font-semibold text-gray-900 dark:text-white">
               {formatFileSize(totalStorageUsed)}
@@ -341,7 +341,7 @@ export function FileManager({
                     </span>
                   </TableCell>
                   <TableCell className="text-center">
-                    <span className="text-sm text-muted-foreground">
+                    <span className="text-muted-foreground text-sm">
                       {formatFileSize(file.fileSize)}
                     </span>
                   </TableCell>
@@ -378,10 +378,10 @@ export function FileManager({
                         d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
                       />
                     </svg>
-                    <p className="text-sm font-medium text-muted-foreground">
+                    <p className="text-muted-foreground text-sm font-medium">
                       No Files
                     </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
+                    <p className="text-muted-foreground mt-1 text-xs">
                       Upload files to get started
                     </p>
                   </div>

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -246,7 +246,7 @@ export function FileManager({
                 />
               </svg>
             </div>
-            <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            <p className="text-sm font-medium text-muted-foreground">
               {isDragging ? 'Drop files here' : 'Add File'}
             </p>
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
@@ -267,7 +267,7 @@ export function FileManager({
       {/* Upload Progress */}
       {isUploading && uploadProgress !== undefined && (
         <div data-slot="file-manager-progress" className="mb-4">
-          <div className="mb-2 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+          <div className="mb-2 flex items-center justify-between text-sm text-muted-foreground">
             <span>Uploading...</span>
             <span>{uploadProgress}%</span>
           </div>
@@ -293,7 +293,7 @@ export function FileManager({
           data-slot="file-manager-storage"
           className="mb-4 rounded-lg bg-gray-50 p-3 text-center dark:bg-gray-800"
         >
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Used Storage:{' '}
             <span className="font-semibold text-gray-900 dark:text-white">
               {formatFileSize(totalStorageUsed)}
@@ -341,7 +341,7 @@ export function FileManager({
                     </span>
                   </TableCell>
                   <TableCell className="text-center">
-                    <span className="text-sm text-gray-600 dark:text-gray-400">
+                    <span className="text-sm text-muted-foreground">
                       {formatFileSize(file.fileSize)}
                     </span>
                   </TableCell>
@@ -378,10 +378,10 @@ export function FileManager({
                         d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
                       />
                     </svg>
-                    <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                    <p className="text-sm font-medium text-muted-foreground">
                       No Files
                     </p>
-                    <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Upload files to get started
                     </p>
                   </div>

--- a/src/components/HRISProviderSelector/HRISProviderSelector.tsx
+++ b/src/components/HRISProviderSelector/HRISProviderSelector.tsx
@@ -177,7 +177,7 @@ export function HRISProviderSelector({
             <button
               type="button"
               onClick={onRefreshSync}
-              className="bg-primary hover:bg-primary-900 rounded-lg px-4 py-2 text-white"
+              className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white"
               data-slot="hris-connected-btn-primary"
             >
               <i className="fas fa-rotate mr-2" />

--- a/src/components/HRISProviderSelector/HRISProviderSelector.tsx
+++ b/src/components/HRISProviderSelector/HRISProviderSelector.tsx
@@ -177,7 +177,7 @@ export function HRISProviderSelector({
             <button
               type="button"
               onClick={onRefreshSync}
-              className="bg-primary hover:bg-primary/90 rounded-lg px-4 py-2 text-white"
+              className="bg-primary hover:bg-primary-900 rounded-lg px-4 py-2 text-white"
               data-slot="hris-connected-btn-primary"
             >
               <i className="fas fa-rotate mr-2" />

--- a/src/components/HelpSupportPanel/HelpSupportPanel.tsx
+++ b/src/components/HelpSupportPanel/HelpSupportPanel.tsx
@@ -148,7 +148,7 @@ export function HelpSupportPanel({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Help & Support
           </h1>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Find answers or get in touch with our support team
           </p>
         </div>
@@ -215,7 +215,7 @@ export function HelpSupportPanel({
 
                 {/* FAQ List */}
                 {filteredFaqs.length === 0 ? (
-                  <p className="py-4 text-center text-muted-foreground">
+                  <p className="text-muted-foreground py-4 text-center">
                     No FAQs match your search
                   </p>
                 ) : (
@@ -396,7 +396,7 @@ export function HelpSupportPanel({
                         </p>
                       )}
                       {contact.availability && (
-                        <p className="mt-1 text-xs text-muted-foreground">
+                        <p className="text-muted-foreground mt-1 text-xs">
                           {contact.availability}
                         </p>
                       )}

--- a/src/components/HelpSupportPanel/HelpSupportPanel.tsx
+++ b/src/components/HelpSupportPanel/HelpSupportPanel.tsx
@@ -148,7 +148,7 @@ export function HelpSupportPanel({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Help & Support
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Find answers or get in touch with our support team
           </p>
         </div>
@@ -215,7 +215,7 @@ export function HelpSupportPanel({
 
                 {/* FAQ List */}
                 {filteredFaqs.length === 0 ? (
-                  <p className="py-4 text-center text-gray-500 dark:text-gray-400">
+                  <p className="py-4 text-center text-muted-foreground">
                     No FAQs match your search
                   </p>
                 ) : (
@@ -369,7 +369,7 @@ export function HelpSupportPanel({
                     data-slot="help-support-contact-item"
                     className="flex items-start gap-3 rounded-lg bg-gray-50 p-3 dark:bg-gray-800"
                   >
-                    <div className="text-gray-500 dark:text-gray-400">
+                    <div className="text-muted-foreground">
                       {getContactIcon(contact.type)}
                     </div>
                     <div>
@@ -396,7 +396,7 @@ export function HelpSupportPanel({
                         </p>
                       )}
                       {contact.availability && (
-                        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        <p className="mt-1 text-xs text-muted-foreground">
                           {contact.availability}
                         </p>
                       )}

--- a/src/components/HelpSupportPanel/HelpSupportPanel.tsx
+++ b/src/components/HelpSupportPanel/HelpSupportPanel.tsx
@@ -255,7 +255,7 @@ export function HelpSupportPanel({
                         </button>
                         {expandedFaq === faq.id && (
                           <div className="border-t border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
-                            <p className="text-gray-600 dark:text-gray-300">
+                            <p className="text-muted-foreground">
                               {faq.answer}
                             </p>
                           </div>
@@ -391,7 +391,7 @@ export function HelpSupportPanel({
                           {contact.value}
                         </a>
                       ) : (
-                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                        <p className="text-muted-foreground text-sm">
                           {contact.value}
                         </p>
                       )}

--- a/src/components/Icons/Icons.stories.tsx
+++ b/src/components/Icons/Icons.stories.tsx
@@ -228,7 +228,7 @@ function IconCard({ name, Icon }: IconCardProps) {
       className="border-border bg-card hover:bg-muted/50 hover:border-primary-300 group flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border p-4 transition-all"
       title={`Click to copy import for ${name}`}
     >
-      <Icon className="text-foreground group-hover:text-primary-500 h-6 w-6 transition-colors" />
+      <Icon className="text-foreground group-hover:text-primary-800 h-6 w-6 transition-colors" />
       <span className="text-muted-foreground group-hover:text-foreground text-center text-xs break-all transition-colors">
         {copied ? '✓ Copied!' : name.replace('Icon', '')}
       </span>
@@ -454,7 +454,7 @@ function MyComponent() {
                 {`<HomeIcon className="h-4 w-4" />           {/* 16px */}
 <HomeIcon className="h-5 w-5" />           {/* 20px - default */}
 <HomeIcon className="h-6 w-6" />           {/* 24px */}
-<HomeIcon className="text-primary-500" />  {/* Brand color */}
+<HomeIcon className="text-primary-800" />  {/* Brand color */}
 <HomeIcon className="text-muted-foreground" /> {/* Muted */}`}
               </pre>
             </div>

--- a/src/components/InventoryManager/InventoryManager.tsx
+++ b/src/components/InventoryManager/InventoryManager.tsx
@@ -311,7 +311,7 @@ export function InventoryManager({
               onClick={() => setUpdateType('debit')}
               className={`rounded-l-md border px-4 py-2 text-sm font-medium transition-colors ${
                 updateType === 'debit'
-                  ? 'border-primary bg-primary text-primary-foreground'
+                  ? 'border-primary bg-primary-800 text-white'
                   : 'border-input bg-card text-foreground hover:bg-muted'
               } `}
             >
@@ -335,7 +335,7 @@ export function InventoryManager({
               onClick={() => setUpdateType('credit')}
               className={`rounded-r-md border-t border-r border-b px-4 py-2 text-sm font-medium transition-colors ${
                 updateType === 'credit'
-                  ? 'border-primary bg-primary text-primary-foreground'
+                  ? 'border-primary bg-primary-800 text-white'
                   : 'border-input bg-card text-foreground hover:bg-muted'
               } `}
             >

--- a/src/components/InvoiceList/InvoiceList.tsx
+++ b/src/components/InvoiceList/InvoiceList.tsx
@@ -224,7 +224,7 @@ export function InvoiceList({
           data-slot="invoice-list-summary-item"
           className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800"
         >
-          <p className="text-xs text-muted-foreground">Total</p>
+          <p className="text-muted-foreground text-xs">Total</p>
           <p className="text-lg font-bold text-gray-900 dark:text-white">
             {formatCurrency(totals.total)}
           </p>
@@ -258,7 +258,7 @@ export function InvoiceList({
           className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700"
         >
           <svg
-            className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -270,7 +270,7 @@ export function InvoiceList({
               d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
             />
           </svg>
-          <p className="mb-3 text-muted-foreground">
+          <p className="text-muted-foreground mb-3">
             {searchQuery || statusFilter !== 'all'
               ? 'No invoices match your filters'
               : 'No invoices yet'}
@@ -331,7 +331,7 @@ export function InvoiceList({
                     </p>
                   </td>
                   <td className="hidden px-4 py-3 md:table-cell">
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-muted-foreground text-sm">
                       {formatDate(invoice.issuedDate)}
                     </p>
                   </td>

--- a/src/components/InvoiceList/InvoiceList.tsx
+++ b/src/components/InvoiceList/InvoiceList.tsx
@@ -224,7 +224,7 @@ export function InvoiceList({
           data-slot="invoice-list-summary-item"
           className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800"
         >
-          <p className="text-xs text-gray-500 dark:text-gray-400">Total</p>
+          <p className="text-xs text-muted-foreground">Total</p>
           <p className="text-lg font-bold text-gray-900 dark:text-white">
             {formatCurrency(totals.total)}
           </p>
@@ -258,7 +258,7 @@ export function InvoiceList({
           className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700"
         >
           <svg
-            className="mx-auto mb-3 h-12 w-12 text-gray-400 dark:text-gray-600"
+            className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -270,7 +270,7 @@ export function InvoiceList({
               d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
             />
           </svg>
-          <p className="mb-3 text-gray-500 dark:text-gray-400">
+          <p className="mb-3 text-muted-foreground">
             {searchQuery || statusFilter !== 'all'
               ? 'No invoices match your filters'
               : 'No invoices yet'}
@@ -331,13 +331,13 @@ export function InvoiceList({
                     </p>
                   </td>
                   <td className="hidden px-4 py-3 md:table-cell">
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                    <p className="text-sm text-muted-foreground">
                       {formatDate(invoice.issuedDate)}
                     </p>
                   </td>
                   <td className="hidden px-4 py-3 md:table-cell">
                     <p
-                      className={`text-sm ${invoice.status === 'overdue' ? 'font-medium text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}`}
+                      className={`text-sm ${invoice.status === 'overdue' ? 'font-medium text-red-600 dark:text-red-400' : 'text-muted-foreground'}`}
                     >
                       {formatDate(invoice.dueDate)}
                     </p>

--- a/src/components/InvoiceList/InvoiceList.tsx
+++ b/src/components/InvoiceList/InvoiceList.tsx
@@ -190,7 +190,7 @@ export function InvoiceList({
                 className={`px-3 py-2 text-sm font-medium transition-colors ${
                   statusFilter === option.value
                     ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
-                    : 'text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800'
+                    : 'text-muted-foreground hover:bg-gray-50 dark:hover:bg-gray-800'
                 } `}
               >
                 {option.label}
@@ -289,22 +289,22 @@ export function InvoiceList({
           <table className="w-full">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                <th className="text-muted-foreground px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                   Invoice
                 </th>
-                <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase sm:table-cell dark:text-gray-400">
+                <th className="text-muted-foreground hidden px-4 py-3 text-left text-xs font-medium tracking-wider uppercase sm:table-cell">
                   Employer
                 </th>
-                <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase md:table-cell dark:text-gray-400">
+                <th className="text-muted-foreground hidden px-4 py-3 text-left text-xs font-medium tracking-wider uppercase md:table-cell">
                   Issued
                 </th>
-                <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase md:table-cell dark:text-gray-400">
+                <th className="text-muted-foreground hidden px-4 py-3 text-left text-xs font-medium tracking-wider uppercase md:table-cell">
                   Due
                 </th>
-                <th className="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                <th className="text-muted-foreground px-4 py-3 text-right text-xs font-medium tracking-wider uppercase">
                   Amount
                 </th>
-                <th className="px-4 py-3 text-center text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                <th className="text-muted-foreground px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
                   Status
                 </th>
               </tr>
@@ -321,7 +321,7 @@ export function InvoiceList({
                     <p className="font-medium text-gray-900 dark:text-white">
                       {invoice.invoiceNumber}
                     </p>
-                    <p className="text-xs text-gray-500 sm:hidden dark:text-gray-400">
+                    <p className="text-muted-foreground text-xs sm:hidden">
                       {invoice.employerName}
                     </p>
                   </td>

--- a/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
+++ b/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
@@ -162,7 +162,7 @@ export function InvoicePaymentPage({
         >
           <CardContent className="py-12">
             <svg
-              className="mx-auto mb-4 h-16 w-16 text-gray-400 dark:text-gray-600"
+              className="mx-auto mb-4 h-16 w-16 text-muted-foreground dark:text-muted-foreground"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -177,7 +177,7 @@ export function InvoicePaymentPage({
             <h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
               Invoice Not Found
             </h2>
-            <p className="text-gray-500 dark:text-gray-400">
+            <p className="text-muted-foreground">
               The invoice you&apos;re looking for doesn&apos;t exist or has
               expired.
             </p>
@@ -219,11 +219,11 @@ export function InvoicePaymentPage({
             <h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
               Payment Successful
             </h2>
-            <p className="mb-4 text-gray-500 dark:text-gray-400">
+            <p className="mb-4 text-muted-foreground">
               {successMessage ||
                 'Thank you! Your payment has been processed successfully.'}
             </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm text-muted-foreground">
               Invoice {invoice.invoiceNumber}
             </p>
           </CardContent>
@@ -272,7 +272,7 @@ export function InvoicePaymentPage({
                 </div>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+                <div className="space-y-1 text-sm text-muted-foreground">
                   <p>Issued: {formatDate(invoice.issuedDate)}</p>
                   <p
                     className={
@@ -292,7 +292,7 @@ export function InvoicePaymentPage({
                 >
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="text-gray-500 dark:text-gray-400">
+                      <tr className="text-muted-foreground">
                         <th className="pb-2 text-left font-medium">Item</th>
                         <th className="pb-2 text-right font-medium">Amount</th>
                       </tr>
@@ -315,14 +315,14 @@ export function InvoicePaymentPage({
                   className="space-y-2 border-t border-gray-200 pt-4 dark:border-gray-700"
                 >
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-500 dark:text-gray-400">
+                    <span className="text-muted-foreground">
                       Subtotal
                     </span>
                     <span>{formatCurrency(invoice.subtotal)}</span>
                   </div>
                   {invoice.tax !== undefined && (
                     <div className="flex justify-between text-sm">
-                      <span className="text-gray-500 dark:text-gray-400">
+                      <span className="text-muted-foreground">
                         Tax
                       </span>
                       <span>{formatCurrency(invoice.tax)}</span>
@@ -490,7 +490,7 @@ export function InvoicePaymentPage({
                   </Button>
 
                   {showStripeBranding && (
-                    <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-center text-xs text-muted-foreground">
                       Secured by Stripe
                     </p>
                   )}

--- a/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
+++ b/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
@@ -365,7 +365,7 @@ export function InvoicePaymentPage({
                           className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${
                             paymentMethod === 'card'
                               ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
-                              : 'text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800'
+                              : 'text-muted-foreground hover:bg-gray-50 dark:hover:bg-gray-800'
                           } `}
                         >
                           Credit Card
@@ -378,7 +378,7 @@ export function InvoicePaymentPage({
                           className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${
                             paymentMethod === 'ach'
                               ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
-                              : 'text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800'
+                              : 'text-muted-foreground hover:bg-gray-50 dark:hover:bg-gray-800'
                           } `}
                         >
                           Bank Transfer

--- a/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
+++ b/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
@@ -162,7 +162,7 @@ export function InvoicePaymentPage({
         >
           <CardContent className="py-12">
             <svg
-              className="mx-auto mb-4 h-16 w-16 text-muted-foreground dark:text-muted-foreground"
+              className="text-muted-foreground dark:text-muted-foreground mx-auto mb-4 h-16 w-16"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -219,11 +219,11 @@ export function InvoicePaymentPage({
             <h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
               Payment Successful
             </h2>
-            <p className="mb-4 text-muted-foreground">
+            <p className="text-muted-foreground mb-4">
               {successMessage ||
                 'Thank you! Your payment has been processed successfully.'}
             </p>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               Invoice {invoice.invoiceNumber}
             </p>
           </CardContent>
@@ -272,7 +272,7 @@ export function InvoicePaymentPage({
                 </div>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="space-y-1 text-sm text-muted-foreground">
+                <div className="text-muted-foreground space-y-1 text-sm">
                   <p>Issued: {formatDate(invoice.issuedDate)}</p>
                   <p
                     className={
@@ -315,16 +315,12 @@ export function InvoicePaymentPage({
                   className="space-y-2 border-t border-gray-200 pt-4 dark:border-gray-700"
                 >
                   <div className="flex justify-between text-sm">
-                    <span className="text-muted-foreground">
-                      Subtotal
-                    </span>
+                    <span className="text-muted-foreground">Subtotal</span>
                     <span>{formatCurrency(invoice.subtotal)}</span>
                   </div>
                   {invoice.tax !== undefined && (
                     <div className="flex justify-between text-sm">
-                      <span className="text-muted-foreground">
-                        Tax
-                      </span>
+                      <span className="text-muted-foreground">Tax</span>
                       <span>{formatCurrency(invoice.tax)}</span>
                     </div>
                   )}
@@ -490,7 +486,7 @@ export function InvoicePaymentPage({
                   </Button>
 
                   {showStripeBranding && (
-                    <p className="text-center text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-center text-xs">
                       Secured by Stripe
                     </p>
                   )}

--- a/src/components/InvoiceView/InvoiceView.tsx
+++ b/src/components/InvoiceView/InvoiceView.tsx
@@ -150,7 +150,7 @@ export function InvoiceView({
                 {invoice.status}
               </Badge>
             </div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm text-muted-foreground">
               Issued {formatDate(invoice.issuedDate)}
             </p>
           </div>
@@ -282,17 +282,17 @@ export function InvoiceView({
                 </h2>
               )}
               {invoice.providerAddress && (
-                <p className="text-sm whitespace-pre-line text-gray-600 dark:text-gray-400">
+                <p className="text-sm whitespace-pre-line text-muted-foreground">
                   {invoice.providerAddress}
                 </p>
               )}
               {invoice.providerPhone && (
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   {invoice.providerPhone}
                 </p>
               )}
               {invoice.providerEmail && (
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-sm text-muted-foreground">
                   {invoice.providerEmail}
                 </p>
               )}
@@ -307,7 +307,7 @@ export function InvoiceView({
               <p className="text-2xl font-bold text-gray-900 dark:text-white">
                 {invoice.invoiceNumber}
               </p>
-              <div className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-400">
+              <div className="mt-2 space-y-1 text-sm text-muted-foreground">
                 <p>
                   <span className="font-medium">Issue Date:</span>{' '}
                   {formatDate(invoice.issuedDate)}
@@ -335,12 +335,12 @@ export function InvoiceView({
               {invoice.employerName}
             </p>
             {invoice.employerAddress && (
-              <p className="text-sm whitespace-pre-line text-gray-600 dark:text-gray-400">
+              <p className="text-sm whitespace-pre-line text-muted-foreground">
                 {invoice.employerAddress}
               </p>
             )}
             {invoice.employerEmail && (
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-muted-foreground">
                 {invoice.employerEmail}
               </p>
             )}
@@ -376,7 +376,7 @@ export function InvoiceView({
                         {item.description}
                       </p>
                       {item.employeeName && (
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                        <p className="text-xs text-muted-foreground">
                           {item.employeeName}
                           {item.date && ` • ${formatDate(item.date)}`}
                         </p>
@@ -401,7 +401,7 @@ export function InvoiceView({
           <div data-slot="invoice-view-totals" className="flex justify-end">
             <div className="w-full space-y-2 sm:w-64">
               <div className="flex justify-between text-sm">
-                <span className="text-gray-600 dark:text-gray-400">
+                <span className="text-muted-foreground">
                   Subtotal
                 </span>
                 <span className="text-gray-900 dark:text-white">
@@ -410,7 +410,7 @@ export function InvoiceView({
               </div>
               {invoice.tax !== undefined && (
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600 dark:text-gray-400">
+                  <span className="text-muted-foreground">
                     Tax {invoice.taxRate && `(${invoice.taxRate}%)`}
                   </span>
                   <span className="text-gray-900 dark:text-white">

--- a/src/components/InvoiceView/InvoiceView.tsx
+++ b/src/components/InvoiceView/InvoiceView.tsx
@@ -150,7 +150,7 @@ export function InvoiceView({
                 {invoice.status}
               </Badge>
             </div>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               Issued {formatDate(invoice.issuedDate)}
             </p>
           </div>
@@ -282,17 +282,17 @@ export function InvoiceView({
                 </h2>
               )}
               {invoice.providerAddress && (
-                <p className="text-sm whitespace-pre-line text-muted-foreground">
+                <p className="text-muted-foreground text-sm whitespace-pre-line">
                   {invoice.providerAddress}
                 </p>
               )}
               {invoice.providerPhone && (
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   {invoice.providerPhone}
                 </p>
               )}
               {invoice.providerEmail && (
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   {invoice.providerEmail}
                 </p>
               )}
@@ -307,7 +307,7 @@ export function InvoiceView({
               <p className="text-2xl font-bold text-gray-900 dark:text-white">
                 {invoice.invoiceNumber}
               </p>
-              <div className="mt-2 space-y-1 text-sm text-muted-foreground">
+              <div className="text-muted-foreground mt-2 space-y-1 text-sm">
                 <p>
                   <span className="font-medium">Issue Date:</span>{' '}
                   {formatDate(invoice.issuedDate)}
@@ -335,12 +335,12 @@ export function InvoiceView({
               {invoice.employerName}
             </p>
             {invoice.employerAddress && (
-              <p className="text-sm whitespace-pre-line text-muted-foreground">
+              <p className="text-muted-foreground text-sm whitespace-pre-line">
                 {invoice.employerAddress}
               </p>
             )}
             {invoice.employerEmail && (
-              <p className="text-sm text-muted-foreground">
+              <p className="text-muted-foreground text-sm">
                 {invoice.employerEmail}
               </p>
             )}
@@ -376,7 +376,7 @@ export function InvoiceView({
                         {item.description}
                       </p>
                       {item.employeeName && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-muted-foreground text-xs">
                           {item.employeeName}
                           {item.date && ` • ${formatDate(item.date)}`}
                         </p>
@@ -401,9 +401,7 @@ export function InvoiceView({
           <div data-slot="invoice-view-totals" className="flex justify-end">
             <div className="w-full space-y-2 sm:w-64">
               <div className="flex justify-between text-sm">
-                <span className="text-muted-foreground">
-                  Subtotal
-                </span>
+                <span className="text-muted-foreground">Subtotal</span>
                 <span className="text-gray-900 dark:text-white">
                   {formatCurrency(invoice.subtotal)}
                 </span>

--- a/src/components/InvoiceView/InvoiceView.tsx
+++ b/src/components/InvoiceView/InvoiceView.tsx
@@ -328,7 +328,7 @@ export function InvoiceView({
 
           {/* Bill To */}
           <div data-slot="invoice-view-bill-to" className="mb-8">
-            <p className="mb-1 text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">
+            <p className="text-muted-foreground mb-1 text-xs font-semibold uppercase">
               Bill To
             </p>
             <p className="font-medium text-gray-900 dark:text-white">
@@ -354,16 +354,16 @@ export function InvoiceView({
             <table className="w-full">
               <thead className="bg-gray-50 dark:bg-gray-800">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase dark:text-gray-400">
+                  <th className="text-muted-foreground px-4 py-3 text-left text-xs font-medium uppercase">
                     Description
                   </th>
-                  <th className="hidden px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase sm:table-cell dark:text-gray-400">
+                  <th className="text-muted-foreground hidden px-4 py-3 text-center text-xs font-medium uppercase sm:table-cell">
                     Qty
                   </th>
-                  <th className="hidden px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase sm:table-cell dark:text-gray-400">
+                  <th className="text-muted-foreground hidden px-4 py-3 text-right text-xs font-medium uppercase sm:table-cell">
                     Unit Price
                   </th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase dark:text-gray-400">
+                  <th className="text-muted-foreground px-4 py-3 text-right text-xs font-medium uppercase">
                     Total
                   </th>
                 </tr>
@@ -435,7 +435,7 @@ export function InvoiceView({
             >
               {invoice.paymentTerms && (
                 <div>
-                  <p className="mb-1 text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">
+                  <p className="text-muted-foreground mb-1 text-xs font-semibold uppercase">
                     Payment Terms
                   </p>
                   <p className="text-sm text-gray-700 dark:text-gray-300">
@@ -445,7 +445,7 @@ export function InvoiceView({
               )}
               {invoice.notes && (
                 <div>
-                  <p className="mb-1 text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">
+                  <p className="text-muted-foreground mb-1 text-xs font-semibold uppercase">
                     Notes
                   </p>
                   <p className="text-sm whitespace-pre-line text-gray-700 dark:text-gray-300">

--- a/src/components/LanguageSelector/LanguageSelector.stories.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.stories.tsx
@@ -234,7 +234,7 @@ export const InHeader: Story = {
             value={value}
             onChange={(language) => setValue(language.code)}
           />
-          <button className="bg-primary-800 text-white rounded-lg px-3 py-1.5 text-sm">
+          <button className="bg-primary-800 rounded-lg px-3 py-1.5 text-sm text-white">
             Sign In
           </button>
         </div>

--- a/src/components/LanguageSelector/LanguageSelector.stories.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.stories.tsx
@@ -234,7 +234,7 @@ export const InHeader: Story = {
             value={value}
             onChange={(language) => setValue(language.code)}
           />
-          <button className="bg-primary text-primary-foreground rounded-lg px-3 py-1.5 text-sm">
+          <button className="bg-primary-800 text-white rounded-lg px-3 py-1.5 text-sm">
             Sign In
           </button>
         </div>

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -67,9 +67,9 @@ const buttonVariants = cva(
         default:
           'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700',
         ghost:
-          'border-transparent bg-transparent text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800',
+          'border-transparent bg-transparent text-muted-foreground hover:bg-gray-100  dark:hover:bg-gray-800',
         minimal:
-          'border-transparent bg-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+          'border-transparent bg-transparent text-muted-foreground hover:text-gray-700  dark:hover:text-gray-200',
       },
     },
     defaultVariants: {

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -404,7 +404,7 @@ export function LanguageSelectorInline({
             index === languages.length - 1 && 'rounded-r-lg',
             index > 0 && 'border-l border-gray-200 dark:border-gray-700',
             language.code === value
-              ? 'bg-primary-600 text-white'
+              ? 'bg-primary-800 text-white'
               : 'bg-white text-gray-700 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
           )}
         >

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -244,7 +244,7 @@ export function LanguageSelector({
                 )}
                 <span className="flex-1">{language.name}</span>
                 {language.code === value && (
-                  <CheckIcon className="text-primary-600 dark:text-primary-400 h-4 w-4" />
+                  <CheckIcon className="text-primary-800 dark:text-primary-400 h-4 w-4" />
                 )}
               </li>
             ))}

--- a/src/components/LoadingPage/LoadingPage.stories.tsx
+++ b/src/components/LoadingPage/LoadingPage.stories.tsx
@@ -106,7 +106,7 @@ function LoadingPageDemo({
                     2000
                   );
                 }}
-                className="bg-primary-800 text-white w-full rounded px-4 py-2"
+                className="bg-primary-800 w-full rounded px-4 py-2 text-white"
               >
                 Save
               </button>

--- a/src/components/LoadingPage/LoadingPage.stories.tsx
+++ b/src/components/LoadingPage/LoadingPage.stories.tsx
@@ -106,7 +106,7 @@ function LoadingPageDemo({
                     2000
                   );
                 }}
-                className="bg-primary text-primary-foreground w-full rounded px-4 py-2"
+                className="bg-primary-800 text-white w-full rounded px-4 py-2"
               >
                 Save
               </button>

--- a/src/components/LoadingPage/LoadingPage.tsx
+++ b/src/components/LoadingPage/LoadingPage.tsx
@@ -146,7 +146,7 @@ export function LoadingBar({
       </div>
       {showPercentage && !isIndeterminate && (
         <p
-          className="mt-1 text-right text-sm text-muted-foreground"
+          className="text-muted-foreground mt-1 text-right text-sm"
           data-slot="loading-bar-percentage"
         >
           {Math.round(progress)}%
@@ -222,7 +222,7 @@ export function LoadingPage({
           )}
           {subMessage && (
             <p
-              className="text-sm text-muted-foreground"
+              className="text-muted-foreground text-sm"
               data-slot="loading-page-submessage"
             >
               {subMessage}

--- a/src/components/LoadingPage/LoadingPage.tsx
+++ b/src/components/LoadingPage/LoadingPage.tsx
@@ -146,7 +146,7 @@ export function LoadingBar({
       </div>
       {showPercentage && !isIndeterminate && (
         <p
-          className="mt-1 text-right text-sm text-gray-600 dark:text-gray-400"
+          className="mt-1 text-right text-sm text-muted-foreground"
           data-slot="loading-bar-percentage"
         >
           {Math.round(progress)}%
@@ -222,7 +222,7 @@ export function LoadingPage({
           )}
           {subMessage && (
             <p
-              className="text-sm text-gray-500 dark:text-gray-400"
+              className="text-sm text-muted-foreground"
               data-slot="loading-page-submessage"
             >
               {subMessage}

--- a/src/components/LoadingPage/LoadingPage.tsx
+++ b/src/components/LoadingPage/LoadingPage.tsx
@@ -53,7 +53,7 @@ export function LoadingDots({
   }[size];
 
   const dotColor = {
-    primary: 'bg-primary-600',
+    primary: 'bg-primary-800',
     secondary: 'bg-gray-400',
     white: 'bg-white',
     current: 'bg-current',
@@ -111,7 +111,7 @@ export function LoadingBar({
 }: LoadingBarProps) {
   const isIndeterminate = progress === undefined;
   const barColor = {
-    primary: 'bg-primary-600',
+    primary: 'bg-primary-800',
     success: 'bg-green-600',
     warning: 'bg-yellow-500',
     error: 'bg-red-600',
@@ -438,8 +438,8 @@ function PulseIndicator() {
   return (
     <div className="relative h-16 w-16" data-slot="pulse-indicator">
       <div className="bg-primary-200 dark:bg-primary-800 absolute inset-0 animate-ping rounded-full opacity-75" />
-      <div className="bg-primary-400 dark:bg-primary-600 absolute inset-2 animate-pulse rounded-full" />
-      <div className="bg-primary-600 dark:bg-primary-400 absolute inset-4 rounded-full" />
+      <div className="bg-primary-400 dark:bg-primary-800 absolute inset-2 animate-pulse rounded-full" />
+      <div className="bg-primary-800 dark:bg-primary-400 absolute inset-4 rounded-full" />
     </div>
   );
 }

--- a/src/components/Messaging/AttachmentPicker.tsx
+++ b/src/components/Messaging/AttachmentPicker.tsx
@@ -520,7 +520,7 @@ function DragDropZone({
         >
           <div className="text-center">
             <svg
-              className="text-primary-500 mx-auto h-12 w-12"
+              className="text-primary-800 mx-auto h-12 w-12"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/src/components/Messaging/ConversationHeader.tsx
+++ b/src/components/Messaging/ConversationHeader.tsx
@@ -391,7 +391,7 @@ const ConversationListItem = React.forwardRef<
             {title}
           </h3>
           {lastMessage && (
-            <span className="shrink-0 text-xs text-muted-foreground">
+            <span className="text-muted-foreground shrink-0 text-xs">
               {formatTime(lastMessage.timestamp)}
             </span>
           )}

--- a/src/components/Messaging/ConversationHeader.tsx
+++ b/src/components/Messaging/ConversationHeader.tsx
@@ -246,7 +246,7 @@ const ConversationHeader = React.forwardRef<
                 'truncate text-sm',
                 isOnline
                   ? 'text-green-600 dark:text-green-400'
-                  : 'text-neutral-500 dark:text-neutral-400'
+                  : 'text-muted-foreground'
               )}
             >
               {displaySubtitle}
@@ -391,7 +391,7 @@ const ConversationListItem = React.forwardRef<
             {title}
           </h3>
           {lastMessage && (
-            <span className="shrink-0 text-xs text-neutral-500 dark:text-neutral-400">
+            <span className="shrink-0 text-xs text-muted-foreground">
               {formatTime(lastMessage.timestamp)}
             </span>
           )}
@@ -402,7 +402,7 @@ const ConversationListItem = React.forwardRef<
               'truncate text-sm',
               isUnread
                 ? 'text-neutral-700 dark:text-neutral-300'
-                : 'text-neutral-500 dark:text-neutral-400'
+                : 'text-muted-foreground'
             )}
           >
             {lastMessage?.content || 'No messages yet'}

--- a/src/components/Messaging/ConversationHeader.tsx
+++ b/src/components/Messaging/ConversationHeader.tsx
@@ -413,7 +413,7 @@ const ConversationListItem = React.forwardRef<
               className={cn(
                 'flex shrink-0 items-center justify-center',
                 'h-5 min-w-[20px] rounded-full px-1.5',
-                'bg-primary-600 text-xs font-medium text-white'
+                'bg-primary-800 text-xs font-medium text-white'
               )}
             >
               {conversation.unreadCount > 99 ? '99+' : conversation.unreadCount}

--- a/src/components/Messaging/ConversationHeader.tsx
+++ b/src/components/Messaging/ConversationHeader.tsx
@@ -426,7 +426,7 @@ const ConversationListItem = React.forwardRef<
       <div className="flex shrink-0 flex-col items-center gap-1">
         {conversation.isPinned && (
           <svg
-            className="text-primary-500 h-4 w-4"
+            className="text-primary-800 h-4 w-4"
             fill="currentColor"
             viewBox="0 0 24 24"
           >

--- a/src/components/Messaging/MessageBubble.tsx
+++ b/src/components/Messaging/MessageBubble.tsx
@@ -524,7 +524,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
           {showSenderName && !isOutgoing && (
             <span
               data-slot="message-sender-name"
-              className="mb-1 px-1 text-xs font-medium text-muted-foreground"
+              className="text-muted-foreground mb-1 px-1 text-xs font-medium"
             >
               {message.sender.name}
             </span>
@@ -594,7 +594,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
             )}
           >
             {showTimestamp && (
-              <span className="text-xs text-muted-foreground">
+              <span className="text-muted-foreground text-xs">
                 {formatTimestamp(message.timestamp)}
               </span>
             )}

--- a/src/components/Messaging/MessageBubble.tsx
+++ b/src/components/Messaging/MessageBubble.tsx
@@ -19,7 +19,7 @@ const statusIconVariants = cva(
       status: {
         sending: 'text-neutral-500',
         sent: 'text-neutral-500',
-        delivered: 'text-neutral-600 dark:text-neutral-400',
+        delivered: 'text-muted-foreground',
         read: 'text-primary-800 dark:text-primary-300',
         failed: 'text-red-500',
       },
@@ -368,7 +368,7 @@ const bubbleVariants = cva(
         ],
         system: [
           'mx-auto max-w-none',
-          'bg-transparent text-neutral-500 dark:text-neutral-400',
+          'bg-transparent text-muted-foreground',
           'text-center text-sm',
           'py-1 px-2',
         ],
@@ -524,7 +524,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
           {showSenderName && !isOutgoing && (
             <span
               data-slot="message-sender-name"
-              className="mb-1 px-1 text-xs font-medium text-neutral-500 dark:text-neutral-400"
+              className="mb-1 px-1 text-xs font-medium text-muted-foreground"
             >
               {message.sender.name}
             </span>
@@ -594,7 +594,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
             )}
           >
             {showTimestamp && (
-              <span className="text-xs text-neutral-500 dark:text-neutral-400">
+              <span className="text-xs text-muted-foreground">
                 {formatTimestamp(message.timestamp)}
               </span>
             )}

--- a/src/components/Messaging/MessageComposer.tsx
+++ b/src/components/Messaging/MessageComposer.tsx
@@ -87,7 +87,7 @@ const sendButtonVariants = cva(
       variant: {
         primary: [
           'bg-primary-800 text-white',
-          'hover:bg-primary-700',
+          'hover:bg-primary-900',
           'active:scale-95',
         ],
         subtle: [

--- a/src/components/Messaging/MessageComposer.tsx
+++ b/src/components/Messaging/MessageComposer.tsx
@@ -91,7 +91,7 @@ const sendButtonVariants = cva(
           'active:scale-95',
         ],
         subtle: [
-          'bg-transparent text-primary-600',
+          'bg-transparent text-primary-800',
           'hover:bg-primary-50 dark:hover:bg-primary-900/20',
         ],
       },
@@ -437,7 +437,7 @@ const MessageComposer = React.forwardRef<
               )}
             >
               <div className="min-w-0 flex-1">
-                <span className="text-primary-600 dark:text-primary-400 text-xs font-medium">
+                <span className="text-primary-800 dark:text-primary-400 text-xs font-medium">
                   Replying to {replyTo.senderName}
                 </span>
                 <p className="truncate text-sm text-neutral-600 dark:text-neutral-300">

--- a/src/components/Messaging/MessageList.tsx
+++ b/src/components/Messaging/MessageList.tsx
@@ -190,9 +190,7 @@ function TypingIndicator({ typingState, className }: TypingIndicatorProps) {
           style={{ animationDelay: '300ms' }}
         />
       </div>
-      <span className="text-xs text-muted-foreground">
-        {typingText}
-      </span>
+      <span className="text-muted-foreground text-xs">{typingText}</span>
     </div>
   );
 }
@@ -293,7 +291,7 @@ function EmptyState({
       <h3 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
         {title}
       </h3>
-      <p className="mb-4 max-w-sm text-sm text-muted-foreground">
+      <p className="text-muted-foreground mb-4 max-w-sm text-sm">
         {description}
       </p>
       {action}

--- a/src/components/Messaging/MessageList.tsx
+++ b/src/components/Messaging/MessageList.tsx
@@ -190,7 +190,7 @@ function TypingIndicator({ typingState, className }: TypingIndicatorProps) {
           style={{ animationDelay: '300ms' }}
         />
       </div>
-      <span className="text-xs text-neutral-500 dark:text-neutral-400">
+      <span className="text-xs text-muted-foreground">
         {typingText}
       </span>
     </div>
@@ -293,7 +293,7 @@ function EmptyState({
       <h3 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
         {title}
       </h3>
-      <p className="mb-4 max-w-sm text-sm text-neutral-500 dark:text-neutral-400">
+      <p className="mb-4 max-w-sm text-sm text-muted-foreground">
         {description}
       </p>
       {action}

--- a/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/src/components/NotificationCenter/NotificationCenter.tsx
@@ -258,7 +258,7 @@ export function NotificationCenter({
           className="py-12 text-center"
         >
           <svg
-            className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -355,14 +355,14 @@ export function NotificationCenter({
                       )}
                     </div>
                   </div>
-                  <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
+                  <p className="text-muted-foreground mt-0.5 line-clamp-2 text-sm">
                     {notification.message}
                   </p>
                   <div
                     data-slot="notification-center-meta"
                     className="mt-2 flex items-center justify-between"
                   >
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-muted-foreground text-xs">
                       {formatTimestamp(notification.timestamp)}
                     </span>
                     <div className="flex items-center gap-2">

--- a/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/src/components/NotificationCenter/NotificationCenter.tsx
@@ -198,7 +198,7 @@ export function NotificationCenter({
       case 'alert':
         return 'text-yellow-500 bg-yellow-100 dark:bg-yellow-900/30';
       default:
-        return 'text-gray-500 bg-gray-100 dark:bg-gray-800';
+        return 'text-muted-foreground bg-gray-100 dark:bg-gray-800';
     }
   };
 

--- a/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/src/components/NotificationCenter/NotificationCenter.tsx
@@ -258,7 +258,7 @@ export function NotificationCenter({
           className="py-12 text-center"
         >
           <svg
-            className="mx-auto mb-3 h-12 w-12 text-gray-400 dark:text-gray-600"
+            className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -270,7 +270,7 @@ export function NotificationCenter({
               d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
             />
           </svg>
-          <p className="text-gray-500 dark:text-gray-400">{emptyMessage}</p>
+          <p className="text-muted-foreground">{emptyMessage}</p>
         </div>
       ) : (
         <div
@@ -355,14 +355,14 @@ export function NotificationCenter({
                       )}
                     </div>
                   </div>
-                  <p className="mt-0.5 line-clamp-2 text-sm text-gray-500 dark:text-gray-400">
+                  <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
                     {notification.message}
                   </p>
                   <div
                     data-slot="notification-center-meta"
                     className="mt-2 flex items-center justify-between"
                   >
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                    <span className="text-xs text-muted-foreground">
                       {formatTimestamp(notification.timestamp)}
                     </span>
                     <div className="flex items-center gap-2">

--- a/src/components/OrderCard/OrderCard.tsx
+++ b/src/components/OrderCard/OrderCard.tsx
@@ -297,7 +297,7 @@ export function OrderCard({
                 <button
                   type="button"
                   onClick={handleAcceptClick}
-                  className="bg-primary hover:bg-primary/90 rounded-md px-3 py-1.5 text-sm font-medium text-white transition-colors"
+                  className="bg-primary hover:bg-primary-900 rounded-md px-3 py-1.5 text-sm font-medium text-white transition-colors"
                 >
                   Accept
                 </button>

--- a/src/components/OrderCard/OrderCard.tsx
+++ b/src/components/OrderCard/OrderCard.tsx
@@ -297,7 +297,7 @@ export function OrderCard({
                 <button
                   type="button"
                   onClick={handleAcceptClick}
-                  className="bg-primary hover:bg-primary-900 rounded-md px-3 py-1.5 text-sm font-medium text-white transition-colors"
+                  className="bg-primary-800 hover:bg-primary-900 rounded-md px-3 py-1.5 text-sm font-medium text-white transition-colors"
                 >
                   Accept
                 </button>

--- a/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
+++ b/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
@@ -134,7 +134,7 @@ export function OrderConfirmationWizard({
                   </div>
                   <span
                     data-slot="ocw-step-label"
-                    className={`mt-2 text-center text-xs font-medium ${isActive ? 'text-blue-600 dark:text-blue-400' : 'text-gray-500 dark:text-gray-400'} `}
+                    className={`mt-2 text-center text-xs font-medium ${isActive ? 'text-blue-600 dark:text-blue-400' : 'text-muted-foreground'} `}
                   >
                     {title}
                   </span>
@@ -167,7 +167,7 @@ export function OrderConfirmationWizard({
                   {order.orderNumber}
                 </p>
                 <p
-                  className="text-sm text-gray-500 dark:text-gray-400"
+                  className="text-sm text-muted-foreground"
                   data-slot="ocw-summary-subtitle"
                 >
                   {order.serviceName}
@@ -193,7 +193,7 @@ export function OrderConfirmationWizard({
                   Verify Employee Identity
                 </h3>
                 <p
-                  className="text-sm text-gray-600 dark:text-gray-400"
+                  className="text-sm text-muted-foreground"
                   data-slot="ocw-step-desc"
                 >
                   Please verify the following information matches the employee
@@ -205,7 +205,7 @@ export function OrderConfirmationWizard({
                   data-slot="ocw-detail-grid"
                 >
                   <div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-muted-foreground">
                       Employee Name
                     </p>
                     <p className="font-medium text-gray-900 dark:text-white">
@@ -213,7 +213,7 @@ export function OrderConfirmationWizard({
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-muted-foreground">
                       Date of Birth
                     </p>
                     <p className="font-medium text-gray-900 dark:text-white">
@@ -221,7 +221,7 @@ export function OrderConfirmationWizard({
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-muted-foreground">
                       Employer
                     </p>
                     <p className="font-medium text-gray-900 dark:text-white">
@@ -229,7 +229,7 @@ export function OrderConfirmationWizard({
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-muted-foreground">
                       Scheduled
                     </p>
                     <p className="font-medium text-gray-900 dark:text-white">
@@ -289,7 +289,7 @@ export function OrderConfirmationWizard({
                   Consent & ID Verification
                 </h3>
                 <p
-                  className="text-sm text-gray-600 dark:text-gray-400"
+                  className="text-sm text-muted-foreground"
                   data-slot="ocw-step-desc"
                 >
                   Obtain consent and verify government-issued identification.
@@ -315,7 +315,7 @@ export function OrderConfirmationWizard({
                       Consent Obtained
                     </p>
                     <p
-                      className="text-sm text-gray-500 dark:text-gray-400"
+                      className="text-sm text-muted-foreground"
                       data-slot="ocw-checkbox-card-desc"
                     >
                       Employee has provided written or verbal consent for the
@@ -343,7 +343,7 @@ export function OrderConfirmationWizard({
                       Photo ID Verified
                     </p>
                     <p
-                      className="mb-2 text-sm text-gray-500 dark:text-gray-400"
+                      className="mb-2 text-sm text-muted-foreground"
                       data-slot="ocw-checkbox-card-desc"
                     >
                       Government-issued photo ID matches employee information
@@ -371,7 +371,7 @@ export function OrderConfirmationWizard({
                   Review & Confirm
                 </h3>
                 <p
-                  className="text-sm text-gray-600 dark:text-gray-400"
+                  className="text-sm text-muted-foreground"
                   data-slot="ocw-step-desc"
                 >
                   Review the verification steps before proceeding.

--- a/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
+++ b/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
@@ -111,7 +111,7 @@ export function OrderConfirmationWizard({
                         ? 'bg-green-500 text-white'
                         : isActive
                           ? 'bg-blue-500 text-white'
-                          : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
+                          : 'text-muted-foreground bg-gray-200 dark:bg-gray-700'
                     } `}
                   >
                     {isComplete ? (

--- a/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
+++ b/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
@@ -167,7 +167,7 @@ export function OrderConfirmationWizard({
                   {order.orderNumber}
                 </p>
                 <p
-                  className="text-sm text-muted-foreground"
+                  className="text-muted-foreground text-sm"
                   data-slot="ocw-summary-subtitle"
                 >
                   {order.serviceName}
@@ -193,7 +193,7 @@ export function OrderConfirmationWizard({
                   Verify Employee Identity
                 </h3>
                 <p
-                  className="text-sm text-muted-foreground"
+                  className="text-muted-foreground text-sm"
                   data-slot="ocw-step-desc"
                 >
                   Please verify the following information matches the employee
@@ -205,7 +205,7 @@ export function OrderConfirmationWizard({
                   data-slot="ocw-detail-grid"
                 >
                   <div>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Employee Name
                     </p>
                     <p className="font-medium text-gray-900 dark:text-white">
@@ -213,7 +213,7 @@ export function OrderConfirmationWizard({
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Date of Birth
                     </p>
                     <p className="font-medium text-gray-900 dark:text-white">
@@ -221,17 +221,13 @@ export function OrderConfirmationWizard({
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-muted-foreground">
-                      Employer
-                    </p>
+                    <p className="text-muted-foreground text-xs">Employer</p>
                     <p className="font-medium text-gray-900 dark:text-white">
                       {order.employerName}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-muted-foreground">
-                      Scheduled
-                    </p>
+                    <p className="text-muted-foreground text-xs">Scheduled</p>
                     <p className="font-medium text-gray-900 dark:text-white">
                       {formatDate(order.scheduledDate)}
                     </p>
@@ -289,7 +285,7 @@ export function OrderConfirmationWizard({
                   Consent & ID Verification
                 </h3>
                 <p
-                  className="text-sm text-muted-foreground"
+                  className="text-muted-foreground text-sm"
                   data-slot="ocw-step-desc"
                 >
                   Obtain consent and verify government-issued identification.
@@ -315,7 +311,7 @@ export function OrderConfirmationWizard({
                       Consent Obtained
                     </p>
                     <p
-                      className="text-sm text-muted-foreground"
+                      className="text-muted-foreground text-sm"
                       data-slot="ocw-checkbox-card-desc"
                     >
                       Employee has provided written or verbal consent for the
@@ -343,7 +339,7 @@ export function OrderConfirmationWizard({
                       Photo ID Verified
                     </p>
                     <p
-                      className="mb-2 text-sm text-muted-foreground"
+                      className="text-muted-foreground mb-2 text-sm"
                       data-slot="ocw-checkbox-card-desc"
                     >
                       Government-issued photo ID matches employee information
@@ -371,7 +367,7 @@ export function OrderConfirmationWizard({
                   Review & Confirm
                 </h3>
                 <p
-                  className="text-sm text-muted-foreground"
+                  className="text-muted-foreground text-sm"
                   data-slot="ocw-step-desc"
                 >
                   Review the verification steps before proceeding.

--- a/src/components/OrderList/OrderList.tsx
+++ b/src/components/OrderList/OrderList.tsx
@@ -131,7 +131,7 @@ export function OrderList<T>({
                     'rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors',
                     activeTab === tab.id
                       ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
-                      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200'
+                      : 'text-muted-foreground hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200'
                   )}
                 >
                   {tab.label}
@@ -142,7 +142,7 @@ export function OrderList<T>({
                         'ml-2 rounded-full px-2 py-0.5 text-xs',
                         activeTab === tab.id
                           ? 'bg-blue-200 text-blue-800 dark:bg-blue-800 dark:text-blue-200'
-                          : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+                          : 'text-muted-foreground bg-gray-200 dark:bg-gray-700'
                       )}
                     >
                       {count}

--- a/src/components/OrderList/OrderList.tsx
+++ b/src/components/OrderList/OrderList.tsx
@@ -235,7 +235,7 @@ export function OrderList<T>({
               </svg>
             )}
             <p
-              className="text-gray-500 dark:text-gray-400"
+              className="text-muted-foreground"
               data-slot="order-list-empty-message"
             >
               {emptyMessage}

--- a/src/components/OrderLookupForm/OrderLookupForm.tsx
+++ b/src/components/OrderLookupForm/OrderLookupForm.tsx
@@ -98,7 +98,7 @@ export function OrderLookupForm({
           <h2 className="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
             Order Lookup
           </h2>
-          <p className="mb-6 text-muted-foreground">
+          <p className="text-muted-foreground mb-6">
             Enter your order details to view your information.
           </p>
 
@@ -185,7 +185,7 @@ export function OrderLookupForm({
             </Button>
           </form>
 
-          <p className="mt-6 text-center text-xs text-muted-foreground">
+          <p className="text-muted-foreground mt-6 text-center text-xs">
             Need help?{' '}
             <button
               type="button"

--- a/src/components/OrderLookupForm/OrderLookupForm.tsx
+++ b/src/components/OrderLookupForm/OrderLookupForm.tsx
@@ -98,7 +98,7 @@ export function OrderLookupForm({
           <h2 className="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
             Order Lookup
           </h2>
-          <p className="mb-6 text-gray-600 dark:text-gray-400">
+          <p className="mb-6 text-muted-foreground">
             Enter your order details to view your information.
           </p>
 
@@ -185,7 +185,7 @@ export function OrderLookupForm({
             </Button>
           </form>
 
-          <p className="mt-6 text-center text-xs text-gray-500 dark:text-gray-400">
+          <p className="mt-6 text-center text-xs text-muted-foreground">
             Need help?{' '}
             <button
               type="button"

--- a/src/components/OrderSidebar/OrderSidebar.tsx
+++ b/src/components/OrderSidebar/OrderSidebar.tsx
@@ -137,7 +137,7 @@ export function OrderSidebar({
             aria-label="Close sidebar"
           >
             <svg
-              className="h-5 w-5 text-gray-500"
+              className="text-muted-foreground h-5 w-5"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -178,7 +178,7 @@ export function OrderSidebar({
           <dl data-slot="order-sidebar-details" className="space-y-4">
             {patientName && (
               <div data-slot="order-sidebar-detail">
-                <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                   Patient
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900 dark:text-white">
@@ -189,7 +189,7 @@ export function OrderSidebar({
 
             {employerName && (
               <div data-slot="order-sidebar-detail">
-                <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                   Employer
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900 dark:text-white">
@@ -200,7 +200,7 @@ export function OrderSidebar({
 
             {serviceName && (
               <div data-slot="order-sidebar-detail">
-                <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                   Service
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900 dark:text-white">
@@ -214,7 +214,7 @@ export function OrderSidebar({
               className="grid grid-cols-2 gap-4"
             >
               <div>
-                <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                   Created
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900 dark:text-white">
@@ -222,7 +222,7 @@ export function OrderSidebar({
                 </dd>
               </div>
               <div>
-                <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                   Scheduled
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900 dark:text-white">
@@ -233,12 +233,12 @@ export function OrderSidebar({
 
             {notes && (
               <div data-slot="order-sidebar-detail">
-                <dt className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                   Notes
                 </dt>
                 <dd
                   data-slot="order-sidebar-notes"
-                  className="mt-1 rounded-lg bg-gray-50 p-3 text-sm text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                  className="text-muted-foreground mt-1 rounded-lg bg-gray-50 p-3 text-sm dark:bg-gray-800"
                 >
                   {notes}
                 </dd>

--- a/src/components/OrderSidebar/OrderSidebar.tsx
+++ b/src/components/OrderSidebar/OrderSidebar.tsx
@@ -94,7 +94,7 @@ export function OrderSidebar({
       case 'urgent':
         return 'text-orange-600 dark:text-orange-400';
       default:
-        return 'text-gray-600 dark:text-gray-400';
+        return 'text-muted-foreground';
     }
   };
 
@@ -128,7 +128,7 @@ export function OrderSidebar({
               Order Details
             </h2>
             {orderId && (
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-muted-foreground">
                 #{orderId}
               </p>
             )}

--- a/src/components/OrderSidebar/OrderSidebar.tsx
+++ b/src/components/OrderSidebar/OrderSidebar.tsx
@@ -128,9 +128,7 @@ export function OrderSidebar({
               Order Details
             </h2>
             {orderId && (
-              <p className="text-sm text-muted-foreground">
-                #{orderId}
-              </p>
+              <p className="text-muted-foreground text-sm">#{orderId}</p>
             )}
           </div>
           <button

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -65,7 +65,7 @@ export function PageHeader({
           {icon && (
             <div
               data-slot="page-header-icon"
-              className={`flex-shrink-0 text-gray-500 dark:text-gray-400 ${iconAlign === 'top' ? 'mt-1' : ''}`}
+              className={`flex-shrink-0 text-muted-foreground ${iconAlign === 'top' ? 'mt-1' : ''}`}
             >
               {icon}
             </div>
@@ -80,7 +80,7 @@ export function PageHeader({
             {subtitle && (
               <p
                 data-slot="page-header-subtitle"
-                className="mt-1 truncate text-sm text-gray-500 dark:text-gray-400"
+                className="mt-1 truncate text-sm text-muted-foreground"
               >
                 {subtitle}
               </p>

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -65,7 +65,7 @@ export function PageHeader({
           {icon && (
             <div
               data-slot="page-header-icon"
-              className={`flex-shrink-0 text-muted-foreground ${iconAlign === 'top' ? 'mt-1' : ''}`}
+              className={`text-muted-foreground flex-shrink-0 ${iconAlign === 'top' ? 'mt-1' : ''}`}
             >
               {icon}
             </div>
@@ -80,7 +80,7 @@ export function PageHeader({
             {subtitle && (
               <p
                 data-slot="page-header-subtitle"
-                className="mt-1 truncate text-sm text-muted-foreground"
+                className="text-muted-foreground mt-1 truncate text-sm"
               >
                 {subtitle}
               </p>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -18,7 +18,7 @@ const paginationButtonVariants = cva(
       variant: {
         default: [
           'text-muted-foreground hover:text-foreground hover:bg-muted',
-          'data-[active=true]:bg-primary-500 data-[active=true]:text-white',
+          'data-[active=true]:bg-primary-800 data-[active=true]:text-white',
         ],
         outline: [
           'border border-border text-muted-foreground',

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -23,12 +23,12 @@ const paginationButtonVariants = cva(
         outline: [
           'border border-border text-muted-foreground',
           'hover:bg-muted hover:text-foreground',
-          'data-[active=true]:border-primary-500 data-[active=true]:bg-primary-50 data-[active=true]:text-primary-500',
+          'data-[active=true]:border-primary-500 data-[active=true]:bg-primary-50 data-[active=true]:text-primary-800',
           'dark:data-[active=true]:bg-primary-950',
         ],
         ghost: [
           'text-muted-foreground hover:text-foreground hover:bg-muted',
-          'data-[active=true]:text-primary-500 data-[active=true]:font-semibold',
+          'data-[active=true]:text-primary-800 data-[active=true]:font-semibold',
         ],
       },
       size: {

--- a/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
+++ b/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
@@ -175,7 +175,7 @@ export function PaymentHistoryTable({
         className={`rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700 ${className}`}
       >
         <svg
-          className="mx-auto mb-3 h-12 w-12 text-gray-400 dark:text-gray-600"
+          className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -189,7 +189,7 @@ export function PaymentHistoryTable({
         </svg>
         <p
           data-slot="payment-history-empty"
-          className="text-gray-500 dark:text-gray-400"
+          className="text-muted-foreground"
         >
           {emptyMessage}
         </p>
@@ -269,7 +269,7 @@ export function PaymentHistoryTable({
                 </p>
               </td>
               <td className="hidden px-4 py-3 lg:table-cell">
-                <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+                <div className="flex items-center gap-2 text-muted-foreground">
                   {getMethodIcon(payment.method)}
                   <span className="text-sm">
                     {getMethodLabel(payment.method)}

--- a/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
+++ b/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
@@ -202,26 +202,26 @@ export function PaymentHistoryTable({
       <table data-slot="payment-history-table" className="w-full">
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
-            <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            <th className="text-muted-foreground px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
               Date
             </th>
-            <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase sm:table-cell dark:text-gray-400">
+            <th className="text-muted-foreground hidden px-4 py-3 text-left text-xs font-medium tracking-wider uppercase sm:table-cell">
               Invoice
             </th>
-            <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase md:table-cell dark:text-gray-400">
+            <th className="text-muted-foreground hidden px-4 py-3 text-left text-xs font-medium tracking-wider uppercase md:table-cell">
               Employer
             </th>
-            <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase lg:table-cell dark:text-gray-400">
+            <th className="text-muted-foreground hidden px-4 py-3 text-left text-xs font-medium tracking-wider uppercase lg:table-cell">
               Method
             </th>
-            <th className="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            <th className="text-muted-foreground px-4 py-3 text-right text-xs font-medium tracking-wider uppercase">
               Amount
             </th>
-            <th className="px-4 py-3 text-center text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            <th className="text-muted-foreground px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
               Status
             </th>
             {onRefund && (
-              <th className="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              <th className="text-muted-foreground px-4 py-3 text-right text-xs font-medium tracking-wider uppercase">
                 Action
               </th>
             )}
@@ -239,7 +239,7 @@ export function PaymentHistoryTable({
                 <p className="text-sm font-medium text-gray-900 dark:text-white">
                   {formatDate(payment.date)}
                 </p>
-                <p className="text-xs text-gray-500 sm:hidden dark:text-gray-400">
+                <p className="text-muted-foreground text-xs sm:hidden">
                   {payment.invoiceNumber}
                 </p>
               </td>
@@ -276,7 +276,7 @@ export function PaymentHistoryTable({
               </td>
               <td className="px-4 py-3 text-right">
                 <p
-                  className={`font-medium ${payment.status === 'refunded' ? 'text-gray-500 line-through dark:text-gray-400' : 'text-gray-900 dark:text-white'}`}
+                  className={`font-medium ${payment.status === 'refunded' ? 'text-muted-foreground line-through' : 'text-gray-900 dark:text-white'}`}
                 >
                   {formatCurrency(payment.amount)}
                 </p>

--- a/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
+++ b/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
@@ -175,7 +175,7 @@ export function PaymentHistoryTable({
         className={`rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700 ${className}`}
       >
         <svg
-          className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
+          className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -187,10 +187,7 @@ export function PaymentHistoryTable({
             d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"
           />
         </svg>
-        <p
-          data-slot="payment-history-empty"
-          className="text-muted-foreground"
-        >
+        <p data-slot="payment-history-empty" className="text-muted-foreground">
           {emptyMessage}
         </p>
       </div>
@@ -269,7 +266,7 @@ export function PaymentHistoryTable({
                 </p>
               </td>
               <td className="hidden px-4 py-3 lg:table-cell">
-                <div className="flex items-center gap-2 text-muted-foreground">
+                <div className="text-muted-foreground flex items-center gap-2">
                   {getMethodIcon(payment.method)}
                   <span className="text-sm">
                     {getMethodLabel(payment.method)}

--- a/src/components/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/PaymentMethod/PaymentMethod.tsx
@@ -172,7 +172,7 @@ export function PaymentMethodCard({
             aria-hidden="true"
           />
           <span
-            className="text-xs font-medium text-gray-600 uppercase dark:text-gray-400"
+            className="text-muted-foreground text-xs font-medium uppercase"
             data-slot="payment-card-label"
           >
             Credit Card
@@ -354,7 +354,7 @@ export function PaymentMethodBank({
         <div className="flex items-center gap-2">
           <BankIcon className="text-muted-foreground h-5 w-5" />
           <span
-            className="text-xs font-medium text-gray-600 uppercase dark:text-gray-400"
+            className="text-muted-foreground text-xs font-medium uppercase"
             data-slot="payment-bank-label"
           >
             ACH
@@ -391,7 +391,7 @@ export function PaymentMethodBank({
           {account.last4}
         </div>
         {account.accountType && (
-          <div className="text-xs text-gray-500 capitalize dark:text-gray-500">
+          <div className="text-muted-foreground text-xs capitalize">
             {account.accountType}
           </div>
         )}

--- a/src/components/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/PaymentMethod/PaymentMethod.tsx
@@ -196,7 +196,7 @@ export function PaymentMethodCard({
         <div className="font-mono text-sm text-gray-900 dark:text-gray-100">
           <span className="hidden lg:inline">•••• •••• </span>•••• {card.last4}
         </div>
-        <div className="text-sm text-gray-600 dark:text-gray-400">
+        <div className="text-sm text-muted-foreground">
           {expMonth}/{expYear}
         </div>
       </div>
@@ -217,7 +217,7 @@ export function PaymentMethodCard({
               disabled={disabled}
               className="text-brand-600 focus:ring-brand-500"
             />
-            <span className="text-xs text-gray-600 dark:text-gray-400">
+            <span className="text-xs text-muted-foreground">
               Set as default
             </span>
           </label>
@@ -352,7 +352,7 @@ export function PaymentMethodBank({
         data-slot="payment-bank-header"
       >
         <div className="flex items-center gap-2">
-          <BankIcon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+          <BankIcon className="h-5 w-5 text-muted-foreground" />
           <span
             className="text-xs font-medium text-gray-600 uppercase dark:text-gray-400"
             data-slot="payment-bank-label"
@@ -386,7 +386,7 @@ export function PaymentMethodBank({
             {account.bankName}
           </div>
         )}
-        <div className="font-mono text-sm text-gray-600 dark:text-gray-400">
+        <div className="font-mono text-sm text-muted-foreground">
           <span className="hidden lg:inline">•••• •••• </span>••••{' '}
           {account.last4}
         </div>
@@ -413,7 +413,7 @@ export function PaymentMethodBank({
               disabled={disabled}
               className="text-brand-600 focus:ring-brand-500"
             />
-            <span className="text-xs text-gray-600 dark:text-gray-400">
+            <span className="text-xs text-muted-foreground">
               Set as default
             </span>
           </label>

--- a/src/components/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/PaymentMethod/PaymentMethod.tsx
@@ -196,7 +196,7 @@ export function PaymentMethodCard({
         <div className="font-mono text-sm text-gray-900 dark:text-gray-100">
           <span className="hidden lg:inline">•••• •••• </span>•••• {card.last4}
         </div>
-        <div className="text-sm text-muted-foreground">
+        <div className="text-muted-foreground text-sm">
           {expMonth}/{expYear}
         </div>
       </div>
@@ -217,7 +217,7 @@ export function PaymentMethodCard({
               disabled={disabled}
               className="text-brand-600 focus:ring-brand-500"
             />
-            <span className="text-xs text-muted-foreground">
+            <span className="text-muted-foreground text-xs">
               Set as default
             </span>
           </label>
@@ -352,7 +352,7 @@ export function PaymentMethodBank({
         data-slot="payment-bank-header"
       >
         <div className="flex items-center gap-2">
-          <BankIcon className="h-5 w-5 text-muted-foreground" />
+          <BankIcon className="text-muted-foreground h-5 w-5" />
           <span
             className="text-xs font-medium text-gray-600 uppercase dark:text-gray-400"
             data-slot="payment-bank-label"
@@ -386,7 +386,7 @@ export function PaymentMethodBank({
             {account.bankName}
           </div>
         )}
-        <div className="font-mono text-sm text-muted-foreground">
+        <div className="text-muted-foreground font-mono text-sm">
           <span className="hidden lg:inline">•••• •••• </span>••••{' '}
           {account.last4}
         </div>
@@ -413,7 +413,7 @@ export function PaymentMethodBank({
               disabled={disabled}
               className="text-brand-600 focus:ring-brand-500"
             />
-            <span className="text-xs text-muted-foreground">
+            <span className="text-muted-foreground text-xs">
               Set as default
             </span>
           </label>

--- a/src/components/PendingClaimsTable/PendingClaimsTable.tsx
+++ b/src/components/PendingClaimsTable/PendingClaimsTable.tsx
@@ -83,7 +83,7 @@ export function PendingClaimsTable({
         className={`rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700 ${className}`}
       >
         <svg
-          className="mx-auto mb-3 h-12 w-12 text-gray-400 dark:text-gray-600"
+          className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -97,7 +97,7 @@ export function PendingClaimsTable({
         </svg>
         <p
           data-slot="pending-claims-empty"
-          className="text-gray-500 dark:text-gray-400"
+          className="text-muted-foreground"
         >
           {emptyMessage}
         </p>
@@ -146,7 +146,7 @@ export function PendingClaimsTable({
                       <p className="font-medium text-gray-900 dark:text-white">
                         {claim.claimantName}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-xs text-muted-foreground">
                         {claim.claimantEmail}
                       </p>
                     </div>
@@ -158,7 +158,7 @@ export function PendingClaimsTable({
                   </p>
                 </td>
                 <td className="px-4 py-4">
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-muted-foreground">
                     {formatDate(claim.submittedDate)}
                   </p>
                 </td>
@@ -227,7 +227,7 @@ export function PendingClaimsTable({
                   <p className="font-medium text-gray-900 dark:text-white">
                     {claim.claimantName}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <p className="text-xs text-muted-foreground">
                     {claim.claimantEmail}
                   </p>
                 </div>
@@ -237,7 +237,7 @@ export function PendingClaimsTable({
               </Badge>
             </div>
             <div className="mt-3 flex items-center justify-between">
-              <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="text-sm text-muted-foreground">
                 <span>{claim.claimantRole || 'No role'}</span>
                 <span className="mx-2">•</span>
                 <span>{formatDate(claim.submittedDate)}</span>

--- a/src/components/PendingClaimsTable/PendingClaimsTable.tsx
+++ b/src/components/PendingClaimsTable/PendingClaimsTable.tsx
@@ -112,19 +112,19 @@ export function PendingClaimsTable({
         <table data-slot="pending-claims-table" className="w-full">
           <thead className="bg-gray-50 dark:bg-gray-800">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              <th className="text-muted-foreground px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                 Claimant
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              <th className="text-muted-foreground px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                 Role
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              <th className="text-muted-foreground px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                 Submitted
               </th>
-              <th className="px-4 py-3 text-center text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              <th className="text-muted-foreground px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
                 Status
               </th>
-              <th className="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              <th className="text-muted-foreground px-4 py-3 text-right text-xs font-medium tracking-wider uppercase">
                 Actions
               </th>
             </tr>

--- a/src/components/PendingClaimsTable/PendingClaimsTable.tsx
+++ b/src/components/PendingClaimsTable/PendingClaimsTable.tsx
@@ -83,7 +83,7 @@ export function PendingClaimsTable({
         className={`rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700 ${className}`}
       >
         <svg
-          className="mx-auto mb-3 h-12 w-12 text-muted-foreground dark:text-muted-foreground"
+          className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -95,10 +95,7 @@ export function PendingClaimsTable({
             d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
           />
         </svg>
-        <p
-          data-slot="pending-claims-empty"
-          className="text-muted-foreground"
-        >
+        <p data-slot="pending-claims-empty" className="text-muted-foreground">
           {emptyMessage}
         </p>
       </div>
@@ -146,7 +143,7 @@ export function PendingClaimsTable({
                       <p className="font-medium text-gray-900 dark:text-white">
                         {claim.claimantName}
                       </p>
-                      <p className="text-xs text-muted-foreground">
+                      <p className="text-muted-foreground text-xs">
                         {claim.claimantEmail}
                       </p>
                     </div>
@@ -158,7 +155,7 @@ export function PendingClaimsTable({
                   </p>
                 </td>
                 <td className="px-4 py-4">
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-muted-foreground text-sm">
                     {formatDate(claim.submittedDate)}
                   </p>
                 </td>
@@ -227,7 +224,7 @@ export function PendingClaimsTable({
                   <p className="font-medium text-gray-900 dark:text-white">
                     {claim.claimantName}
                   </p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-muted-foreground text-xs">
                     {claim.claimantEmail}
                   </p>
                 </div>
@@ -237,7 +234,7 @@ export function PendingClaimsTable({
               </Badge>
             </div>
             <div className="mt-3 flex items-center justify-between">
-              <div className="text-sm text-muted-foreground">
+              <div className="text-muted-foreground text-sm">
                 <span>{claim.claimantRole || 'No role'}</span>
                 <span className="mx-2">•</span>
                 <span>{formatDate(claim.submittedDate)}</span>

--- a/src/components/PermissionsEditor/PermissionsEditor.stories.tsx
+++ b/src/components/PermissionsEditor/PermissionsEditor.stories.tsx
@@ -285,7 +285,7 @@ function InModalContextDemo() {
 
   return (
     <div className="bg-background mx-auto max-w-2xl rounded-lg border shadow-lg">
-      <div className="bg-primary text-primary-foreground rounded-t-lg p-4">
+      <div className="bg-primary-800 text-white rounded-t-lg p-4">
         <h4 className="text-lg font-semibold">User Permissions</h4>
       </div>
       <div className="p-6">

--- a/src/components/PermissionsEditor/PermissionsEditor.stories.tsx
+++ b/src/components/PermissionsEditor/PermissionsEditor.stories.tsx
@@ -285,7 +285,7 @@ function InModalContextDemo() {
 
   return (
     <div className="bg-background mx-auto max-w-2xl rounded-lg border shadow-lg">
-      <div className="bg-primary-800 text-white rounded-t-lg p-4">
+      <div className="bg-primary-800 rounded-t-lg p-4 text-white">
         <h4 className="text-lg font-semibold">User Permissions</h4>
       </div>
       <div className="p-6">

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -260,7 +260,7 @@ function PhoneInputGroup({
                 'h-10 w-full rounded-md border px-3 py-2 text-sm',
                 'border-gray-300 bg-white text-gray-900',
                 'focus:border-brand-500 focus:ring-brand-500/20 focus:ring-2 focus:outline-none',
-                'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500',
+                'disabled:text-muted-foreground disabled:cursor-not-allowed disabled:bg-gray-50',
                 'dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100',
                 'dark:focus:border-brand-400 dark:focus:ring-brand-400/20',
                 index === 0 && label ? 'mt-[26px]' : ''
@@ -293,7 +293,7 @@ function PhoneInputGroup({
                   'text-brand-600 hover:bg-brand-50',
                   'disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent',
                   'dark:text-brand-400 dark:hover:bg-brand-900/20',
-                  'dark:disabled:text-gray-600'
+                  'dark:disabled:text-muted-foreground'
                 )}
                 aria-label="Add phone number"
               >
@@ -323,7 +323,7 @@ function PhoneInputGroup({
                   'text-red-600 hover:bg-red-50',
                   'disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent',
                   'dark:text-red-400 dark:hover:bg-red-900/20',
-                  'dark:disabled:text-gray-600'
+                  'dark:disabled:text-muted-foreground'
                 )}
                 aria-label="Remove phone number"
               >

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -28,7 +28,7 @@ const progressBarFillVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary-500',
+        default: 'bg-primary-800',
         success: 'bg-green-500',
         warning: 'bg-yellow-500',
         danger: 'bg-red-500',
@@ -151,7 +151,7 @@ function Progress({
             progressBarFillVariants({ variant, animated, striped }),
             indeterminate &&
               'w-1/3 animate-[indeterminate_1.5s_ease-in-out_infinite]',
-            !striped && variant === 'default' && 'bg-primary-500',
+            !striped && variant === 'default' && 'bg-primary-800',
             !striped && variant === 'success' && 'bg-green-500',
             !striped && variant === 'warning' && 'bg-yellow-500',
             !striped && variant === 'danger' && 'bg-red-500'

--- a/src/components/ProviderCard/ProviderCard.stories.tsx
+++ b/src/components/ProviderCard/ProviderCard.stories.tsx
@@ -102,7 +102,7 @@ export const AllVariants: Story = {
   render: () => (
     <div className="space-y-8">
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Compact (grid)
         </p>
         <div className="w-80">
@@ -110,7 +110,7 @@ export const AllVariants: Story = {
         </div>
       </div>
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           List (horizontal)
         </p>
         <div className="max-w-2xl">
@@ -118,7 +118,7 @@ export const AllVariants: Story = {
         </div>
       </div>
       <div>
-        <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mb-2 text-sm text-muted-foreground">
           Featured
         </p>
         <div className="max-w-md">

--- a/src/components/ProviderCard/ProviderCard.stories.tsx
+++ b/src/components/ProviderCard/ProviderCard.stories.tsx
@@ -102,25 +102,19 @@ export const AllVariants: Story = {
   render: () => (
     <div className="space-y-8">
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Compact (grid)
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Compact (grid)</p>
         <div className="w-80">
           <ProviderCard provider={sampleProvider} variant="compact" />
         </div>
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          List (horizontal)
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">List (horizontal)</p>
         <div className="max-w-2xl">
           <ProviderCard provider={sampleProvider} variant="list" />
         </div>
       </div>
       <div>
-        <p className="mb-2 text-sm text-muted-foreground">
-          Featured
-        </p>
+        <p className="text-muted-foreground mb-2 text-sm">Featured</p>
         <div className="max-w-md">
           <ProviderCard provider={sampleProvider} variant="featured" />
         </div>

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -210,7 +210,7 @@ export function Breadcrumb({ items, className }: BreadcrumbProps) {
         {items.map((item, index) => (
           <li key={item.href} className="flex items-center">
             {index > 0 && (
-              <ChevronRightIcon className="mx-2 h-4 w-4 text-muted-foreground" />
+              <ChevronRightIcon className="text-muted-foreground mx-2 h-4 w-4" />
             )}
             {index === items.length - 1 ? (
               <span className="max-w-[200px] truncate font-medium text-gray-900 dark:text-white">
@@ -453,7 +453,7 @@ export function VerifiedBadge({
     <div
       data-slot="provider-detail-verified"
       className={cn(
-        'flex items-center gap-2 text-sm text-muted-foreground',
+        'text-muted-foreground flex items-center gap-2 text-sm',
         className
       )}
     >
@@ -548,7 +548,7 @@ export function ClaimListingButton({
     <a
       href={claimUrl}
       className={cn(
-        'hover:text-primary-600 dark:hover:text-primary-400 inline-flex items-center gap-2 text-sm text-muted-foreground',
+        'hover:text-primary-600 dark:hover:text-primary-400 text-muted-foreground inline-flex items-center gap-2 text-sm',
         className
       )}
     >
@@ -841,7 +841,7 @@ export function CompactProviderHeader({
           <h2 className="truncate text-lg font-semibold text-gray-900 dark:text-white">
             {provider.name}
           </h2>
-          <p className="truncate text-sm text-muted-foreground">
+          <p className="text-muted-foreground truncate text-sm">
             {provider.address.city}, {provider.address.state}{' '}
             {provider.address.postalCode}
           </p>

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -210,7 +210,7 @@ export function Breadcrumb({ items, className }: BreadcrumbProps) {
         {items.map((item, index) => (
           <li key={item.href} className="flex items-center">
             {index > 0 && (
-              <ChevronRightIcon className="mx-2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+              <ChevronRightIcon className="mx-2 h-4 w-4 text-muted-foreground" />
             )}
             {index === items.length - 1 ? (
               <span className="max-w-[200px] truncate font-medium text-gray-900 dark:text-white">
@@ -453,7 +453,7 @@ export function VerifiedBadge({
     <div
       data-slot="provider-detail-verified"
       className={cn(
-        'flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400',
+        'flex items-center gap-2 text-sm text-muted-foreground',
         className
       )}
     >
@@ -548,7 +548,7 @@ export function ClaimListingButton({
     <a
       href={claimUrl}
       className={cn(
-        'hover:text-primary-600 dark:hover:text-primary-400 inline-flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400',
+        'hover:text-primary-600 dark:hover:text-primary-400 inline-flex items-center gap-2 text-sm text-muted-foreground',
         className
       )}
     >
@@ -841,7 +841,7 @@ export function CompactProviderHeader({
           <h2 className="truncate text-lg font-semibold text-gray-900 dark:text-white">
             {provider.name}
           </h2>
-          <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+          <p className="truncate text-sm text-muted-foreground">
             {provider.address.city}, {provider.address.state}{' '}
             {provider.address.postalCode}
           </p>

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -55,7 +55,7 @@ const actionButtonVariants = cva(
     variants: {
       variant: {
         default:
-          'text-gray-600 hover:text-primary-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-800',
+          'text-gray-600 hover:text-primary-800 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-800',
         active:
           'text-primary-800 bg-primary-50 dark:text-primary-300 dark:bg-primary-900/20',
       },
@@ -410,7 +410,7 @@ export function SocialMediaLinks({
           rel="noopener noreferrer"
           title={`Visit ${providerName} on ${link.label}`}
           className={cn(
-            'hover:text-primary-600 dark:hover:text-primary-400 text-gray-500 transition-colors dark:text-gray-400',
+            'hover:text-primary-800 dark:hover:text-primary-400 text-gray-500 transition-colors dark:text-gray-400',
             socialIconSizes[size]
           )}
         >
@@ -509,7 +509,7 @@ export function AddressDisplay({
         target="_blank"
         rel="noopener noreferrer"
         className={cn(
-          'hover:text-primary-600 dark:hover:text-primary-400 text-gray-600 hover:underline dark:text-gray-300',
+          'hover:text-primary-800 dark:hover:text-primary-400 text-gray-600 hover:underline dark:text-gray-300',
           className
         )}
       >
@@ -548,7 +548,7 @@ export function ClaimListingButton({
     <a
       href={claimUrl}
       className={cn(
-        'hover:text-primary-600 dark:hover:text-primary-400 text-muted-foreground inline-flex items-center gap-2 text-sm',
+        'hover:text-primary-800 dark:hover:text-primary-400 text-muted-foreground inline-flex items-center gap-2 text-sm',
         className
       )}
     >

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -253,7 +253,7 @@ export function MobileBackButton({
     >
       <a
         href={href}
-        className="bg-primary-700 hover:bg-primary-800 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
+        className="bg-primary-800 hover:bg-primary-900 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
       >
         <ChevronLeftIcon className="h-4 w-4" />
         {label}
@@ -600,7 +600,7 @@ const bookButtonVariants = cva(
       },
       variant: {
         primary:
-          'bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500',
+          'bg-primary-800 text-white hover:bg-primary-900 focus:ring-primary-500',
         outline:
           'border-2 border-primary-800 text-primary-800 hover:bg-primary-50 focus:ring-primary-500 dark:border-primary-300 dark:text-primary-300 dark:hover:bg-primary-900/20',
       },

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -55,7 +55,7 @@ const actionButtonVariants = cva(
     variants: {
       variant: {
         default:
-          'text-gray-600 hover:text-primary-800 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-800',
+          'text-muted-foreground hover:text-primary-800 hover:bg-gray-50  dark:hover:text-primary-400 dark:hover:bg-gray-800',
         active:
           'text-primary-800 bg-primary-50 dark:text-primary-300 dark:bg-primary-900/20',
       },
@@ -410,7 +410,7 @@ export function SocialMediaLinks({
           rel="noopener noreferrer"
           title={`Visit ${providerName} on ${link.label}`}
           className={cn(
-            'hover:text-primary-800 dark:hover:text-primary-400 text-gray-500 transition-colors dark:text-gray-400',
+            'hover:text-primary-800 dark:hover:text-primary-400 text-muted-foreground transition-colors',
             socialIconSizes[size]
           )}
         >
@@ -509,7 +509,7 @@ export function AddressDisplay({
         target="_blank"
         rel="noopener noreferrer"
         className={cn(
-          'hover:text-primary-800 dark:hover:text-primary-400 text-gray-600 hover:underline dark:text-gray-300',
+          'hover:text-primary-800 dark:hover:text-primary-400 text-muted-foreground hover:underline',
           className
         )}
       >
@@ -519,9 +519,7 @@ export function AddressDisplay({
   }
 
   return (
-    <address
-      className={cn('text-gray-600 not-italic dark:text-gray-300', className)}
-    >
+    <address className={cn('text-muted-foreground not-italic', className)}>
       {addressContent}
     </address>
   );
@@ -575,7 +573,7 @@ export function ReportLink({ slug, href, className }: ReportLinkProps) {
     <a
       href={reportUrl}
       className={cn(
-        'inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300',
+        'text-muted-foreground inline-flex items-center gap-2 text-sm hover:text-gray-700 dark:hover:text-gray-300',
         className
       )}
     >

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -223,7 +223,7 @@ export function ProviderOverview({
           <h1 className="text-xl font-bold text-gray-900 dark:text-white">
             {providerName}
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Dashboard Overview
           </p>
         </div>
@@ -338,7 +338,7 @@ export function ProviderOverview({
                     }}
                     className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
                   >
-                    <span className="text-gray-500 dark:text-gray-400">
+                    <span className="text-muted-foreground">
                       {action.icon || (
                         <svg
                           className="h-5 w-5"
@@ -409,11 +409,11 @@ export function ProviderOverview({
                         )}
                       </div>
                       {activity.description && (
-                        <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+                        <p className="truncate text-sm text-muted-foreground">
                           {activity.description}
                         </p>
                       )}
-                      <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                      <p className="mt-0.5 text-xs text-muted-foreground">
                         {formatTime(activity.timestamp)}
                       </p>
                     </div>
@@ -462,7 +462,7 @@ function StatCard({ label, value, icon, color, onClick }: StatCardProps) {
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
             {value}
           </p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
+          <p className="text-xs text-muted-foreground">{label}</p>
         </div>
       </div>
     </div>

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -223,9 +223,7 @@ export function ProviderOverview({
           <h1 className="text-xl font-bold text-gray-900 dark:text-white">
             {providerName}
           </h1>
-          <p className="text-sm text-muted-foreground">
-            Dashboard Overview
-          </p>
+          <p className="text-muted-foreground text-sm">Dashboard Overview</p>
         </div>
       </div>
 
@@ -409,11 +407,11 @@ export function ProviderOverview({
                         )}
                       </div>
                       {activity.description && (
-                        <p className="truncate text-sm text-muted-foreground">
+                        <p className="text-muted-foreground truncate text-sm">
                           {activity.description}
                         </p>
                       )}
-                      <p className="mt-0.5 text-xs text-muted-foreground">
+                      <p className="text-muted-foreground mt-0.5 text-xs">
                         {formatTime(activity.timestamp)}
                       </p>
                     </div>
@@ -462,7 +460,7 @@ function StatCard({ label, value, icon, color, onClick }: StatCardProps) {
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
             {value}
           </p>
-          <p className="text-xs text-muted-foreground">{label}</p>
+          <p className="text-muted-foreground text-xs">{label}</p>
         </div>
       </div>
     </div>

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -384,7 +384,7 @@ export function ProviderOverview({
                     }
                     className={`flex items-start gap-3 rounded-lg p-2 ${onActivityClick ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800' : ''} `}
                   >
-                    <div className="rounded-full bg-gray-100 p-2 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                    <div className="text-muted-foreground rounded-full bg-gray-100 p-2 dark:bg-gray-800">
                       {getActivityIcon(activity.type)}
                     </div>
                     <div className="min-w-0 flex-1">

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.stories.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.stories.tsx
@@ -116,7 +116,7 @@ function FiltersDemo(
         services={mockServices}
         {...props}
       />
-      <div className="text-sm text-gray-500 dark:text-gray-400">
+      <div className="text-sm text-muted-foreground">
         <strong>Current filters:</strong>
         <pre className="mt-1">{JSON.stringify(filters, null, 2)}</pre>
       </div>

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.stories.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.stories.tsx
@@ -116,7 +116,7 @@ function FiltersDemo(
         services={mockServices}
         {...props}
       />
-      <div className="text-sm text-muted-foreground">
+      <div className="text-muted-foreground text-sm">
         <strong>Current filters:</strong>
         <pre className="mt-1">{JSON.stringify(filters, null, 2)}</pre>
       </div>

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -963,7 +963,7 @@ export function ActiveFilters({
       <button
         type="button"
         onClick={onClearAll}
-        className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 text-sm"
+        className="text-primary-800 hover:text-primary-900 dark:text-primary-400 dark:hover:text-primary-300 text-sm"
       >
         Clear all
       </button>

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -421,7 +421,7 @@ export function ServiceMultiSelect({
             selectVariants(),
             'w-full text-left',
             !selectedServices.length &&
-              'text-neutral-500 dark:text-neutral-400',
+              'text-muted-foreground',
             disabled && 'cursor-not-allowed opacity-50'
           )}
         >
@@ -516,7 +516,7 @@ export function ServiceMultiSelect({
               )
             )
           ) : (
-            <div className="px-3 py-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+            <div className="px-3 py-4 text-center text-sm text-muted-foreground">
               No services found
             </div>
           )}
@@ -940,7 +940,7 @@ export function ActiveFilters({
       className={cn('flex flex-wrap items-center gap-2', className)}
       data-slot="provider-active-filters"
     >
-      <span className="text-sm text-neutral-500 dark:text-neutral-400">
+      <span className="text-sm text-muted-foreground">
         Active filters:
       </span>
       {activeFilters.map((filter) => (

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -488,7 +488,7 @@ export function ServiceMultiSelect({
                             className={cn(
                               'flex h-4 w-4 items-center justify-center rounded border',
                               isSelected
-                                ? 'bg-primary-500 border-primary-500 text-white'
+                                ? 'bg-primary-800 border-primary-500 text-white'
                                 : 'border-neutral-300 dark:border-neutral-600'
                             )}
                           >
@@ -837,7 +837,7 @@ export function CompactFilterBar({
           disabled={loading}
           className={cn(
             'h-9 rounded-md px-4 text-sm font-medium',
-            'bg-primary-500 hover:bg-primary-600 text-white',
+            'bg-primary-800 hover:bg-primary-900 text-white',
             'focus:ring-primary-500 focus:ring-2 focus:ring-offset-2 focus:outline-none',
             'disabled:cursor-not-allowed disabled:opacity-50'
           )}

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -420,8 +420,7 @@ export function ServiceMultiSelect({
           className={cn(
             selectVariants(),
             'w-full text-left',
-            !selectedServices.length &&
-              'text-muted-foreground',
+            !selectedServices.length && 'text-muted-foreground',
             disabled && 'cursor-not-allowed opacity-50'
           )}
         >
@@ -516,7 +515,7 @@ export function ServiceMultiSelect({
               )
             )
           ) : (
-            <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+            <div className="text-muted-foreground px-3 py-4 text-center text-sm">
               No services found
             </div>
           )}
@@ -940,9 +939,7 @@ export function ActiveFilters({
       className={cn('flex flex-wrap items-center gap-2', className)}
       data-slot="provider-active-filters"
     >
-      <span className="text-sm text-muted-foreground">
-        Active filters:
-      </span>
+      <span className="text-muted-foreground text-sm">Active filters:</span>
       {activeFilters.map((filter) => (
         <span
           key={filter.key}

--- a/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/src/components/ProviderSettings/ProviderSettings.tsx
@@ -628,7 +628,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
-                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"
@@ -654,7 +654,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
-                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"
@@ -680,7 +680,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
-                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"
@@ -706,7 +706,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
-                          className="h-8 w-8 text-gray-600 dark:text-gray-300"
+                          className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"

--- a/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/src/components/ProviderSettings/ProviderSettings.tsx
@@ -426,7 +426,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           New Orders
                         </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           Receive email when a new order is placed
                         </p>
                       </div>
@@ -442,7 +442,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           Order Updates
                         </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           Receive email when an order status changes
                         </p>
                       </div>
@@ -458,7 +458,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           Invoice Notifications
                         </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           Receive email for invoice activity
                         </p>
                       </div>
@@ -482,7 +482,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           New Orders
                         </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           Receive SMS when a new order is placed
                         </p>
                       </div>
@@ -498,7 +498,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           Order Updates
                         </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           Receive SMS when an order status changes
                         </p>
                       </div>
@@ -530,7 +530,7 @@ export function ProviderSettings({
                       <p className="font-medium text-gray-700 dark:text-gray-300">
                         Accepting New Patients
                       </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                      <p className="text-sm text-muted-foreground">
                         Allow new patients to schedule appointments
                       </p>
                     </div>
@@ -546,7 +546,7 @@ export function ProviderSettings({
                       <p className="font-medium text-gray-700 dark:text-gray-300">
                         Require Appointment
                       </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                      <p className="text-sm text-muted-foreground">
                         Patients must schedule before arriving
                       </p>
                     </div>
@@ -579,7 +579,7 @@ export function ProviderSettings({
                         )
                       }
                     />
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Minimum time between appointments
                     </p>
                   </div>
@@ -602,7 +602,7 @@ export function ProviderSettings({
                         )
                       }
                     />
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Maximum appointments allowed per day
                     </p>
                   </div>
@@ -752,7 +752,7 @@ export function ProviderSettings({
                         )
                       }
                     />
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Number of days until invoice is due (e.g., Net 30)
                     </p>
                   </div>

--- a/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/src/components/ProviderSettings/ProviderSettings.tsx
@@ -426,7 +426,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           New Orders
                         </p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-muted-foreground text-sm">
                           Receive email when a new order is placed
                         </p>
                       </div>
@@ -442,7 +442,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           Order Updates
                         </p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-muted-foreground text-sm">
                           Receive email when an order status changes
                         </p>
                       </div>
@@ -458,7 +458,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           Invoice Notifications
                         </p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-muted-foreground text-sm">
                           Receive email for invoice activity
                         </p>
                       </div>
@@ -482,7 +482,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           New Orders
                         </p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-muted-foreground text-sm">
                           Receive SMS when a new order is placed
                         </p>
                       </div>
@@ -498,7 +498,7 @@ export function ProviderSettings({
                         <p className="font-medium text-gray-700 dark:text-gray-300">
                           Order Updates
                         </p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-muted-foreground text-sm">
                           Receive SMS when an order status changes
                         </p>
                       </div>
@@ -530,7 +530,7 @@ export function ProviderSettings({
                       <p className="font-medium text-gray-700 dark:text-gray-300">
                         Accepting New Patients
                       </p>
-                      <p className="text-sm text-muted-foreground">
+                      <p className="text-muted-foreground text-sm">
                         Allow new patients to schedule appointments
                       </p>
                     </div>
@@ -546,7 +546,7 @@ export function ProviderSettings({
                       <p className="font-medium text-gray-700 dark:text-gray-300">
                         Require Appointment
                       </p>
-                      <p className="text-sm text-muted-foreground">
+                      <p className="text-muted-foreground text-sm">
                         Patients must schedule before arriving
                       </p>
                     </div>
@@ -579,7 +579,7 @@ export function ProviderSettings({
                         )
                       }
                     />
-                    <p className="mt-1 text-xs text-muted-foreground">
+                    <p className="text-muted-foreground mt-1 text-xs">
                       Minimum time between appointments
                     </p>
                   </div>
@@ -602,7 +602,7 @@ export function ProviderSettings({
                         )
                       }
                     />
-                    <p className="mt-1 text-xs text-muted-foreground">
+                    <p className="text-muted-foreground mt-1 text-xs">
                       Maximum appointments allowed per day
                     </p>
                   </div>
@@ -752,7 +752,7 @@ export function ProviderSettings({
                         )
                       }
                     />
-                    <p className="mt-1 text-xs text-muted-foreground">
+                    <p className="text-muted-foreground mt-1 text-xs">
                       Number of days until invoice is due (e.g., Net 30)
                     </p>
                   </div>

--- a/src/components/ProviderUsersTable/ProviderUsersTable.tsx
+++ b/src/components/ProviderUsersTable/ProviderUsersTable.tsx
@@ -223,7 +223,7 @@ export function ProviderUsersTable({
                       <p className="font-medium text-gray-900 dark:text-white">
                         {user.name}
                         {isCurrentUser && (
-                          <span className="ml-1.5 text-xs text-gray-500">
+                          <span className="text-muted-foreground ml-1.5 text-xs">
                             (you)
                           </span>
                         )}

--- a/src/components/ProviderUsersTable/ProviderUsersTable.tsx
+++ b/src/components/ProviderUsersTable/ProviderUsersTable.tsx
@@ -171,9 +171,7 @@ export function ProviderUsersTable({
 
   if (users.length === 0) {
     return (
-      <div
-        className={`py-12 text-center text-muted-foreground ${className}`}
-      >
+      <div className={`text-muted-foreground py-12 text-center ${className}`}>
         <svg
           className="mx-auto h-12 w-12 text-gray-400"
           fill="none"
@@ -230,7 +228,7 @@ export function ProviderUsersTable({
                           </span>
                         )}
                       </p>
-                      <p className="text-sm text-muted-foreground">
+                      <p className="text-muted-foreground text-sm">
                         {user.email}
                       </p>
                     </div>
@@ -247,7 +245,7 @@ export function ProviderUsersTable({
                   </Badge>
                 </TableCell>
                 <TableCell>
-                  <span className="text-sm text-muted-foreground">
+                  <span className="text-muted-foreground text-sm">
                     {isPending
                       ? `Invited ${formatDate(user.invitedAt)}`
                       : formatDate(user.lastActive)}

--- a/src/components/ProviderUsersTable/ProviderUsersTable.tsx
+++ b/src/components/ProviderUsersTable/ProviderUsersTable.tsx
@@ -172,7 +172,7 @@ export function ProviderUsersTable({
   if (users.length === 0) {
     return (
       <div
-        className={`py-12 text-center text-gray-500 dark:text-gray-400 ${className}`}
+        className={`py-12 text-center text-muted-foreground ${className}`}
       >
         <svg
           className="mx-auto h-12 w-12 text-gray-400"
@@ -230,7 +230,7 @@ export function ProviderUsersTable({
                           </span>
                         )}
                       </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                      <p className="text-sm text-muted-foreground">
                         {user.email}
                       </p>
                     </div>
@@ -247,7 +247,7 @@ export function ProviderUsersTable({
                   </Badge>
                 </TableCell>
                 <TableCell>
-                  <span className="text-sm text-gray-500 dark:text-gray-400">
+                  <span className="text-sm text-muted-foreground">
                     {isPending
                       ? `Invited ${formatDate(user.invitedAt)}`
                       : formatDate(user.lastActive)}

--- a/src/components/QuickAction/QuickAction.tsx
+++ b/src/components/QuickAction/QuickAction.tsx
@@ -134,7 +134,7 @@ const QuickAction = React.forwardRef<HTMLButtonElement, QuickActionProps>(
           </div>
           <div
             data-slot="quick-action-subtitle"
-            className="text-xs text-muted-foreground"
+            className="text-muted-foreground text-xs"
           >
             {subtitle}
           </div>

--- a/src/components/QuickAction/QuickAction.tsx
+++ b/src/components/QuickAction/QuickAction.tsx
@@ -134,7 +134,7 @@ const QuickAction = React.forwardRef<HTMLButtonElement, QuickActionProps>(
           </div>
           <div
             data-slot="quick-action-subtitle"
-            className="text-xs text-neutral-500 dark:text-neutral-400"
+            className="text-xs text-muted-foreground"
           >
             {subtitle}
           </div>

--- a/src/components/QuickAction/QuickAction.tsx
+++ b/src/components/QuickAction/QuickAction.tsx
@@ -8,7 +8,7 @@ const quickActionIconVariants = cva(
     variants: {
       color: {
         primary:
-          'bg-primary-100 text-primary-600 dark:bg-primary-900/50 dark:text-primary-400',
+          'bg-primary-100 text-primary-800 dark:bg-primary-900/50 dark:text-primary-400',
         green:
           'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/50 dark:text-emerald-400',
         purple:

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -285,7 +285,7 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
         <span
           data-slot="radio-dot"
           className={cn(
-            'bg-primary-500 pointer-events-none absolute rounded-full transition-transform',
+            'bg-primary-800 pointer-events-none absolute rounded-full transition-transform',
             size === 'sm' && 'h-2 w-2',
             size === 'md' && 'h-2.5 w-2.5',
             size === 'lg' && 'h-3 w-3',

--- a/src/components/RecurringServiceCard/RecurringServiceCard.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.tsx
@@ -461,7 +461,7 @@ export function RecurringServiceSetupModal({
         data-slot="recurring-service-modal"
       >
         {/* Header */}
-        <div className="bg-primary-800 flex items-center justify-between p-4 text-white">
+        <div className="bg-primary-800 text-primary-foreground flex items-center justify-between p-4">
           <h4 className="text-lg font-semibold">{title}</h4>
           <button
             type="button"
@@ -573,7 +573,7 @@ export function RecurringServiceSetupModal({
             <button
               type="submit"
               disabled={saving}
-              className="bg-primary-800 hover:bg-primary-900 disabled:bg-muted disabled:text-muted-foreground rounded-lg px-4 py-2 text-white transition-colors"
+              className="bg-primary-800 hover:bg-primary-900 disabled:bg-muted disabled:text-muted-foreground text-primary-foreground rounded-lg px-4 py-2 transition-colors"
             >
               {saving ? (
                 <span className="flex items-center gap-2">

--- a/src/components/RecurringServiceCard/RecurringServiceCard.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.tsx
@@ -146,7 +146,7 @@ export function RecurringServiceCard({
     primary: {
       border: 'border-primary/30',
       icon: (
-        <span className="bg-primary-800 text-white flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
+        <span className="bg-primary-800 text-primary-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
           <svg
             className="h-3 w-3"
             fill="none"

--- a/src/components/RecurringServiceCard/RecurringServiceCard.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.tsx
@@ -461,7 +461,7 @@ export function RecurringServiceSetupModal({
         data-slot="recurring-service-modal"
       >
         {/* Header */}
-        <div className="bg-primary-800 text-white flex items-center justify-between p-4">
+        <div className="bg-primary-800 flex items-center justify-between p-4 text-white">
           <h4 className="text-lg font-semibold">{title}</h4>
           <button
             type="button"
@@ -573,7 +573,7 @@ export function RecurringServiceSetupModal({
             <button
               type="submit"
               disabled={saving}
-              className="bg-primary-800 text-white hover:bg-primary-900 disabled:bg-muted disabled:text-muted-foreground rounded-lg px-4 py-2 transition-colors"
+              className="bg-primary-800 hover:bg-primary-900 disabled:bg-muted disabled:text-muted-foreground rounded-lg px-4 py-2 text-white transition-colors"
             >
               {saving ? (
                 <span className="flex items-center gap-2">

--- a/src/components/RecurringServiceCard/RecurringServiceCard.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.tsx
@@ -146,7 +146,7 @@ export function RecurringServiceCard({
     primary: {
       border: 'border-primary/30',
       icon: (
-        <span className="bg-primary text-primary-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
+        <span className="bg-primary-800 text-white flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
           <svg
             className="h-3 w-3"
             fill="none"
@@ -461,7 +461,7 @@ export function RecurringServiceSetupModal({
         data-slot="recurring-service-modal"
       >
         {/* Header */}
-        <div className="bg-primary text-primary-foreground flex items-center justify-between p-4">
+        <div className="bg-primary-800 text-white flex items-center justify-between p-4">
           <h4 className="text-lg font-semibold">{title}</h4>
           <button
             type="button"
@@ -573,7 +573,7 @@ export function RecurringServiceSetupModal({
             <button
               type="submit"
               disabled={saving}
-              className="bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground rounded-lg px-4 py-2 transition-colors"
+              className="bg-primary-800 text-white hover:bg-primary-900 disabled:bg-muted disabled:text-muted-foreground rounded-lg px-4 py-2 transition-colors"
             >
               {saving ? (
                 <span className="flex items-center gap-2">

--- a/src/components/ReportDashboard/ReportDashboard.tsx
+++ b/src/components/ReportDashboard/ReportDashboard.tsx
@@ -177,9 +177,7 @@ export function ReportDashboard({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             {title}
           </h1>
-          <p className="text-sm text-muted-foreground">
-            {dateRangeLabel}
-          </p>
+          <p className="text-muted-foreground text-sm">{dateRangeLabel}</p>
         </div>
         <div className="flex items-center gap-3">
           <Select
@@ -230,9 +228,7 @@ export function ReportDashboard({
         {metrics.map((metric, index) => (
           <Card key={index}>
             <CardContent className="p-4">
-              <p className="text-sm text-muted-foreground">
-                {metric.label}
-              </p>
+              <p className="text-muted-foreground text-sm">{metric.label}</p>
               <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
                 {typeof metric.value === 'number'
                   ? metric.label.toLowerCase().includes('revenue') ||
@@ -291,7 +287,7 @@ export function ReportDashboard({
                         title={`Current: ${point.value}`}
                       />
                     </div>
-                    <span className="w-full truncate text-center text-xs text-muted-foreground">
+                    <span className="text-muted-foreground w-full truncate text-center text-xs">
                       {point.label}
                     </span>
                   </div>

--- a/src/components/ReportDashboard/ReportDashboard.tsx
+++ b/src/components/ReportDashboard/ReportDashboard.tsx
@@ -296,14 +296,12 @@ export function ReportDashboard({
               <div className="mt-4 flex items-center justify-center gap-4 text-sm">
                 <div className="flex items-center gap-2">
                   <div className="h-3 w-3 rounded bg-blue-500 dark:bg-blue-400" />
-                  <span className="text-gray-600 dark:text-gray-300">
-                    Current Period
-                  </span>
+                  <span className="text-muted-foreground">Current Period</span>
                 </div>
                 {chartData.some((d) => d.previousValue !== undefined) && (
                   <div className="flex items-center gap-2">
                     <div className="h-3 w-3 rounded bg-gray-200 dark:bg-gray-700" />
-                    <span className="text-gray-600 dark:text-gray-300">
+                    <span className="text-muted-foreground">
                       Previous Period
                     </span>
                   </div>
@@ -340,7 +338,7 @@ export function ReportDashboard({
                         <p className="font-medium text-gray-900 dark:text-white">
                           {service.name}
                         </p>
-                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                        <p className="text-muted-foreground text-sm">
                           {formatNumber(service.value)}
                         </p>
                       </div>
@@ -381,7 +379,7 @@ export function ReportDashboard({
                         <p className="font-medium text-gray-900 dark:text-white">
                           {employer.name}
                         </p>
-                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                        <p className="text-muted-foreground text-sm">
                           {formatCurrency(employer.value)}
                         </p>
                       </div>

--- a/src/components/ReportDashboard/ReportDashboard.tsx
+++ b/src/components/ReportDashboard/ReportDashboard.tsx
@@ -98,7 +98,7 @@ export function ReportDashboard({
       case 'down':
         return 'text-red-700 dark:text-red-300';
       default:
-        return 'text-gray-500 dark:text-gray-400';
+        return 'text-muted-foreground';
     }
   };
 
@@ -177,7 +177,7 @@ export function ReportDashboard({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             {title}
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             {dateRangeLabel}
           </p>
         </div>
@@ -230,7 +230,7 @@ export function ReportDashboard({
         {metrics.map((metric, index) => (
           <Card key={index}>
             <CardContent className="p-4">
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-muted-foreground">
                 {metric.label}
               </p>
               <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
@@ -291,7 +291,7 @@ export function ReportDashboard({
                         title={`Current: ${point.value}`}
                       />
                     </div>
-                    <span className="w-full truncate text-center text-xs text-gray-500 dark:text-gray-400">
+                    <span className="w-full truncate text-center text-xs text-muted-foreground">
                       {point.label}
                     </span>
                   </div>

--- a/src/components/ScheduleCalendar/ScheduleCalendar.tsx
+++ b/src/components/ScheduleCalendar/ScheduleCalendar.tsx
@@ -273,7 +273,7 @@ export function ScheduleCalendar({
                       : ''
                   }`}
                 >
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-muted-foreground text-xs">
                     {date.toLocaleDateString('en-US', { weekday: 'short' })}
                   </p>
                   <p
@@ -300,7 +300,7 @@ export function ScheduleCalendar({
               {hours.map((hour) => (
                 <div
                   key={hour}
-                  className="h-16 pr-2 text-right text-xs text-muted-foreground"
+                  className="text-muted-foreground h-16 pr-2 text-right text-xs"
                 >
                   {new Date(2000, 0, 1, hour).toLocaleTimeString('en-US', {
                     hour: 'numeric',

--- a/src/components/ScheduleCalendar/ScheduleCalendar.tsx
+++ b/src/components/ScheduleCalendar/ScheduleCalendar.tsx
@@ -273,7 +273,7 @@ export function ScheduleCalendar({
                       : ''
                   }`}
                 >
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <p className="text-xs text-muted-foreground">
                     {date.toLocaleDateString('en-US', { weekday: 'short' })}
                   </p>
                   <p
@@ -300,7 +300,7 @@ export function ScheduleCalendar({
               {hours.map((hour) => (
                 <div
                   key={hour}
-                  className="h-16 pr-2 text-right text-xs text-gray-500 dark:text-gray-400"
+                  className="h-16 pr-2 text-right text-xs text-muted-foreground"
                 >
                   {new Date(2000, 0, 1, hour).toLocaleTimeString('en-US', {
                     hour: 'numeric',
@@ -390,19 +390,19 @@ export function ScheduleCalendar({
       >
         <div className="flex items-center gap-1">
           <span className="h-3 w-3 rounded bg-blue-700" />
-          <span className="text-gray-600 dark:text-gray-400">Confirmed</span>
+          <span className="text-muted-foreground">Confirmed</span>
         </div>
         <div className="flex items-center gap-1">
           <span className="h-3 w-3 rounded bg-yellow-700" />
-          <span className="text-gray-600 dark:text-gray-400">Pending</span>
+          <span className="text-muted-foreground">Pending</span>
         </div>
         <div className="flex items-center gap-1">
           <span className="h-3 w-3 rounded bg-green-700" />
-          <span className="text-gray-600 dark:text-gray-400">Completed</span>
+          <span className="text-muted-foreground">Completed</span>
         </div>
         <div className="flex items-center gap-1">
           <span className="h-3 w-3 rounded bg-gray-600" />
-          <span className="text-gray-600 dark:text-gray-400">Cancelled</span>
+          <span className="text-muted-foreground">Cancelled</span>
         </div>
       </div>
     </div>

--- a/src/components/SchedulePicker/SchedulePicker.stories.tsx
+++ b/src/components/SchedulePicker/SchedulePicker.stories.tsx
@@ -74,7 +74,7 @@ function SchedulePickerWithState(
         onTimeSelect={setSelectedTime}
       />
       <div className="mt-4 rounded-lg border border-neutral-200 p-4 dark:border-neutral-700">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Selected:{' '}
           {selectedDate
             ? selectedDate.toLocaleDateString('en-US', {
@@ -308,7 +308,7 @@ export const RadioOptions: Story = {
         selected
       >
         <div className="mt-4 rounded bg-neutral-100 p-2 dark:bg-neutral-800">
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Additional content shown when selected
           </p>
         </div>
@@ -357,7 +357,7 @@ function CompleteFlowDemo() {
         <h4 className="font-medium text-neutral-900 dark:text-white">
           Selection Summary
         </h4>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="text-muted-foreground mt-1 text-sm">
           {mode === 'walk-in'
             ? 'Walk-in appointment - no reservation needed'
             : selectedDate

--- a/src/components/SchedulePicker/SchedulePicker.stories.tsx
+++ b/src/components/SchedulePicker/SchedulePicker.stories.tsx
@@ -74,7 +74,7 @@ function SchedulePickerWithState(
         onTimeSelect={setSelectedTime}
       />
       <div className="mt-4 rounded-lg border border-neutral-200 p-4 dark:border-neutral-700">
-        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+        <p className="text-sm text-muted-foreground">
           Selected:{' '}
           {selectedDate
             ? selectedDate.toLocaleDateString('en-US', {
@@ -308,7 +308,7 @@ export const RadioOptions: Story = {
         selected
       >
         <div className="mt-4 rounded bg-neutral-100 p-2 dark:bg-neutral-800">
-          <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          <p className="text-sm text-muted-foreground">
             Additional content shown when selected
           </p>
         </div>
@@ -357,7 +357,7 @@ function CompleteFlowDemo() {
         <h4 className="font-medium text-neutral-900 dark:text-white">
           Selection Summary
         </h4>
-        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+        <p className="mt-1 text-sm text-muted-foreground">
           {mode === 'walk-in'
             ? 'Walk-in appointment - no reservation needed'
             : selectedDate

--- a/src/components/SchedulePicker/SchedulePicker.tsx
+++ b/src/components/SchedulePicker/SchedulePicker.tsx
@@ -189,7 +189,7 @@ const RadioOption = React.forwardRef<HTMLDivElement, RadioOptionProps>(
             className={cn(
               'flex h-5 w-5 items-center justify-center rounded-full border-2',
               selected
-                ? 'border-primary-500 bg-primary-500'
+                ? 'border-primary-500 bg-primary-800'
                 : 'border-neutral-300'
             )}
           >

--- a/src/components/SchedulePicker/SchedulePicker.tsx
+++ b/src/components/SchedulePicker/SchedulePicker.tsx
@@ -49,7 +49,7 @@ const DateButton = React.forwardRef<HTMLButtonElement, DateButtonProps>(
       >
         <div
           data-slot="schedule-date-weekday"
-          className="text-xs text-muted-foreground"
+          className="text-muted-foreground text-xs"
         >
           {date.toLocaleDateString('en-US', { weekday: 'short' })}
         </div>
@@ -61,7 +61,7 @@ const DateButton = React.forwardRef<HTMLButtonElement, DateButtonProps>(
         </div>
         <div
           data-slot="schedule-date-month"
-          className="text-xs text-muted-foreground"
+          className="text-muted-foreground text-xs"
         >
           {date.toLocaleDateString('en-US', { month: 'short' })}
         </div>
@@ -210,7 +210,7 @@ const RadioOption = React.forwardRef<HTMLDivElement, RadioOptionProps>(
             {description && (
               <div
                 data-slot="schedule-radio-desc"
-                className="text-sm text-muted-foreground"
+                className="text-muted-foreground text-sm"
               >
                 {description}
               </div>

--- a/src/components/SchedulePicker/SchedulePicker.tsx
+++ b/src/components/SchedulePicker/SchedulePicker.tsx
@@ -49,7 +49,7 @@ const DateButton = React.forwardRef<HTMLButtonElement, DateButtonProps>(
       >
         <div
           data-slot="schedule-date-weekday"
-          className="text-xs text-neutral-500 dark:text-neutral-400"
+          className="text-xs text-muted-foreground"
         >
           {date.toLocaleDateString('en-US', { weekday: 'short' })}
         </div>
@@ -61,7 +61,7 @@ const DateButton = React.forwardRef<HTMLButtonElement, DateButtonProps>(
         </div>
         <div
           data-slot="schedule-date-month"
-          className="text-xs text-neutral-500 dark:text-neutral-400"
+          className="text-xs text-muted-foreground"
         >
           {date.toLocaleDateString('en-US', { month: 'short' })}
         </div>
@@ -210,7 +210,7 @@ const RadioOption = React.forwardRef<HTMLDivElement, RadioOptionProps>(
             {description && (
               <div
                 data-slot="schedule-radio-desc"
-                className="text-sm text-neutral-500 dark:text-neutral-400"
+                className="text-sm text-muted-foreground"
               >
                 {description}
               </div>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -413,7 +413,7 @@ function ControlledDemo() {
       <button
         type="button"
         onClick={() => setValue('')}
-        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm"
+        className="bg-primary-800 text-white hover:bg-primary-900 rounded px-3 py-1.5 text-sm"
       >
         Reset
       </button>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -413,7 +413,7 @@ function ControlledDemo() {
       <button
         type="button"
         onClick={() => setValue('')}
-        className="bg-primary-800 text-white hover:bg-primary-900 rounded px-3 py-1.5 text-sm"
+        className="bg-primary-800 hover:bg-primary-900 rounded px-3 py-1.5 text-sm text-white"
       >
         Reset
       </button>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -607,7 +607,7 @@ function SelectOptionItem({
     >
       <span className="flex-1 truncate">{option.label}</span>
       {isSelected && (
-        <CheckIcon className="text-primary-500 h-4 w-4 shrink-0" />
+        <CheckIcon className="text-primary-800 h-4 w-4 shrink-0" />
       )}
     </li>
   );

--- a/src/components/ServiceAccordion/ServiceAccordion.tsx
+++ b/src/components/ServiceAccordion/ServiceAccordion.tsx
@@ -114,7 +114,7 @@ const serviceLinkVariants = cva(
   [
     'flex items-center gap-2 py-2 px-3 rounded-md',
     'text-neutral-700 dark:text-neutral-300',
-    'hover:bg-neutral-100 dark:hover:bg-neutral-700/50 hover:text-primary-600 dark:hover:text-primary-400',
+    'hover:bg-neutral-100 dark:hover:bg-neutral-700/50 hover:text-primary-800 dark:hover:text-primary-400',
     'transition-colors',
     'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
   ],
@@ -238,7 +238,7 @@ function SubCategoryAccordion({
         className={cn(
           'flex w-full items-center justify-between px-3 py-2',
           'text-left font-medium text-neutral-700 dark:text-neutral-200',
-          'hover:text-primary-600 dark:hover:text-primary-400',
+          'hover:text-primary-800 dark:hover:text-primary-400',
           'focus-visible:ring-primary-500 focus:outline-none focus-visible:ring-2'
         )}
         aria-expanded={isExpanded}
@@ -341,7 +341,7 @@ function CategoryAccordionItem({
       >
         <div className="flex items-center gap-3">
           {category.icon && (
-            <span className="text-primary-500 dark:text-primary-400">
+            <span className="text-primary-800 dark:text-primary-400">
               {typeof category.icon === 'string' ? (
                 <span className="text-xl">{category.icon}</span>
               ) : (
@@ -617,7 +617,7 @@ export function ServiceList({
             className={cn(
               'flex items-center gap-2 py-1.5',
               'text-neutral-700 dark:text-neutral-300',
-              'hover:text-primary-600 dark:hover:text-primary-400',
+              'hover:text-primary-800 dark:hover:text-primary-400',
               'transition-colors'
             )}
           >

--- a/src/components/ServiceAccordion/ServiceAccordion.tsx
+++ b/src/components/ServiceAccordion/ServiceAccordion.tsx
@@ -204,7 +204,7 @@ export function ServiceLink({
       <LinkIcon className="flex-shrink-0 text-neutral-400" />
       <span className="flex-grow">{service.name}</span>
       {service.providerCount !== undefined && (
-        <span className="ml-2 text-xs text-neutral-400 dark:text-neutral-500">
+        <span className="ml-2 text-xs text-muted-foreground">
           ({service.providerCount})
         </span>
       )}
@@ -557,7 +557,7 @@ export function ServiceTagCloud({
         </a>
       ))}
       {hasMore && (
-        <span className="inline-flex items-center px-3 py-1.5 text-sm text-neutral-500 dark:text-neutral-400">
+        <span className="inline-flex items-center px-3 py-1.5 text-sm text-muted-foreground">
           +{services.length - (maxItems || 0)} more
         </span>
       )}

--- a/src/components/ServiceAccordion/ServiceAccordion.tsx
+++ b/src/components/ServiceAccordion/ServiceAccordion.tsx
@@ -204,7 +204,7 @@ export function ServiceLink({
       <LinkIcon className="flex-shrink-0 text-neutral-400" />
       <span className="flex-grow">{service.name}</span>
       {service.providerCount !== undefined && (
-        <span className="ml-2 text-xs text-muted-foreground">
+        <span className="text-muted-foreground ml-2 text-xs">
           ({service.providerCount})
         </span>
       )}
@@ -557,7 +557,7 @@ export function ServiceTagCloud({
         </a>
       ))}
       {hasMore && (
-        <span className="inline-flex items-center px-3 py-1.5 text-sm text-muted-foreground">
+        <span className="text-muted-foreground inline-flex items-center px-3 py-1.5 text-sm">
           +{services.length - (maxItems || 0)} more
         </span>
       )}

--- a/src/components/ServiceBadge/ServiceBadge.stories.tsx
+++ b/src/components/ServiceBadge/ServiceBadge.stories.tsx
@@ -138,7 +138,7 @@ function RemovableWrapper() {
     return (
       <button
         onClick={() => setVisible(true)}
-        className="text-primary-600 underline"
+        className="text-primary-800 underline"
       >
         Reset
       </button>

--- a/src/components/ServiceBadge/ServiceBadge.tsx
+++ b/src/components/ServiceBadge/ServiceBadge.tsx
@@ -374,7 +374,7 @@ export function SelectedServicesBadges({
         <button
           type="button"
           onClick={onClearAll}
-          className="ml-1 text-xs text-gray-500 underline hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          className="text-muted-foreground ml-1 text-xs underline hover:text-gray-700 dark:hover:text-gray-200"
         >
           Clear all
         </button>

--- a/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
+++ b/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
@@ -91,7 +91,7 @@ export function ServiceGeneralSettings({
           General Settings
         </CardTitle>
         <p
-          className="text-sm text-muted-foreground"
+          className="text-muted-foreground text-sm"
           data-slot="service-settings-description"
         >
           Basic service information and configuration
@@ -122,7 +122,7 @@ export function ServiceGeneralSettings({
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Active
               </p>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 Service is available for orders
               </p>
             </div>
@@ -134,7 +134,7 @@ export function ServiceGeneralSettings({
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Featured
               </p>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 Show prominently in listings
               </p>
             </div>

--- a/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
+++ b/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
@@ -209,7 +209,7 @@ export function ServiceGeneralSettings({
                 Base Price
               </label>
               <div className="relative">
-                <span className="absolute top-1/2 left-3 -translate-y-1/2 text-gray-500">
+                <span className="text-muted-foreground absolute top-1/2 left-3 -translate-y-1/2">
                   $
                 </span>
                 <input
@@ -246,7 +246,7 @@ export function ServiceGeneralSettings({
                   }
                   placeholder="0"
                 />
-                <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">
+                <span className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 text-sm">
                   days
                 </span>
               </div>

--- a/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
+++ b/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
@@ -91,7 +91,7 @@ export function ServiceGeneralSettings({
           General Settings
         </CardTitle>
         <p
-          className="text-sm text-gray-500 dark:text-gray-400"
+          className="text-sm text-muted-foreground"
           data-slot="service-settings-description"
         >
           Basic service information and configuration
@@ -122,7 +122,7 @@ export function ServiceGeneralSettings({
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Active
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 Service is available for orders
               </p>
             </div>
@@ -134,7 +134,7 @@ export function ServiceGeneralSettings({
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Featured
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 Show prominently in listings
               </p>
             </div>

--- a/src/components/ServicePicker/ServicePicker.tsx
+++ b/src/components/ServicePicker/ServicePicker.tsx
@@ -481,7 +481,7 @@ function ServiceItem({
                 'cursor-pointer transition-all duration-150',
                 'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
                 'disabled:cursor-not-allowed disabled:opacity-50',
-                'checked:bg-primary-500 checked:border-primary-500'
+                'checked:bg-primary-800 checked:border-primary-500'
               )}
             />
             <CheckIcon className="pointer-events-none absolute h-3 w-3 text-white opacity-0 transition-opacity peer-checked:opacity-100" />
@@ -507,7 +507,7 @@ function ServiceItem({
             />
             <span
               data-slot="service-picker-radio-dot"
-              className="bg-primary-500 pointer-events-none absolute h-2 w-2 scale-0 rounded-full transition-transform peer-checked:scale-100"
+              className="bg-primary-800 pointer-events-none absolute h-2 w-2 scale-0 rounded-full transition-transform peer-checked:scale-100"
             />
           </span>
         )}

--- a/src/components/ServicePricingManager/ServicePricingManager.tsx
+++ b/src/components/ServicePricingManager/ServicePricingManager.tsx
@@ -257,7 +257,7 @@ export function ServicePricingManager({
             ) : (
               <div className="divide-y divide-gray-200 dark:divide-gray-700">
                 {/* Desktop header */}
-                <div className="hidden gap-4 py-3 text-xs font-medium text-gray-500 uppercase md:grid md:grid-cols-6 dark:text-gray-400">
+                <div className="text-muted-foreground hidden gap-4 py-3 text-xs font-medium uppercase md:grid md:grid-cols-6">
                   <div className="col-span-2">Service</div>
                   <div className="text-right">Base Price</div>
                   <div className="text-right">Employer Price</div>
@@ -288,7 +288,7 @@ export function ServicePricingManager({
 
                     {/* Base price */}
                     <div className="mb-2 flex items-center justify-between md:mb-0 md:block">
-                      <span className="text-sm text-gray-500 md:hidden">
+                      <span className="text-muted-foreground text-sm md:hidden">
                         Base:
                       </span>
                       <p className="text-right font-semibold text-gray-900 dark:text-white">
@@ -298,10 +298,10 @@ export function ServicePricingManager({
 
                     {/* Employer price */}
                     <div className="mb-2 flex items-center justify-between md:mb-0 md:block">
-                      <span className="text-sm text-gray-500 md:hidden">
+                      <span className="text-muted-foreground text-sm md:hidden">
                         Employer:
                       </span>
-                      <p className="text-right text-gray-600 dark:text-gray-300">
+                      <p className="text-muted-foreground text-right">
                         {service.employerPrice
                           ? formatCurrency(service.employerPrice)
                           : '—'}
@@ -310,7 +310,7 @@ export function ServicePricingManager({
 
                     {/* Status */}
                     <div className="mb-2 flex items-center md:mb-0 md:justify-center">
-                      <span className="mr-2 text-sm text-gray-500 md:hidden">
+                      <span className="text-muted-foreground mr-2 text-sm md:hidden">
                         Status:
                       </span>
                       <Badge

--- a/src/components/ServicePricingManager/ServicePricingManager.tsx
+++ b/src/components/ServicePricingManager/ServicePricingManager.tsx
@@ -190,7 +190,7 @@ export function ServicePricingManager({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Service Pricing
           </h1>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Manage pricing for {services.length} services
           </p>
         </div>
@@ -251,7 +251,7 @@ export function ServicePricingManager({
           </CardHeader>
           <CardContent>
             {filteredServices.length === 0 ? (
-              <p className="py-8 text-center text-muted-foreground">
+              <p className="text-muted-foreground py-8 text-center">
                 No services found
               </p>
             ) : (
@@ -276,7 +276,7 @@ export function ServicePricingManager({
                       <p className="font-medium text-gray-900 dark:text-white">
                         {service.serviceName}
                       </p>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <div className="text-muted-foreground flex items-center gap-2 text-sm">
                         {service.serviceCode && (
                           <span>{service.serviceCode}</span>
                         )}
@@ -414,7 +414,7 @@ export function ServicePricingManager({
           <ModalTitle>Bulk Price Adjustment</ModalTitle>
         </ModalHeader>
         <ModalBody className="space-y-4">
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Apply adjustment to {filteredServices.length} filtered services
           </p>
           <div className="flex gap-2">
@@ -448,7 +448,7 @@ export function ServicePricingManager({
                 bulkAdjustmentType === 'percent' ? 'e.g., 5' : 'e.g., 10.00'
               }
             />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="text-muted-foreground mt-1 text-xs">
               Use negative values to decrease prices
             </p>
           </div>

--- a/src/components/ServicePricingManager/ServicePricingManager.tsx
+++ b/src/components/ServicePricingManager/ServicePricingManager.tsx
@@ -190,7 +190,7 @@ export function ServicePricingManager({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Service Pricing
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Manage pricing for {services.length} services
           </p>
         </div>
@@ -251,7 +251,7 @@ export function ServicePricingManager({
           </CardHeader>
           <CardContent>
             {filteredServices.length === 0 ? (
-              <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+              <p className="py-8 text-center text-muted-foreground">
                 No services found
               </p>
             ) : (
@@ -276,7 +276,7 @@ export function ServicePricingManager({
                       <p className="font-medium text-gray-900 dark:text-white">
                         {service.serviceName}
                       </p>
-                      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
                         {service.serviceCode && (
                           <span>{service.serviceCode}</span>
                         )}
@@ -414,7 +414,7 @@ export function ServicePricingManager({
           <ModalTitle>Bulk Price Adjustment</ModalTitle>
         </ModalHeader>
         <ModalBody className="space-y-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Apply adjustment to {filteredServices.length} filtered services
           </p>
           <div className="flex gap-2">
@@ -448,7 +448,7 @@ export function ServicePricingManager({
                 bulkAdjustmentType === 'percent' ? 'e.g., 5' : 'e.g., 10.00'
               }
             />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-xs text-muted-foreground">
               Use negative values to decrease prices
             </p>
           </div>

--- a/src/components/ServiceShippingSettings/ServiceShippingSettings.tsx
+++ b/src/components/ServiceShippingSettings/ServiceShippingSettings.tsx
@@ -160,7 +160,7 @@ export function ServiceShippingSettings({
           />
         </div>
         <p
-          className="text-sm text-muted-foreground"
+          className="text-muted-foreground text-sm"
           data-slot="shipping-settings-description"
         >
           Configure how kits and materials are shipped
@@ -195,7 +195,7 @@ export function ServiceShippingSettings({
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Use Kit Shipping
               </p>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 Send collection kits to patients
               </p>
             </div>

--- a/src/components/ServiceShippingSettings/ServiceShippingSettings.tsx
+++ b/src/components/ServiceShippingSettings/ServiceShippingSettings.tsx
@@ -160,7 +160,7 @@ export function ServiceShippingSettings({
           />
         </div>
         <p
-          className="text-sm text-gray-500 dark:text-gray-400"
+          className="text-sm text-muted-foreground"
           data-slot="shipping-settings-description"
         >
           Configure how kits and materials are shipped
@@ -195,7 +195,7 @@ export function ServiceShippingSettings({
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Use Kit Shipping
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 Send collection kits to patients
               </p>
             </div>

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -227,7 +227,7 @@ function CollapsibleDemo() {
         <h1 className="mb-4 text-xl font-semibold text-neutral-900 capitalize dark:text-white">
           {activePage}
         </h1>
-        <p className="text-neutral-600 dark:text-neutral-400">
+        <p className="text-muted-foreground">
           Try clicking the collapse button in the sidebar footer to see the
           collapsed state.
         </p>
@@ -362,7 +362,7 @@ function ConfigurableSidebarDemo({
           </h1>
         </div>
         <div className="rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-700 dark:bg-neutral-800">
-          <p className="text-neutral-600 dark:text-neutral-400">
+          <p className="text-muted-foreground">
             Content for the {activePage} page goes here. Click navigation items
             to change pages.
           </p>

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -115,7 +115,7 @@ function AppLogo() {
 
   if (showCollapsed) {
     return (
-      <div className="bg-primary-500 flex h-8 w-8 items-center justify-center rounded-lg font-bold text-white">
+      <div className="bg-primary-800 flex h-8 w-8 items-center justify-center rounded-lg font-bold text-white">
         M
       </div>
     );
@@ -123,7 +123,7 @@ function AppLogo() {
 
   return (
     <div className="flex items-center gap-3">
-      <div className="bg-primary-500 flex h-8 w-8 items-center justify-center rounded-lg font-bold text-white">
+      <div className="bg-primary-800 flex h-8 w-8 items-center justify-center rounded-lg font-bold text-white">
         M
       </div>
       <div className="font-semibold text-neutral-900 dark:text-white">

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -456,7 +456,7 @@ export function SidebarNavItem({
           className={cn(
             'h-5 w-5 flex-shrink-0',
             isActive
-              ? 'text-primary-600 dark:text-primary-400'
+              ? 'text-primary-800 dark:text-primary-400'
               : 'text-muted-foreground',
             !showCollapsed && 'mr-3'
           )}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -362,7 +362,7 @@ export function SidebarNavGroup({
         {icon && (
           <span
             className={cn(
-              'h-5 w-5 flex-shrink-0 text-muted-foreground',
+              'text-muted-foreground h-5 w-5 flex-shrink-0',
               !showCollapsed && 'mr-3'
             )}
           >
@@ -547,7 +547,7 @@ export function SidebarToggle({
     <button
       onClick={toggleCollapsed}
       className={cn(
-        'rounded-lg p-2 text-muted-foreground',
+        'text-muted-foreground rounded-lg p-2',
         'transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800',
         'focus:ring-primary-500 focus:ring-2 focus:outline-none',
         className
@@ -593,7 +593,7 @@ export function SidebarMobileToggle({
     <button
       onClick={openMobile}
       className={cn(
-        'rounded-lg p-2 text-muted-foreground',
+        'text-muted-foreground rounded-lg p-2',
         'transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800',
         'focus:ring-primary-500 focus:ring-2 focus:outline-none',
         className

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -362,7 +362,7 @@ export function SidebarNavGroup({
         {icon && (
           <span
             className={cn(
-              'h-5 w-5 flex-shrink-0 text-neutral-500 dark:text-neutral-400',
+              'h-5 w-5 flex-shrink-0 text-muted-foreground',
               !showCollapsed && 'mr-3'
             )}
           >
@@ -457,7 +457,7 @@ export function SidebarNavItem({
             'h-5 w-5 flex-shrink-0',
             isActive
               ? 'text-primary-600 dark:text-primary-400'
-              : 'text-neutral-500 dark:text-neutral-400',
+              : 'text-muted-foreground',
             !showCollapsed && 'mr-3'
           )}
         >
@@ -547,7 +547,7 @@ export function SidebarToggle({
     <button
       onClick={toggleCollapsed}
       className={cn(
-        'rounded-lg p-2 text-neutral-500 dark:text-neutral-400',
+        'rounded-lg p-2 text-muted-foreground',
         'transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800',
         'focus:ring-primary-500 focus:ring-2 focus:outline-none',
         className
@@ -593,7 +593,7 @@ export function SidebarMobileToggle({
     <button
       onClick={openMobile}
       className={cn(
-        'rounded-lg p-2 text-neutral-500 dark:text-neutral-400',
+        'rounded-lg p-2 text-muted-foreground',
         'transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800',
         'focus:ring-primary-500 focus:ring-2 focus:outline-none',
         className

--- a/src/components/SiteFooter/SiteFooter.stories.tsx
+++ b/src/components/SiteFooter/SiteFooter.stories.tsx
@@ -163,7 +163,7 @@ export const SocialLinksDemo: StoryObj<typeof SocialMediaLinks> = {
 export const NewsletterDemo: StoryObj<typeof NewsletterForm> = {
   render: () => (
     <div className="max-w-md space-y-4 p-4">
-      <div className="bg-primary-600 rounded-lg p-6">
+      <div className="bg-primary-800 rounded-lg p-6">
         <NewsletterForm
           variant="light"
           onSubmit={(email) => window.alert(`Subscribed: ${email}`)}

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -254,7 +254,7 @@ export function NewsletterForm({
           'rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors',
           variant === 'light'
             ? 'text-primary-900 bg-white hover:bg-white/90'
-            : 'bg-primary-700 hover:bg-primary-800 text-white',
+            : 'bg-primary-800 hover:bg-primary-900 text-white',
           isLoading && 'cursor-not-allowed opacity-50'
         )}
       >
@@ -457,7 +457,7 @@ const footerVariants = cva('', {
     variant: {
       default: 'bg-gray-100 dark:bg-gray-900',
       dark: 'bg-gray-900 dark:bg-gray-950',
-      primary: 'bg-primary-600 dark:bg-primary-800',
+      primary: 'bg-primary-800 dark:bg-primary-800',
       white:
         'bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800',
     },
@@ -715,7 +715,7 @@ export function SimpleFooter({
       className={cn(
         'border-t py-4',
         variant === 'light'
-          ? 'bg-primary-700 border-white/10'
+          ? 'bg-primary-800 border-white/10'
           : 'border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900',
         className
       )}

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -285,9 +285,7 @@ export function FooterLinkSection({
         data-slot="site-footer-link-title"
         className={cn(
           'mb-4 text-sm font-semibold tracking-wider uppercase',
-          variant === 'light'
-            ? 'text-white/70'
-            : 'text-muted-foreground'
+          variant === 'light' ? 'text-white/70' : 'text-muted-foreground'
         )}
       >
         {group.title}
@@ -340,9 +338,7 @@ export function CopyrightText({
       data-slot="site-footer-copyright"
       className={cn(
         'text-sm',
-        variant === 'light'
-          ? 'text-white/60'
-          : 'text-muted-foreground',
+        variant === 'light' ? 'text-white/60' : 'text-muted-foreground',
         className
       )}
     >
@@ -437,9 +433,7 @@ export function DisclaimerText({
       data-slot="site-footer-disclaimer"
       className={cn(
         'text-xs leading-relaxed',
-        variant === 'light'
-          ? 'text-white/50'
-          : 'text-muted-foreground',
+        variant === 'light' ? 'text-white/50' : 'text-muted-foreground',
         className
       )}
     >

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -185,7 +185,7 @@ export function SocialMediaLinks({
               sizeClasses[size],
               variant === 'light'
                 ? 'text-white/70 hover:bg-white/10 hover:text-white'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white'
+                : 'text-muted-foreground hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-white'
             )}
           >
             <Icon />
@@ -301,7 +301,7 @@ export function FooterLinkSection({
                 'text-sm transition-colors',
                 variant === 'light'
                   ? 'text-white/60 hover:text-white'
-                  : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+                  : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
               )}
             >
               {link.label}
@@ -388,7 +388,7 @@ export function LegalLinks({
                 'hidden sm:inline',
                 variant === 'light'
                   ? 'text-white/40'
-                  : 'text-gray-300 dark:text-gray-600'
+                  : 'dark:text-muted-foreground text-gray-300'
               )}
             >
               |
@@ -402,7 +402,7 @@ export function LegalLinks({
               'text-sm transition-colors',
               variant === 'light'
                 ? 'text-white/60 hover:text-white'
-                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+                : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
             )}
           >
             {link.label}
@@ -724,7 +724,7 @@ export function SimpleFooter({
                 'text-sm transition-colors',
                 variant === 'light'
                   ? 'text-white/60 hover:text-white'
-                  : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+                  : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
               )}
             >
               Privacy
@@ -735,7 +735,7 @@ export function SimpleFooter({
                 'text-sm transition-colors',
                 variant === 'light'
                   ? 'text-white/60 hover:text-white'
-                  : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+                  : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
               )}
             >
               Terms

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -287,7 +287,7 @@ export function FooterLinkSection({
           'mb-4 text-sm font-semibold tracking-wider uppercase',
           variant === 'light'
             ? 'text-white/70'
-            : 'text-gray-600 dark:text-gray-400'
+            : 'text-muted-foreground'
         )}
       >
         {group.title}
@@ -342,7 +342,7 @@ export function CopyrightText({
         'text-sm',
         variant === 'light'
           ? 'text-white/60'
-          : 'text-gray-600 dark:text-gray-400',
+          : 'text-muted-foreground',
         className
       )}
     >
@@ -439,7 +439,7 @@ export function DisclaimerText({
         'text-xs leading-relaxed',
         variant === 'light'
           ? 'text-white/50'
-          : 'text-gray-500 dark:text-gray-400',
+          : 'text-muted-foreground',
         className
       )}
     >
@@ -583,7 +583,7 @@ export function SiteFooter({
                   'mb-4 text-sm',
                   colorVariant === 'light'
                     ? 'text-white/70'
-                    : 'text-gray-600 dark:text-gray-400'
+                    : 'text-muted-foreground'
                 )}
               >
                 {description}

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -185,7 +185,7 @@ export function SocialMediaLinks({
               sizeClasses[size],
               variant === 'light'
                 ? 'text-white/70 hover:bg-white/10 hover:text-white'
-                : 'text-muted-foreground hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-white'
+                : 'dark:text-muted-foreground text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-white'
             )}
           >
             <Icon />
@@ -285,7 +285,9 @@ export function FooterLinkSection({
         data-slot="site-footer-link-title"
         className={cn(
           'mb-4 text-sm font-semibold tracking-wider uppercase',
-          variant === 'light' ? 'text-white/70' : 'text-muted-foreground'
+          variant === 'light'
+            ? 'text-white/70'
+            : 'dark:text-muted-foreground text-gray-600'
         )}
       >
         {group.title}
@@ -301,7 +303,7 @@ export function FooterLinkSection({
                 'text-sm transition-colors',
                 variant === 'light'
                   ? 'text-white/60 hover:text-white'
-                  : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
+                  : 'dark:text-muted-foreground text-gray-600 hover:text-gray-900 dark:hover:text-white'
               )}
             >
               {link.label}
@@ -338,7 +340,9 @@ export function CopyrightText({
       data-slot="site-footer-copyright"
       className={cn(
         'text-sm',
-        variant === 'light' ? 'text-white/60' : 'text-muted-foreground',
+        variant === 'light'
+          ? 'text-white/60'
+          : 'dark:text-muted-foreground text-gray-600',
         className
       )}
     >
@@ -402,7 +406,7 @@ export function LegalLinks({
               'text-sm transition-colors',
               variant === 'light'
                 ? 'text-white/60 hover:text-white'
-                : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
+                : 'dark:text-muted-foreground text-gray-600 hover:text-gray-900 dark:hover:text-white'
             )}
           >
             {link.label}
@@ -433,7 +437,9 @@ export function DisclaimerText({
       data-slot="site-footer-disclaimer"
       className={cn(
         'text-xs leading-relaxed',
-        variant === 'light' ? 'text-white/50' : 'text-muted-foreground',
+        variant === 'light'
+          ? 'text-white/50'
+          : 'dark:text-muted-foreground text-gray-600',
         className
       )}
     >
@@ -577,7 +583,7 @@ export function SiteFooter({
                   'mb-4 text-sm',
                   colorVariant === 'light'
                     ? 'text-white/70'
-                    : 'text-muted-foreground'
+                    : 'dark:text-muted-foreground text-gray-600'
                 )}
               >
                 {description}
@@ -724,7 +730,7 @@ export function SimpleFooter({
                 'text-sm transition-colors',
                 variant === 'light'
                   ? 'text-white/60 hover:text-white'
-                  : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
+                  : 'dark:text-muted-foreground text-gray-600 hover:text-gray-900 dark:hover:text-white'
               )}
             >
               Privacy
@@ -735,7 +741,7 @@ export function SimpleFooter({
                 'text-sm transition-colors',
                 variant === 'light'
                   ? 'text-white/60 hover:text-white'
-                  : 'text-muted-foreground hover:text-gray-900 dark:hover:text-white'
+                  : 'dark:text-muted-foreground text-gray-600 hover:text-gray-900 dark:hover:text-white'
               )}
             >
               Terms

--- a/src/components/SiteHeader/SiteHeader.stories.tsx
+++ b/src/components/SiteHeader/SiteHeader.stories.tsx
@@ -125,7 +125,7 @@ export const NavLinksDemo: StoryObj<typeof NavLinks> = {
       <div className="bg-primary-800 rounded-lg p-4">
         <NavLinks links={defaultLinks} variant="light" />
       </div>
-      <div className="rounded-lg border bg-white p-4">
+      <div className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
         <NavLinks links={defaultLinks} variant="dark" />
       </div>
     </div>
@@ -138,7 +138,7 @@ export const AuthButtonsDemo: StoryObj<typeof AuthButtons> = {
       <div className="bg-primary-800 rounded-lg p-4">
         <AuthButtons variant="light" onLogin={() => {}} onSignUp={() => {}} />
       </div>
-      <div className="rounded-lg border bg-white p-4">
+      <div className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
         <AuthButtons variant="dark" onLogin={() => {}} onSignUp={() => {}} />
       </div>
     </div>
@@ -151,10 +151,10 @@ export const UserMenuDemo: StoryObj<typeof UserMenu> = {
       <div className="bg-primary-800 flex justify-end rounded-lg p-4">
         <UserMenu user={sampleUser} variant="light" onLogout={() => {}} />
       </div>
-      <div className="flex justify-end rounded-lg border bg-white p-4">
+      <div className="flex justify-end rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
         <UserMenu user={sampleUser} variant="dark" onLogout={() => {}} />
       </div>
-      <div className="flex justify-end rounded-lg border bg-white p-4">
+      <div className="flex justify-end rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
         <UserMenu
           user={{ ...sampleUser, avatarUrl: undefined }}
           variant="dark"

--- a/src/components/SiteHeader/SiteHeader.stories.tsx
+++ b/src/components/SiteHeader/SiteHeader.stories.tsx
@@ -111,7 +111,7 @@ export const GlassVariant: Story = {
 export const LogoVariants: StoryObj<typeof SiteLogo> = {
   render: () => (
     <div className="space-y-4 p-4">
-      <div className="bg-primary-600 rounded-lg p-4">
+      <div className="bg-primary-800 rounded-lg p-4">
         <SiteLogo name="BlueHive" variant="light" />
       </div>
       <div className="rounded-lg border bg-white p-4">
@@ -124,7 +124,7 @@ export const LogoVariants: StoryObj<typeof SiteLogo> = {
 export const NavLinksDemo: StoryObj<typeof NavLinks> = {
   render: () => (
     <div className="space-y-4 p-4">
-      <div className="bg-primary-600 rounded-lg p-4">
+      <div className="bg-primary-800 rounded-lg p-4">
         <NavLinks links={defaultLinks} variant="light" />
       </div>
       <div className="rounded-lg border bg-white p-4">
@@ -137,7 +137,7 @@ export const NavLinksDemo: StoryObj<typeof NavLinks> = {
 export const AuthButtonsDemo: StoryObj<typeof AuthButtons> = {
   render: () => (
     <div className="space-y-4 p-4">
-      <div className="bg-primary-600 rounded-lg p-4">
+      <div className="bg-primary-800 rounded-lg p-4">
         <AuthButtons variant="light" onLogin={() => {}} onSignUp={() => {}} />
       </div>
       <div className="rounded-lg border bg-white p-4">
@@ -150,7 +150,7 @@ export const AuthButtonsDemo: StoryObj<typeof AuthButtons> = {
 export const UserMenuDemo: StoryObj<typeof UserMenu> = {
   render: () => (
     <div className="space-y-4 p-4">
-      <div className="bg-primary-600 flex justify-end rounded-lg p-4">
+      <div className="bg-primary-800 flex justify-end rounded-lg p-4">
         <UserMenu user={sampleUser} variant="light" onLogout={() => {}} />
       </div>
       <div className="flex justify-end rounded-lg border bg-white p-4">

--- a/src/components/SiteHeader/SiteHeader.stories.tsx
+++ b/src/components/SiteHeader/SiteHeader.stories.tsx
@@ -61,9 +61,7 @@ const meta: Meta<typeof SiteHeader> = {
       <div className="min-h-[300px] bg-gray-100 dark:bg-gray-950">
         <Story />
         <div className="p-8">
-          <p className="text-muted-foreground">
-            Page content below header
-          </p>
+          <p className="text-muted-foreground">Page content below header</p>
         </div>
       </div>
     ),

--- a/src/components/SiteHeader/SiteHeader.stories.tsx
+++ b/src/components/SiteHeader/SiteHeader.stories.tsx
@@ -61,7 +61,7 @@ const meta: Meta<typeof SiteHeader> = {
       <div className="min-h-[300px] bg-gray-100 dark:bg-gray-950">
         <Story />
         <div className="p-8">
-          <p className="text-gray-600 dark:text-gray-400">
+          <p className="text-muted-foreground">
             Page content below header
           </p>
         </div>

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -62,7 +62,7 @@ export function SiteLogo({
             'flex h-8 w-8 items-center justify-center rounded-lg text-lg font-bold',
             variant === 'light'
               ? 'bg-white/20 text-white'
-              : 'bg-primary-600 text-white'
+              : 'bg-primary-800 text-white'
           )}
         >
           {name?.[0] || 'B'}
@@ -188,7 +188,7 @@ export function AuthButtons({
         'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
         variant === 'light'
           ? 'text-primary-600 bg-white hover:bg-white/90'
-          : 'bg-primary-700 hover:bg-primary-800 text-white'
+          : 'bg-primary-800 hover:bg-primary-900 text-white'
       )}
     >
       Sign Up
@@ -223,7 +223,7 @@ export function AuthButtons({
               'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
               variant === 'light'
                 ? 'text-primary-600 bg-white hover:bg-white/90'
-                : 'bg-primary-700 hover:bg-primary-800 text-white'
+                : 'bg-primary-800 hover:bg-primary-900 text-white'
             )}
           >
             Sign Up
@@ -605,7 +605,7 @@ export function MobileMenuPanel({
                   onSignUp?.();
                   onClose();
                 }}
-                className="bg-primary-700 hover:bg-primary-800 rounded-lg px-4 py-2 text-sm font-medium text-white"
+                className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-sm font-medium text-white"
               >
                 Sign Up
               </button>
@@ -626,7 +626,7 @@ const headerVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'bg-primary-600',
+        primary: 'bg-primary-800',
         white:
           'bg-white shadow-sm dark:bg-gray-900 dark:border-b dark:border-gray-800',
         transparent: 'bg-transparent',

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -375,7 +375,7 @@ export function UserMenu({
             'h-4 w-4 transition-transform',
             variant === 'light'
               ? 'text-white/70'
-              : 'text-gray-500 dark:text-gray-400',
+              : 'text-muted-foreground',
             isOpen && 'rotate-180'
           )}
         />
@@ -392,7 +392,7 @@ export function UserMenu({
               {user.name}
             </p>
             {user.email && (
-              <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+              <p className="truncate text-xs text-muted-foreground">
                 {user.email}
               </p>
             )}
@@ -570,7 +570,7 @@ export function MobileMenuPanel({
                     {user.name}
                   </p>
                   {user.email && (
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-muted-foreground">
                       {user.email}
                     </p>
                   )}

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -373,9 +373,7 @@ export function UserMenu({
         <ChevronDownIcon
           className={cn(
             'h-4 w-4 transition-transform',
-            variant === 'light'
-              ? 'text-white/70'
-              : 'text-muted-foreground',
+            variant === 'light' ? 'text-white/70' : 'text-muted-foreground',
             isOpen && 'rotate-180'
           )}
         />
@@ -392,7 +390,7 @@ export function UserMenu({
               {user.name}
             </p>
             {user.email && (
-              <p className="truncate text-xs text-muted-foreground">
+              <p className="text-muted-foreground truncate text-xs">
                 {user.email}
               </p>
             )}
@@ -570,7 +568,7 @@ export function MobileMenuPanel({
                     {user.name}
                   </p>
                   {user.email && (
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       {user.email}
                     </p>
                   )}

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -527,7 +527,7 @@ export function MobileMenuPanel({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            className="text-muted-foreground rounded-lg p-2 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
             aria-label="Close menu"
           >
             <CloseIcon className="h-5 w-5" />

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -187,7 +187,7 @@ export function AuthButtons({
       className={cn(
         'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
         variant === 'light'
-          ? 'text-primary-600 bg-white hover:bg-white/90'
+          ? 'text-primary-800 bg-white hover:bg-white/90'
           : 'bg-primary-800 hover:bg-primary-900 text-white'
       )}
     >
@@ -222,7 +222,7 @@ export function AuthButtons({
             className={cn(
               'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
               variant === 'light'
-                ? 'text-primary-600 bg-white hover:bg-white/90'
+                ? 'text-primary-800 bg-white hover:bg-white/90'
                 : 'bg-primary-800 hover:bg-primary-900 text-white'
             )}
           >

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -167,13 +167,13 @@ export const Controlled: Story = {
           </button>
           <button
             onClick={() => setValue(50)}
-            className="bg-primary-500 hover:bg-primary-600 rounded px-3 py-1 text-sm text-white"
+            className="bg-primary-800 hover:bg-primary-900 rounded px-3 py-1 text-sm text-white"
           >
             Set 50
           </button>
           <button
             onClick={() => setValue(100)}
-            className="bg-primary-500 hover:bg-primary-600 rounded px-3 py-1 text-sm text-white"
+            className="bg-primary-800 hover:bg-primary-900 rounded px-3 py-1 text-sm text-white"
           >
             Max
           </button>

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -32,7 +32,7 @@ const sliderRangeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary-500',
+        default: 'bg-primary-800',
         success: 'bg-green-500',
         warning: 'bg-yellow-500',
         danger: 'bg-red-500',

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -14,7 +14,7 @@ const spinnerVariants = cva(
         xl: 'h-12 w-12',
       },
       variant: {
-        default: 'text-primary-500',
+        default: 'text-primary-800',
         muted: 'text-muted-foreground',
         white: 'text-white',
       },

--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -138,9 +138,9 @@ export function StepIndicator({
         step.hasError
           ? 'bg-red-100 text-red-600 focus:ring-red-500 dark:bg-red-900/30 dark:text-red-400'
           : status === 'completed'
-            ? 'bg-primary-600 focus:ring-primary-500 dark:bg-primary-500 text-white'
+            ? 'bg-primary-800 focus:ring-primary-500 dark:bg-primary-800 text-white'
             : status === 'current'
-              ? 'bg-primary-600 ring-primary-600 focus:ring-primary-500 dark:bg-primary-500 dark:ring-primary-500 text-white ring-2 ring-offset-2 dark:ring-offset-neutral-900'
+              ? 'bg-primary-800 ring-primary-600 focus:ring-primary-500 dark:bg-primary-800 dark:ring-primary-500 text-white ring-2 ring-offset-2 dark:ring-offset-neutral-900'
               : 'bg-neutral-200 text-neutral-500 focus:ring-neutral-400 dark:bg-neutral-700 dark:text-neutral-300'
       }`.trim()}
       aria-current={status === 'current' ? 'step' : undefined}
@@ -219,7 +219,7 @@ export function StepIndicator({
                     data-slot="step-indicator-connector"
                     className={`flex-1 ${sizes.line} ${
                       index <= currentStep
-                        ? 'bg-primary-600 dark:bg-primary-500'
+                        ? 'bg-primary-800 dark:bg-primary-800'
                         : 'bg-neutral-200 dark:bg-neutral-700'
                     }`}
                     aria-hidden="true"
@@ -235,7 +235,7 @@ export function StepIndicator({
                     data-slot="step-indicator-connector"
                     className={`flex-1 ${sizes.line} ${
                       index < currentStep
-                        ? 'bg-primary-600 dark:bg-primary-500'
+                        ? 'bg-primary-800 dark:bg-primary-800'
                         : 'bg-neutral-200 dark:bg-neutral-700'
                     }`}
                     aria-hidden="true"
@@ -282,7 +282,7 @@ export function StepIndicator({
                 <div
                   className={`h-full min-h-4 ${sizes.line} ${
                     index < currentStep
-                      ? 'bg-primary-600 dark:bg-primary-500'
+                      ? 'bg-primary-800 dark:bg-primary-800'
                       : 'bg-neutral-200 dark:bg-neutral-700'
                   }`}
                 />

--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -181,16 +181,13 @@ export function StepIndicator({
       >
         {step.label}
         {step.optional && (
-          <span className="font-normal text-muted-foreground">
-            {' '}
-            (optional)
-          </span>
+          <span className="text-muted-foreground font-normal"> (optional)</span>
         )}
       </p>
       {step.description && (
         <p
           data-slot="step-indicator-description"
-          className="mt-0.5 text-muted-foreground"
+          className="text-muted-foreground mt-0.5"
         >
           {step.description}
         </p>

--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -176,12 +176,12 @@ export function StepIndicator({
             ? 'text-red-600 dark:text-red-400'
             : status === 'completed' || status === 'current'
               ? 'text-neutral-900 dark:text-white'
-              : 'text-neutral-500 dark:text-neutral-400'
+              : 'text-muted-foreground'
         }`.trim()}
       >
         {step.label}
         {step.optional && (
-          <span className="font-normal text-neutral-500 dark:text-neutral-400">
+          <span className="font-normal text-muted-foreground">
             {' '}
             (optional)
           </span>
@@ -190,7 +190,7 @@ export function StepIndicator({
       {step.description && (
         <p
           data-slot="step-indicator-description"
-          className="mt-0.5 text-neutral-500 dark:text-neutral-400"
+          className="mt-0.5 text-muted-foreground"
         >
           {step.description}
         </p>

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -10,7 +10,7 @@ const switchTrackVariants = cva(
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
     'disabled:cursor-not-allowed disabled:opacity-50',
     'bg-neutral-200 dark:bg-neutral-700',
-    'data-[state=checked]:bg-primary-500',
+    'data-[state=checked]:bg-primary-800',
   ],
   {
     variants: {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -213,6 +213,7 @@ const tabsTriggerVariants = cva(
           'border-b-2 border-transparent',
           'text-muted-foreground hover:text-foreground',
           'data-[state=active]:border-primary-700 data-[state=active]:text-primary-800',
+          'dark:data-[state=active]:border-primary-400 dark:data-[state=active]:text-primary-400',
         ],
         pills: [
           'px-3 py-1.5 rounded-md text-sm',

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,7 +7,7 @@ const textVariants = cva('', {
     variant: {
       default: 'text-foreground',
       muted: 'text-muted-foreground',
-      primary: 'text-primary-600 dark:text-primary-400',
+      primary: 'text-primary-800 dark:text-primary-400',
       destructive: 'text-destructive',
       success: 'text-success',
       warning: 'text-warning',

--- a/src/components/Timeline/Timeline.stories.tsx
+++ b/src/components/Timeline/Timeline.stories.tsx
@@ -326,7 +326,7 @@ export const Confirmation: StoryObj<typeof OrderConfirmation> = {
       <div>
         <button
           onClick={() => setOpen(true)}
-          className="bg-primary-600 rounded px-4 py-2 text-white"
+          className="bg-primary-800 rounded px-4 py-2 text-white"
         >
           Show Confirmation
         </button>

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -189,7 +189,7 @@ export function TimelineProgress({
               {showTimestamps && (
                 <div
                   className={cn(
-                    'h-4 text-center text-neutral-500 dark:text-neutral-400',
+                    'h-4 text-center text-muted-foreground',
                     sizes.timestamp,
                     sizes.timestampMargin
                   )}
@@ -300,7 +300,7 @@ export function TimelineProgress({
                   state === 'current' &&
                     'font-semibold text-neutral-900 dark:text-white',
                   state === 'pending' &&
-                    'text-neutral-500 dark:text-neutral-400',
+                    'text-muted-foreground',
                   state === 'error' &&
                     'font-semibold text-red-600 dark:text-red-400'
                 )}
@@ -445,12 +445,12 @@ export function TimelineEventList({
                     {event.title}
                   </h4>
                   {event.author && (
-                    <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                    <p className="text-sm text-muted-foreground">
                       by {event.author}
                     </p>
                   )}
                 </div>
-                <time className="shrink-0 pt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
+                <time className="shrink-0 pt-0.5 text-xs text-muted-foreground">
                   {formatTime(event.timestamp)}
                 </time>
               </div>
@@ -538,7 +538,7 @@ export function OrderConfirmation({
         </h2>
 
         {orderNumber && (
-          <p className="mb-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+          <p className="mb-4 text-center text-sm text-muted-foreground">
             Order #{orderNumber}
           </p>
         )}

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -211,7 +211,7 @@ export function TimelineProgress({
                       state === 'completed' ||
                         state === 'current' ||
                         state === 'error'
-                        ? 'bg-primary-600 dark:bg-primary-500'
+                        ? 'bg-primary-800 dark:bg-primary-800'
                         : 'bg-neutral-200 dark:bg-neutral-700'
                     )}
                   />
@@ -235,7 +235,7 @@ export function TimelineProgress({
                         ),
                       state === 'current' &&
                         cn(
-                          'bg-primary-500 shadow-primary-500/30 ring-primary-100 dark:bg-primary-500 dark:ring-primary-900/50 text-white shadow-md ring-4',
+                          'bg-primary-800 shadow-primary-500/30 ring-primary-100 dark:bg-primary-800 dark:ring-primary-900/50 text-white shadow-md ring-4',
                           sizes.current,
                           pulse && 'animate-pulse'
                         ),
@@ -281,7 +281,7 @@ export function TimelineProgress({
                       'flex-1',
                       sizes.connector,
                       state === 'completed'
-                        ? 'bg-primary-600 dark:bg-primary-500'
+                        ? 'bg-primary-800 dark:bg-primary-800'
                         : 'bg-neutral-200 dark:bg-neutral-700'
                     )}
                   />
@@ -554,8 +554,8 @@ export function OrderConfirmation({
           onClick={onClose}
           className={cn(
             'w-full rounded-lg px-4 py-3 font-medium',
-            'bg-primary-700 hover:bg-primary-800 text-white',
-            'dark:bg-primary-600 dark:hover:bg-primary-700',
+            'bg-primary-800 hover:bg-primary-900 text-white',
+            'dark:bg-primary-800 dark:hover:bg-primary-900',
             'transition-colors'
           )}
         >

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -189,7 +189,7 @@ export function TimelineProgress({
               {showTimestamps && (
                 <div
                   className={cn(
-                    'h-4 text-center text-muted-foreground',
+                    'text-muted-foreground h-4 text-center',
                     sizes.timestamp,
                     sizes.timestampMargin
                   )}
@@ -299,8 +299,7 @@ export function TimelineProgress({
                     'text-primary-800 dark:text-primary-300',
                   state === 'current' &&
                     'font-semibold text-neutral-900 dark:text-white',
-                  state === 'pending' &&
-                    'text-muted-foreground',
+                  state === 'pending' && 'text-muted-foreground',
                   state === 'error' &&
                     'font-semibold text-red-600 dark:text-red-400'
                 )}
@@ -445,12 +444,12 @@ export function TimelineEventList({
                     {event.title}
                   </h4>
                   {event.author && (
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-muted-foreground text-sm">
                       by {event.author}
                     </p>
                   )}
                 </div>
-                <time className="shrink-0 pt-0.5 text-xs text-muted-foreground">
+                <time className="text-muted-foreground shrink-0 pt-0.5 text-xs">
                   {formatTime(event.timestamp)}
                 </time>
               </div>
@@ -538,7 +537,7 @@ export function OrderConfirmation({
         </h2>
 
         {orderNumber && (
-          <p className="mb-4 text-center text-sm text-muted-foreground">
+          <p className="text-muted-foreground mb-4 text-center text-sm">
             Order #{orderNumber}
           </p>
         )}

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -38,7 +38,7 @@ function ToastDemo() {
         </button>
         <button
           onClick={() => info('New features are available!')}
-          className="bg-primary-700 hover:bg-primary-800 rounded-lg px-4 py-2 text-white transition-colors"
+          className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white transition-colors"
         >
           Info
         </button>
@@ -70,7 +70,7 @@ function ToastWithTitleDemo() {
             },
           })
         }
-        className="bg-primary-700 hover:bg-primary-800 rounded-lg px-4 py-2 text-white transition-colors"
+        className="bg-primary-800 hover:bg-primary-900 rounded-lg px-4 py-2 text-white transition-colors"
       >
         Show Toast with Title & Action
       </button>

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -106,7 +106,7 @@ const variantStyles: Record<ToastVariant, { container: string; icon: string }> =
     info: {
       container:
         'bg-primary-50 dark:bg-primary-900 border-primary-200 dark:border-primary-800 text-primary-800 dark:text-primary-200',
-      icon: 'text-primary-500 dark:text-primary-400',
+      icon: 'text-primary-800 dark:text-primary-400',
     },
   };
 

--- a/src/components/WebsiteInput/WebsiteInput.stories.tsx
+++ b/src/components/WebsiteInput/WebsiteInput.stories.tsx
@@ -205,7 +205,7 @@ function MinMaxEntriesDemo() {
         minEntries={2}
         maxEntries={4}
       />
-      <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+      <p className="mt-2 text-sm text-muted-foreground">
         Minimum 2 entries required, maximum 4 allowed.
       </p>
     </div>

--- a/src/components/WebsiteInput/WebsiteInput.stories.tsx
+++ b/src/components/WebsiteInput/WebsiteInput.stories.tsx
@@ -205,7 +205,7 @@ function MinMaxEntriesDemo() {
         minEntries={2}
         maxEntries={4}
       />
-      <p className="mt-2 text-sm text-muted-foreground">
+      <p className="text-muted-foreground mt-2 text-sm">
         Minimum 2 entries required, maximum 4 allowed.
       </p>
     </div>

--- a/src/components/WebsiteInput/WebsiteInput.tsx
+++ b/src/components/WebsiteInput/WebsiteInput.tsx
@@ -295,7 +295,7 @@ function WebsiteInputGroup({
                 'w-full rounded-md border px-3 py-2 text-sm',
                 'border-gray-300 bg-white text-gray-900',
                 'focus:border-brand-500 focus:ring-brand-500/20 focus:ring-2 focus:outline-none',
-                'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500',
+                'disabled:text-muted-foreground disabled:cursor-not-allowed disabled:bg-gray-50',
                 'dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100',
                 'dark:focus:border-brand-400 dark:focus:ring-brand-400/20',
                 index === 0 && label ? 'mt-6' : ''
@@ -326,7 +326,7 @@ function WebsiteInputGroup({
                   'text-brand-600 hover:bg-brand-50',
                   'disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent',
                   'dark:text-brand-400 dark:hover:bg-brand-900/20',
-                  'dark:disabled:text-gray-600'
+                  'dark:disabled:text-muted-foreground'
                 )}
                 aria-label="Add website"
               >
@@ -354,7 +354,7 @@ function WebsiteInputGroup({
                   'text-red-600 hover:bg-red-50',
                   'disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent',
                   'dark:text-red-400 dark:hover:bg-red-900/20',
-                  'dark:disabled:text-gray-600'
+                  'dark:disabled:text-muted-foreground'
                 )}
                 aria-label="Remove website"
               >

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -134,7 +134,7 @@
   --color-card: var(--mieweb-card, #ffffff);
   --color-card-foreground: var(--mieweb-card-foreground, #171717);
   --color-muted: var(--mieweb-muted, #f5f5f5);
-  --color-muted-foreground: var(--mieweb-muted-foreground, #737373);
+  --color-muted-foreground: var(--mieweb-muted-foreground, #525252);
 
   /* ── Chart / Data Visualization Colors ─────────────────────────────── */
   --color-chart-1: var(--mieweb-chart-1);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -121,7 +121,7 @@
   --color-warning-800: var(--mieweb-warning-800, #92400e);
   --color-warning-900: var(--mieweb-warning-900, #78350f);
   --color-warning-950: var(--mieweb-warning-950, #451a03);
-  --color-warning-foreground: var(--mieweb-warning-foreground, #ffffff);
+  --color-warning-foreground: var(--mieweb-warning-foreground, #451a03);
 
   /* ── Info Scale ────────────────────────────────────────────────────── */
   --color-info: var(--mieweb-info, var(--mieweb-info-500, #0ea5e9));
@@ -246,7 +246,7 @@
   --mieweb-warning-800: #92400e;
   --mieweb-warning-900: #78350f;
   --mieweb-warning-950: #451a03;
-  --mieweb-warning-foreground: #ffffff;
+  --mieweb-warning-foreground: #451a03;
 
   /* ── Info Scale (Sky Blue) ─────────────────────────────────────────── */
   --mieweb-info-50: #f0f9ff;
@@ -319,7 +319,7 @@
   /* Status foregrounds */
   --mieweb-destructive-foreground: #fafafa;
   --mieweb-success-foreground: #fafafa;
-  --mieweb-warning-foreground: #fafafa;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info-foreground: #fafafa;
   --mieweb-secondary-foreground: #fafafa;
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -62,6 +62,19 @@
   --color-neutral-900: var(--mieweb-neutral-900, #171717);
   --color-neutral-950: var(--mieweb-neutral-950, #0a0a0a);
 
+  /* ── Gray → Neutral Alias (a11y: unify gray with themed neutral) ─── */
+  --color-gray-50: var(--color-neutral-50);
+  --color-gray-100: var(--color-neutral-100);
+  --color-gray-200: var(--color-neutral-200);
+  --color-gray-300: var(--color-neutral-300);
+  --color-gray-400: var(--color-neutral-400);
+  --color-gray-500: var(--color-neutral-500);
+  --color-gray-600: var(--color-neutral-600);
+  --color-gray-700: var(--color-neutral-700);
+  --color-gray-800: var(--color-neutral-800);
+  --color-gray-900: var(--color-neutral-900);
+  --color-gray-950: var(--color-neutral-950);
+
   /* ── Destructive / Error Scale ─────────────────────────────────────── */
   --color-destructive: var(
     --mieweb-destructive,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -78,14 +78,14 @@
   /* ── Destructive / Error Scale ─────────────────────────────────────── */
   --color-destructive: var(
     --mieweb-destructive,
-    var(--mieweb-destructive-500, #ef4444)
+    var(--mieweb-destructive-500, #dc2626)
   );
   --color-destructive-50: var(--mieweb-destructive-50, #fef2f2);
   --color-destructive-100: var(--mieweb-destructive-100, #fee2e2);
   --color-destructive-200: var(--mieweb-destructive-200, #fecaca);
   --color-destructive-300: var(--mieweb-destructive-300, #fca5a5);
   --color-destructive-400: var(--mieweb-destructive-400, #f87171);
-  --color-destructive-500: var(--mieweb-destructive-500, #ef4444);
+  --color-destructive-500: var(--mieweb-destructive-500, #dc2626);
   --color-destructive-600: var(--mieweb-destructive-600, #dc2626);
   --color-destructive-700: var(--mieweb-destructive-700, #b91c1c);
   --color-destructive-800: var(--mieweb-destructive-800, #991b1b);
@@ -94,13 +94,13 @@
   --color-destructive-foreground: var(--mieweb-destructive-foreground, #ffffff);
 
   /* ── Success Scale ─────────────────────────────────────────────────── */
-  --color-success: var(--mieweb-success, var(--mieweb-success-500, #22c55e));
+  --color-success: var(--mieweb-success, var(--mieweb-success-500, #15803d));
   --color-success-50: var(--mieweb-success-50, #f0fdf4);
   --color-success-100: var(--mieweb-success-100, #dcfce7);
   --color-success-200: var(--mieweb-success-200, #bbf7d0);
   --color-success-300: var(--mieweb-success-300, #86efac);
   --color-success-400: var(--mieweb-success-400, #4ade80);
-  --color-success-500: var(--mieweb-success-500, #22c55e);
+  --color-success-500: var(--mieweb-success-500, #15803d);
   --color-success-600: var(--mieweb-success-600, #16a34a);
   --color-success-700: var(--mieweb-success-700, #15803d);
   --color-success-800: var(--mieweb-success-800, #166534);
@@ -212,7 +212,7 @@
   --mieweb-destructive-200: #fecaca;
   --mieweb-destructive-300: #fca5a5;
   --mieweb-destructive-400: #f87171;
-  --mieweb-destructive-500: #ef4444;
+  --mieweb-destructive-500: #dc2626;
   --mieweb-destructive-600: #dc2626;
   --mieweb-destructive-700: #b91c1c;
   --mieweb-destructive-800: #991b1b;
@@ -226,7 +226,7 @@
   --mieweb-success-200: #bbf7d0;
   --mieweb-success-300: #86efac;
   --mieweb-success-400: #4ade80;
-  --mieweb-success-500: #22c55e;
+  --mieweb-success-500: #15803d;
   --mieweb-success-600: #16a34a;
   --mieweb-success-700: #15803d;
   --mieweb-success-800: #166534;

--- a/src/styles/init.css
+++ b/src/styles/init.css
@@ -144,7 +144,7 @@
   --color-card: var(--mieweb-card, #ffffff);
   --color-card-foreground: var(--mieweb-card-foreground, #171717);
   --color-muted: var(--mieweb-muted, #f5f5f5);
-  --color-muted-foreground: var(--mieweb-muted-foreground, #737373);
+  --color-muted-foreground: var(--mieweb-muted-foreground, #525252);
 
   /* ── Chart / Data Visualization Colors ─────────────────────────────── */
   --color-chart-1: var(--mieweb-chart-1);
@@ -270,7 +270,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #737373;
+  --mieweb-muted-foreground: #525252;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;

--- a/src/styles/init.css
+++ b/src/styles/init.css
@@ -72,6 +72,19 @@
   --color-neutral-900: var(--mieweb-neutral-900, #171717);
   --color-neutral-950: var(--mieweb-neutral-950, #0a0a0a);
 
+  /* ── Gray → Neutral Alias (a11y: unify gray with themed neutral) ─── */
+  --color-gray-50: var(--color-neutral-50);
+  --color-gray-100: var(--color-neutral-100);
+  --color-gray-200: var(--color-neutral-200);
+  --color-gray-300: var(--color-neutral-300);
+  --color-gray-400: var(--color-neutral-400);
+  --color-gray-500: var(--color-neutral-500);
+  --color-gray-600: var(--color-neutral-600);
+  --color-gray-700: var(--color-neutral-700);
+  --color-gray-800: var(--color-neutral-800);
+  --color-gray-900: var(--color-neutral-900);
+  --color-gray-950: var(--color-neutral-950);
+
   /* ── Destructive / Error Scale ─────────────────────────────────────── */
   --color-destructive: var(
     --mieweb-destructive,

--- a/src/styles/init.css
+++ b/src/styles/init.css
@@ -131,7 +131,7 @@
   --color-warning-800: var(--mieweb-warning-800, #92400e);
   --color-warning-900: var(--mieweb-warning-900, #78350f);
   --color-warning-950: var(--mieweb-warning-950, #451a03);
-  --color-warning-foreground: var(--mieweb-warning-foreground, #ffffff);
+  --color-warning-foreground: var(--mieweb-warning-foreground, #451a03);
 
   /* ── Info Scale ────────────────────────────────────────────────────── */
   --color-info: var(--mieweb-info, var(--mieweb-info-500, #0ea5e9));
@@ -254,7 +254,7 @@
   --mieweb-warning-800: #92400e;
   --mieweb-warning-900: #78350f;
   --mieweb-warning-950: #451a03;
-  --mieweb-warning-foreground: #ffffff;
+  --mieweb-warning-foreground: #451a03;
 
   /* Info Scale (Sky Blue) */
   --mieweb-info-50: #f0f9ff;
@@ -308,7 +308,7 @@
   --mieweb-ring: #27aae1;
   --mieweb-destructive-foreground: #fafafa;
   --mieweb-success-foreground: #fafafa;
-  --mieweb-warning-foreground: #fafafa;
+  --mieweb-warning-foreground: #451a03;
   --mieweb-info-foreground: #fafafa;
   --mieweb-secondary-foreground: #fafafa;
   --mieweb-chart-1: #38bdf8;

--- a/src/styles/init.css
+++ b/src/styles/init.css
@@ -88,14 +88,14 @@
   /* ── Destructive / Error Scale ─────────────────────────────────────── */
   --color-destructive: var(
     --mieweb-destructive,
-    var(--mieweb-destructive-500, #ef4444)
+    var(--mieweb-destructive-500, #dc2626)
   );
   --color-destructive-50: var(--mieweb-destructive-50, #fef2f2);
   --color-destructive-100: var(--mieweb-destructive-100, #fee2e2);
   --color-destructive-200: var(--mieweb-destructive-200, #fecaca);
   --color-destructive-300: var(--mieweb-destructive-300, #fca5a5);
   --color-destructive-400: var(--mieweb-destructive-400, #f87171);
-  --color-destructive-500: var(--mieweb-destructive-500, #ef4444);
+  --color-destructive-500: var(--mieweb-destructive-500, #dc2626);
   --color-destructive-600: var(--mieweb-destructive-600, #dc2626);
   --color-destructive-700: var(--mieweb-destructive-700, #b91c1c);
   --color-destructive-800: var(--mieweb-destructive-800, #991b1b);
@@ -104,13 +104,13 @@
   --color-destructive-foreground: var(--mieweb-destructive-foreground, #ffffff);
 
   /* ── Success Scale ─────────────────────────────────────────────────── */
-  --color-success: var(--mieweb-success, var(--mieweb-success-500, #22c55e));
+  --color-success: var(--mieweb-success, var(--mieweb-success-500, #15803d));
   --color-success-50: var(--mieweb-success-50, #f0fdf4);
   --color-success-100: var(--mieweb-success-100, #dcfce7);
   --color-success-200: var(--mieweb-success-200, #bbf7d0);
   --color-success-300: var(--mieweb-success-300, #86efac);
   --color-success-400: var(--mieweb-success-400, #4ade80);
-  --color-success-500: var(--mieweb-success-500, #22c55e);
+  --color-success-500: var(--mieweb-success-500, #15803d);
   --color-success-600: var(--mieweb-success-600, #16a34a);
   --color-success-700: var(--mieweb-success-700, #15803d);
   --color-success-800: var(--mieweb-success-800, #166534);
@@ -220,7 +220,7 @@
   --mieweb-destructive-200: #fecaca;
   --mieweb-destructive-300: #fca5a5;
   --mieweb-destructive-400: #f87171;
-  --mieweb-destructive-500: #ef4444;
+  --mieweb-destructive-500: #dc2626;
   --mieweb-destructive-600: #dc2626;
   --mieweb-destructive-700: #b91c1c;
   --mieweb-destructive-800: #991b1b;
@@ -234,7 +234,7 @@
   --mieweb-success-200: #bbf7d0;
   --mieweb-success-300: #86efac;
   --mieweb-success-400: #4ade80;
-  --mieweb-success-500: #22c55e;
+  --mieweb-success-500: #15803d;
   --mieweb-success-600: #16a34a;
   --mieweb-success-700: #15803d;
   --mieweb-success-800: #166534;


### PR DESCRIPTION
WCAG 2.1 AA color-contrast remediation across all brands and components.

## Token-level changes (all brands + init.css/base.css fallbacks)

- **muted-foreground**: `#737373` → `#525252` (7.14:1 on muted bg, was 4.34)
- **destructive / destructive-500**: `#ef4444` → `#dc2626` (4.84:1 on white, was 3.76)
- **success / success-500**: `#22c55e` → `#15803d` (5.05:1 on white, was 2.27)
- **warning-foreground**: `#ffffff` → `#451a03` (amber-950, matching enterprise-health/waggleline)
- **gray → neutral alias**: 11 gray-* CSS variables now alias to neutral-* in `@theme` block

## Component-level migrations

- **text-gray-500/600** → `text-muted-foreground` across 74 components (251 lines)
- **bg-primary-500/600/700** → `bg-primary-800` for interactive elements (57 files, 124 lines)
  - Primary-800 passes AA (≥4.5:1) across all brands: BlueHive 5.25, MIE Web 5.61, WebChart 7.31, Waggleline 5.83
  - Preserved opacity variants (bg-primary-500/10, bg-primary-900/20, etc.)

## Review feedback fixes

- **AIChatModal**: `hover:bg-primary-800` → `hover:bg-primary-900` (visible hover state)
- **CellRenderers**: Deduplicated `bg-primary-800` in avatar colors → `bg-primary-700`
- **RecurringServiceCard**: `text-white` → `text-primary-foreground` (semantic token)
- **init.css/base.css**: Updated `--mieweb-destructive-500` and `--mieweb-success-500` default fallbacks to AA-passing values

## Estimated impact

Resolves ~80% of color-contrast element failures across all brands.

## Remaining work (follow-up PR)

- `text-primary-500/600` on white backgrounds (links/icons) — needs case-by-case review
- axe-playwright test configuration