### PR TITLE
fix(a11y): resolve Dashboard accessibility violations (WCAG 2.1 AA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 playwright-report/
 playwright-results/
 test-results/*.swp
+TODO.local.md

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default [
         HTMLInputElement: 'readonly',
         HTMLButtonElement: 'readonly',
         HTMLDivElement: 'readonly',
+        HTMLDListElement: 'readonly',
         HTMLSpanElement: 'readonly',
         HTMLParagraphElement: 'readonly',
         HTMLTableElement: 'readonly',

--- a/src/brands/bluehive.ts
+++ b/src/brands/bluehive.ts
@@ -43,7 +43,7 @@ export const bluehiveBrand: BrandConfig = {
       border: '#e5e7eb',
       input: '#e5e7eb',
       ring: '#27aae1',
-      destructive: '#ef4444',
+      destructive: '#dc2626',
       destructiveForeground: '#ffffff',
       success: '#22c55e',
       successForeground: '#ffffff',

--- a/src/brands/default.ts
+++ b/src/brands/default.ts
@@ -37,7 +37,7 @@ export const defaultBrand: BrandConfig = {
       border: '#e2e8f0',
       input: '#e2e8f0',
       ring: '#3b82f6',
-      destructive: '#ef4444',
+      destructive: '#dc2626',
       destructiveForeground: '#ffffff',
       success: '#22c55e',
       successForeground: '#ffffff',

--- a/src/brands/mieweb.ts
+++ b/src/brands/mieweb.ts
@@ -43,7 +43,7 @@ export const miewebBrand: BrandConfig = {
       border: '#e5e7eb',
       input: '#e5e7eb',
       ring: '#27ae60',
-      destructive: '#ef4444',
+      destructive: '#dc2626',
       destructiveForeground: '#ffffff',
       success: '#22c55e',
       successForeground: '#ffffff',

--- a/src/brands/ozwell.ts
+++ b/src/brands/ozwell.ts
@@ -44,7 +44,7 @@ export const ozwellBrand: BrandConfig = {
       border: '#e5e7eb',
       input: '#e5e7eb',
       ring: '#27aae1',
-      destructive: '#ef4444',
+      destructive: '#dc2626',
       destructiveForeground: '#ffffff',
       success: '#22c55e',
       successForeground: '#ffffff',

--- a/src/brands/waggleline.css
+++ b/src/brands/waggleline.css
@@ -45,7 +45,7 @@
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #17aeed;
-  --mieweb-destructive: #ef4444;
+  --mieweb-destructive: #dc2626;
   --mieweb-destructive-foreground: #ffffff;
   --mieweb-success: #009c4e;
   --mieweb-success-foreground: #ffffff;

--- a/src/brands/waggleline.ts
+++ b/src/brands/waggleline.ts
@@ -58,7 +58,7 @@ export const wagglelineBrand: BrandConfig = {
       border: '#e5e7eb',
       input: '#e5e7eb',
       ring: '#17AEED',
-      destructive: '#ef4444',
+      destructive: '#dc2626',
       destructiveForeground: '#ffffff',
       success: '#009C4E', // Brand green
       successForeground: '#ffffff',

--- a/src/brands/webchart.ts
+++ b/src/brands/webchart.ts
@@ -43,7 +43,7 @@ export const webchartBrand: BrandConfig = {
       border: '#e5e7eb',
       input: '#e5e7eb',
       ring: '#f5841f',
-      destructive: '#ef4444',
+      destructive: '#dc2626',
       destructiveForeground: '#ffffff',
       success: '#22c55e',
       successForeground: '#ffffff',

--- a/src/components/AGGrid/ag-grid-theme.css
+++ b/src/components/AGGrid/ag-grid-theme.css
@@ -89,7 +89,7 @@
   /* Control panel */
   --ag-control-panel-background-color: var(--mieweb-background, #ffffff);
   --ag-subheader-background-color: var(--mieweb-muted, #f9fafb);
-  --ag-invalid-background-color: var(--mieweb-destructive, #ef4444);
+  --ag-invalid-background-color: var(--mieweb-destructive, #dc2626);
 
   /* Other colors */
   --ag-chip-background-color: var(--mieweb-muted, #f3f4f6);

--- a/src/components/AI/OzwellWidget.tsx
+++ b/src/components/AI/OzwellWidget.tsx
@@ -98,7 +98,7 @@ const THEME_OVERRIDES_CSS = `
 
   /* --- Unread badge --- */
   .ozwell-unread-badge {
-    background: var(--mieweb-destructive, #ef4444) !important;
+    background: var(--mieweb-destructive, #dc2626) !important;
     border-color: var(--mieweb-background, #ffffff) !important;
   }
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -96,7 +96,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         {showImage ? (
           <img
             src={src}
-            alt={alt || name || 'Avatar'}
+            alt={alt !== undefined ? alt : name || 'Avatar'}
             className="h-full w-full object-cover"
             onError={() => setImageError(true)}
           />

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -169,11 +169,16 @@ CardHeader.displayName = 'CardHeader';
 /**
  * Title for a Card
  */
+export interface CardTitleProps extends React.HTMLAttributes<globalThis.HTMLHeadingElement> {
+  /** Heading level — defaults to `h3` */
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
 const CardTitle = React.forwardRef<
   globalThis.HTMLHeadingElement,
-  React.HTMLAttributes<globalThis.HTMLHeadingElement>
->(({ className, children, ...props }, ref) => (
-  <h3
+  CardTitleProps
+>(({ className, children, as: Comp = 'h3', ...props }, ref) => (
+  <Comp
     ref={ref}
     data-slot="card-title"
     className={cn(
@@ -183,7 +188,7 @@ const CardTitle = React.forwardRef<
     {...props}
   >
     {children}
-  </h3>
+  </Comp>
 ));
 
 CardTitle.displayName = 'CardTitle';

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -19,4 +19,5 @@ export {
   type CardActionsProps,
   type CardCollapsibleProps,
   type CardStatProps,
+  type CardTitleProps,
 } from './Card';

--- a/src/components/CountBadge/CountBadge.tsx
+++ b/src/components/CountBadge/CountBadge.tsx
@@ -50,7 +50,7 @@ const countBadgeVariants = cva(
           'dark:border-border/40 dark:hover:border-border dark:hover:bg-muted/30',
         ],
         info: [
-          'border-primary-200 text-primary-700',
+          'border-primary-200 text-primary-800',
           'hover:border-primary-300 hover:bg-primary-50',
           'dark:border-primary-800 dark:text-primary-300',
           'dark:hover:border-primary-700 dark:hover:bg-primary-950/50',

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -545,7 +545,7 @@ function UserMenu({ user, onProfile, onSettings, onLogout }: UserMenuProps) {
           className="focus:ring-primary-500/40 hover:bg-muted flex items-center gap-2 rounded-full p-1 transition-colors focus:ring-2 focus:outline-none"
           aria-label="User menu"
         >
-          <Avatar src={user.avatarUrl} name={user.name} size="sm" ring />
+          <Avatar src={user.avatarUrl} name={user.name} alt="" size="sm" ring />
           <span className="text-foreground hidden text-sm font-medium md:block">
             {user.name}
           </span>
@@ -923,7 +923,7 @@ function DashboardPage() {
           <CardHeader>
             <div className="flex items-center justify-between">
               <div>
-                <CardTitle>Recent Orders</CardTitle>
+                <CardTitle as="h2">Recent Orders</CardTitle>
                 <CardDescription>Latest customer orders</CardDescription>
               </div>
               <Button variant="outline" size="sm">
@@ -945,12 +945,12 @@ function DashboardPage() {
         {/* Recent Activity */}
         <Card>
           <CardHeader>
-            <CardTitle>Recent Activity</CardTitle>
+            <CardTitle as="h2">Recent Activity</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             {mockActivity.map((item, i) => (
               <div key={i} className="flex items-center gap-3">
-                <Avatar name={item.user} size="sm" />
+                <Avatar name={item.user} alt="" size="sm" />
                 <div className="min-w-0 flex-1">
                   <Text size="sm" weight="medium" truncate>
                     {item.user}
@@ -971,7 +971,7 @@ function DashboardPage() {
       {/* Quick Actions */}
       <Card>
         <CardHeader>
-          <CardTitle>Quick Actions</CardTitle>
+          <CardTitle as="h2">Quick Actions</CardTitle>
         </CardHeader>
         <CardContent>
           <QuickActionGroup>
@@ -2254,7 +2254,12 @@ export const AllComponents: StoryObj = {
         </Text>
         <div className="space-y-4">
           <Pagination page={1} totalPages={10} onPageChange={() => {}} />
-          <SimplePagination page={1} totalPages={10} onPageChange={() => {}} />
+          <SimplePagination
+            page={1}
+            totalPages={10}
+            onPageChange={() => {}}
+            label="Simple pagination"
+          />
         </div>
       </section>
     </div>

--- a/src/components/Dashboard/DashboardWidgets.stories.tsx
+++ b/src/components/Dashboard/DashboardWidgets.stories.tsx
@@ -372,6 +372,7 @@ export const BusinessDashboard: StoryObj = {
               key={stat.label}
               title={stat.label}
               icon={<ActivityIcon className="h-4 w-4" />}
+              headingLevel="h2"
             >
               <Text size="3xl" weight="bold">
                 {stat.value}
@@ -390,6 +391,7 @@ export const BusinessDashboard: StoryObj = {
               title="Recent Orders"
               icon={<DollarSignIcon className="h-4 w-4" />}
               count={orderData.length}
+              headingLevel="h2"
             >
               <DashboardWidgetTable<Order>
                 showHeader
@@ -432,6 +434,7 @@ export const BusinessDashboard: StoryObj = {
             title="Recent Activity"
             icon={<ActivityIcon className="h-4 w-4" />}
             count={activityData.length}
+            headingLevel="h2"
           >
             <DashboardWidgetTable<ActivityItem>
               columns={[
@@ -466,6 +469,7 @@ export const BusinessDashboard: StoryObj = {
         <DashboardWidget
           title="Quick Actions"
           icon={<ZapIcon className="h-4 w-4" />}
+          headingLevel="h2"
         >
           <DashboardWidgetActions columns={3} actions={quickActions} />
         </DashboardWidget>

--- a/src/components/DashboardWidget/DashboardWidget.tsx
+++ b/src/components/DashboardWidget/DashboardWidget.tsx
@@ -54,6 +54,8 @@ export interface DashboardWidgetProps
   accent?: 'primary' | 'success' | 'warning' | 'destructive' | 'info';
   /** Optional footer content beneath the widget body */
   footer?: React.ReactNode;
+  /** Heading level for the widget title — defaults to `h3` */
+  headingLevel?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 /**
@@ -85,6 +87,7 @@ const DashboardWidget = React.forwardRef<HTMLDivElement, DashboardWidgetProps>(
       loading,
       accent,
       footer,
+      headingLevel: Heading = 'h3',
       children,
       ...props
     },
@@ -111,9 +114,9 @@ const DashboardWidget = React.forwardRef<HTMLDivElement, DashboardWidgetProps>(
             {icon && (
               <span className="text-muted-foreground shrink-0">{icon}</span>
             )}
-            <h3 className="text-foreground text-sm font-semibold tracking-wide uppercase">
+            <Heading className="text-foreground text-sm font-semibold tracking-wide uppercase">
               {title}
-            </h3>
+            </Heading>
             {count !== undefined && (
               <span className="bg-primary-100 text-primary-900 dark:bg-primary-900/50 dark:text-primary-300 inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-semibold">
                 {count}
@@ -186,7 +189,7 @@ export interface InfoItem {
   className?: string;
 }
 
-export interface DashboardWidgetInfoProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface DashboardWidgetInfoProps extends React.HTMLAttributes<HTMLDListElement> {
   /** Array of label/value items to display */
   items: InfoItem[];
   /** Number of columns in the grid */
@@ -211,7 +214,7 @@ export interface DashboardWidgetInfoProps extends React.HTMLAttributes<HTMLDivEl
  * ```
  */
 const DashboardWidgetInfo = React.forwardRef<
-  HTMLDivElement,
+  HTMLDListElement,
   DashboardWidgetInfoProps
 >(({ className, items, columns = 2, layout = 'stacked', ...props }, ref) => {
   const gridCols = {
@@ -222,7 +225,7 @@ const DashboardWidgetInfo = React.forwardRef<
   };
 
   return (
-    <div
+    <dl
       ref={ref}
       data-slot="dashboard-widget-info"
       className={cn('grid gap-x-6 gap-y-3', gridCols[columns], className)}
@@ -250,7 +253,7 @@ const DashboardWidgetInfo = React.forwardRef<
           </dd>
         </div>
       ))}
-    </div>
+    </dl>
   );
 });
 
@@ -382,7 +385,9 @@ function DashboardWidgetTableInner<T extends Record<string, unknown>>(
                 </TableHead>
               ))}
               {actions && actions.length > 0 && (
-                <TableHead className="w-0 px-4" />
+                <TableHead className="w-0 px-4">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
               )}
             </TableRow>
           </TableHeader>
@@ -763,7 +768,7 @@ const DashboardWidgetDataCards = React.forwardRef<
       className={cn('space-y-3', className)}
       {...props}
     >
-      <div className={cn('grid gap-x-6 gap-y-3', gridCols[columns])}>
+      <dl className={cn('grid gap-x-6 gap-y-3', gridCols[columns])}>
         {items.map((item, i) => (
           <div key={`${item.label}-${i}`} className={cn('', item.className)}>
             <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
@@ -779,7 +784,7 @@ const DashboardWidgetDataCards = React.forwardRef<
             </dd>
           </div>
         ))}
-      </div>
+      </dl>
       {footer && (
         <div className="border-border text-muted-foreground flex items-center gap-2 border-t pt-2 text-xs">
           {footer}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -70,6 +70,8 @@ export interface PaginationProps extends VariantProps<
     next?: string;
     last?: string;
   };
+  /** Accessible label for the navigation landmark */
+  label?: string;
   /** Additional class name */
   className?: string;
 }
@@ -96,6 +98,7 @@ function Pagination({
   variant,
   size,
   labels,
+  label,
   className,
 }: PaginationProps) {
   // Calculate page range to display
@@ -144,7 +147,7 @@ function Pagination({
     <nav
       data-slot="pagination"
       role="navigation"
-      aria-label="Pagination"
+      aria-label={label || 'Pagination'}
       className={cn('flex items-center gap-1', className)}
     >
       {/* First Page Button */}
@@ -267,6 +270,8 @@ export interface SimplePaginationProps extends VariantProps<
   onPageChange: (page: number) => void;
   /** Show page info */
   showPageInfo?: boolean;
+  /** Accessible label for the navigation landmark */
+  label?: string;
   /** Additional class name */
   className?: string;
 }
@@ -291,6 +296,7 @@ function SimplePagination({
   showPageInfo = true,
   variant,
   size,
+  label,
   className,
 }: SimplePaginationProps) {
   const canGoPrev = page > 1;
@@ -300,7 +306,7 @@ function SimplePagination({
     <nav
       data-slot="simple-pagination"
       role="navigation"
-      aria-label="Pagination"
+      aria-label={label || 'Pagination'}
       className={cn('flex items-center gap-2', className)}
     >
       <button

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -293,9 +293,9 @@ export function SidebarNav({
   className,
 }: SidebarNavProps): React.JSX.Element {
   return (
-    <nav data-slot="sidebar-nav" className={cn('space-y-1 px-2', className)}>
+    <div data-slot="sidebar-nav" className={cn('space-y-1 px-2', className)}>
       {children}
-    </nav>
+    </div>
   );
 }
 

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -98,7 +98,7 @@ module.exports = {
           foreground: 'var(--mieweb-muted-foreground, hsl(215.4 16.3% 46.9%))',
         },
         destructive: {
-          DEFAULT: 'var(--mieweb-destructive, hsl(0 84.2% 60.2%))',
+          DEFAULT: 'var(--mieweb-destructive, var(--mieweb-destructive-500, hsl(0 72.2% 50.6%)))',
           foreground: 'var(--mieweb-destructive-foreground, hsl(210 40% 98%))',
         },
         success: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -356,13 +356,14 @@ export const miewebUIPreset: MiewebUIPreset = {
         },
         // Destructive / error scale
         destructive: {
-          DEFAULT: 'var(--mieweb-destructive-500, #ef4444)',
+          DEFAULT:
+            'var(--mieweb-destructive, var(--mieweb-destructive-500, #dc2626))',
           50: 'var(--mieweb-destructive-50, #fef2f2)',
           100: 'var(--mieweb-destructive-100, #fee2e2)',
           200: 'var(--mieweb-destructive-200, #fecaca)',
           300: 'var(--mieweb-destructive-300, #fca5a5)',
           400: 'var(--mieweb-destructive-400, #f87171)',
-          500: 'var(--mieweb-destructive-500, #ef4444)',
+          500: 'var(--mieweb-destructive-500, #dc2626)',
           600: 'var(--mieweb-destructive-600, #dc2626)',
           700: 'var(--mieweb-destructive-700, #b91c1c)',
           800: 'var(--mieweb-destructive-800, #991b1b)',


### PR DESCRIPTION
Component fixes:
- DashboardWidgetInfo/DataCards: div → dl for definition list semantics (dlitem)
- DashboardWidgetTable: add sr-only 'Actions' text to empty table header
- CardTitle: add 'as' prop for configurable heading level (default h3)
- DashboardWidget: add 'headingLevel' prop, replace hardcoded h3
- CountBadge: text-primary-700 → text-primary-800 for AA contrast
- SidebarNav: nav → div to fix nested landmark-unique violation
- Avatar: allow alt='' for decorative images (was falsy, fell through)
- Pagination/SimplePagination: add 'label' prop for unique landmarks
- Destructive color: #ef4444 (3.76:1) → #dc2626 (4.62:1) across preset and all brand configs for WCAG AA compliance

Story fixes:
- Dashboard.stories: heading levels, decorative alt, pagination labels
- DashboardWidgets.stories: widget heading levels

Verification:
- Business Dashboard: 0 violations
- Patient Summary: 0 violations
- All Components: 0 violations
- Dashboard (composite): 8 remaining — all DataVis NITRO (deferred)