### PR TITLE
fix(a11y): CSS-only color contrast overrides for DataVis NITRO

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import './condensed-view.css';
 @import './datavis-dark.css';
+@import './datavis-overrides.css';
 @custom-variant dark (&:where(.dark, [data-theme=dark], .dark *, [data-theme=dark] *));
 
 /* Hide DataVis slider from layout when closed to prevent horizontal overflow */

--- a/src/styles/datavis-overrides.css
+++ b/src/styles/datavis-overrides.css
@@ -1,0 +1,62 @@
+/*
+ * DataVis NITRO — Accessibility Overrides (Light & Dark)
+ *
+ * The datavis package uses hardcoded Tailwind utility classes that
+ * produce WCAG 2.1 AA violations. These overrides fix issues that
+ * can be addressed with CSS without modifying the datavis submodule.
+ *
+ * Fixes applied:
+ *   1. color-contrast: text-gray-600 (#737373) on bg-gray-50 (#f5f5f5)
+ *      gives 4.34:1 — needs 4.5:1. Bump to #525252 (~7.4:1).
+ *
+ * Remaining violations that require datavis submodule changes:
+ *   - aria-allowed-attr: aria-sort="none" on role="button" (.wcdv-th)
+ *   - aria-required-attr: role="separator" missing aria-valuenow
+ *   - aria-required-children: role="grid" with wrong child structure
+ *   - landmark-banner-is-top-level: .wcdv-title-bar has role="banner"
+ *   - landmark-no-duplicate-banner / landmark-unique: duplicate banners
+ *
+ * NOTE: Included via base.css alongside datavis-dark.css.
+ */
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * Color Contrast — Table headers
+ *
+ * .wcdv-th uses text-gray-600 (#737373) on bg-gray-50 (#f5f5f5)
+ * which gives 4.34:1 contrast. WCAG AA requires 4.5:1 for normal text.
+ * Override to #525252 (gray-700 equivalent) which gives ~7.4:1.
+ *
+ * Dark mode uses #a3a3a3 (neutral-400 equivalent) on dark backgrounds
+ * for ~5.3:1 contrast, matching the existing dark theme tokens.
+ * ═══════════════════════════════════════════════════════════════════════ */
+.wcdv-th {
+  color: #525252 !important;
+}
+.dark .wcdv-th,
+[data-theme='dark'] .wcdv-th {
+  color: #a3a3a3 !important;
+}
+
+/* ── Color Contrast — Aggregate footer row (COUNT, SUM, etc.) ──────── */
+.wcdv-grid td.text-gray-500,
+.wcdv-grid td.text-gray-600 {
+  color: #525252 !important;
+}
+.dark .wcdv-grid td.text-gray-500,
+.dark .wcdv-grid td.text-gray-600,
+[data-theme='dark'] .wcdv-grid td.text-gray-500,
+[data-theme='dark'] .wcdv-grid td.text-gray-600 {
+  color: #a3a3a3 !important;
+}
+
+/* ── Color Contrast — Status bar ("Showing N rows") ──────────────────── */
+.wcdv-table-footer span,
+.wcdv-agg-footer span {
+  color: #525252 !important;
+}
+.dark .wcdv-table-footer span,
+.dark .wcdv-agg-footer span,
+[data-theme='dark'] .wcdv-table-footer span,
+[data-theme='dark'] .wcdv-agg-footer span {
+  color: #a3a3a3 !important;
+}

--- a/src/styles/datavis-overrides.css
+++ b/src/styles/datavis-overrides.css
@@ -18,7 +18,7 @@
  *
  * NOTE: Included via base.css alongside datavis-dark.css.
  *
- * Uses design-system tokens instead of hardcoded hex values:
+ * Defines --color-datavis-a11y-text, a semantic token that resolves to:
  *   Light: var(--color-neutral-600) = #525252 (~7.4:1 on #f5f5f5)
  *   Dark:  var(--color-neutral-400) = #a3a3a3 (~5.3:1 on #262626)
  *
@@ -27,6 +27,15 @@
  * palette tokens are stable across brands.
  */
 
+/* ── Semantic token — auto-switches with theme ─────────────────────── */
+:root {
+  --color-datavis-a11y-text: var(--color-neutral-600);
+}
+.dark,
+[data-theme='dark'] {
+  --color-datavis-a11y-text: var(--color-neutral-400);
+}
+
 /* ═══════════════════════════════════════════════════════════════════════
  * Color Contrast — Table headers
  *
@@ -34,33 +43,17 @@
  * which gives 4.34:1 contrast. WCAG AA requires 4.5:1 for normal text.
  * ═══════════════════════════════════════════════════════════════════════ */
 .wcdv-th {
-  color: var(--color-neutral-600) !important;
-}
-.dark .wcdv-th,
-[data-theme='dark'] .wcdv-th {
-  color: var(--color-neutral-400) !important;
+  color: var(--color-datavis-a11y-text) !important;
 }
 
 /* ── Color Contrast — Aggregate footer row (COUNT, SUM, etc.) ──────── */
 .wcdv-grid td.text-gray-500,
 .wcdv-grid td.text-gray-600 {
-  color: var(--color-neutral-600) !important;
-}
-.dark .wcdv-grid td.text-gray-500,
-.dark .wcdv-grid td.text-gray-600,
-[data-theme='dark'] .wcdv-grid td.text-gray-500,
-[data-theme='dark'] .wcdv-grid td.text-gray-600 {
-  color: var(--color-neutral-400) !important;
+  color: var(--color-datavis-a11y-text) !important;
 }
 
 /* ── Color Contrast — Status bar ("Showing N rows") ──────────────────── */
 .wcdv-table-footer span,
 .wcdv-agg-footer span {
-  color: var(--color-neutral-600) !important;
-}
-.dark .wcdv-table-footer span,
-.dark .wcdv-agg-footer span,
-[data-theme='dark'] .wcdv-table-footer span,
-[data-theme='dark'] .wcdv-agg-footer span {
-  color: var(--color-neutral-400) !important;
+  color: var(--color-datavis-a11y-text) !important;
 }

--- a/src/styles/datavis-overrides.css
+++ b/src/styles/datavis-overrides.css
@@ -41,8 +41,13 @@
  *
  * .wcdv-th uses text-gray-600 (#737373) on bg-gray-50 (#f5f5f5)
  * which gives 4.34:1 contrast. WCAG AA requires 4.5:1 for normal text.
+ *
+ * Include dark-scoped selectors so this override matches the specificity
+ * of datavis-dark.css rules such as `.dark .wcdv-th`.
  * ═══════════════════════════════════════════════════════════════════════ */
-.wcdv-th {
+.wcdv-th,
+.dark .wcdv-th,
+[data-theme='dark'] .wcdv-th {
   color: var(--color-datavis-a11y-text) !important;
 }
 
@@ -54,6 +59,10 @@
 
 /* ── Color Contrast — Status bar ("Showing N rows") ──────────────────── */
 .wcdv-table-footer span,
-.wcdv-agg-footer span {
+.wcdv-agg-footer span,
+.dark .wcdv-table-footer span,
+.dark .wcdv-agg-footer span,
+[data-theme='dark'] .wcdv-table-footer span,
+[data-theme='dark'] .wcdv-agg-footer span {
   color: var(--color-datavis-a11y-text) !important;
 }

--- a/src/styles/datavis-overrides.css
+++ b/src/styles/datavis-overrides.css
@@ -7,7 +7,7 @@
  *
  * Fixes applied:
  *   1. color-contrast: text-gray-600 (#737373) on bg-gray-50 (#f5f5f5)
- *      gives 4.34:1 — needs 4.5:1. Bump to #525252 (~7.4:1).
+ *      gives 4.34:1 — needs 4.5:1. Override with --color-neutral-600/400.
  *
  * Remaining violations that require datavis submodule changes:
  *   - aria-allowed-attr: aria-sort="none" on role="button" (.wcdv-th)
@@ -17,6 +17,14 @@
  *   - landmark-no-duplicate-banner / landmark-unique: duplicate banners
  *
  * NOTE: Included via base.css alongside datavis-dark.css.
+ *
+ * Uses design-system tokens instead of hardcoded hex values:
+ *   Light: var(--color-neutral-600) = #525252 (~7.4:1 on #f5f5f5)
+ *   Dark:  var(--color-neutral-400) = #a3a3a3 (~5.3:1 on #262626)
+ *
+ * NOTE: Cannot use --color-muted-foreground because brand overrides
+ * may set it to the same failing value (#737373). The neutral-*
+ * palette tokens are stable across brands.
  */
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -24,39 +32,35 @@
  *
  * .wcdv-th uses text-gray-600 (#737373) on bg-gray-50 (#f5f5f5)
  * which gives 4.34:1 contrast. WCAG AA requires 4.5:1 for normal text.
- * Override to #525252 (gray-700 equivalent) which gives ~7.4:1.
- *
- * Dark mode uses #a3a3a3 (neutral-400 equivalent) on dark backgrounds
- * for ~5.3:1 contrast, matching the existing dark theme tokens.
  * ═══════════════════════════════════════════════════════════════════════ */
 .wcdv-th {
-  color: #525252 !important;
+  color: var(--color-neutral-600) !important;
 }
 .dark .wcdv-th,
 [data-theme='dark'] .wcdv-th {
-  color: #a3a3a3 !important;
+  color: var(--color-neutral-400) !important;
 }
 
 /* ── Color Contrast — Aggregate footer row (COUNT, SUM, etc.) ──────── */
 .wcdv-grid td.text-gray-500,
 .wcdv-grid td.text-gray-600 {
-  color: #525252 !important;
+  color: var(--color-neutral-600) !important;
 }
 .dark .wcdv-grid td.text-gray-500,
 .dark .wcdv-grid td.text-gray-600,
 [data-theme='dark'] .wcdv-grid td.text-gray-500,
 [data-theme='dark'] .wcdv-grid td.text-gray-600 {
-  color: #a3a3a3 !important;
+  color: var(--color-neutral-400) !important;
 }
 
 /* ── Color Contrast — Status bar ("Showing N rows") ──────────────────── */
 .wcdv-table-footer span,
 .wcdv-agg-footer span {
-  color: #525252 !important;
+  color: var(--color-neutral-600) !important;
 }
 .dark .wcdv-table-footer span,
 .dark .wcdv-agg-footer span,
 [data-theme='dark'] .wcdv-table-footer span,
 [data-theme='dark'] .wcdv-agg-footer span {
-  color: #a3a3a3 !important;
+  color: var(--color-neutral-400) !important;
 }


### PR DESCRIPTION
Add datavis-overrides.css with WCAG 2.1 AA color contrast fixes for DataVis NITRO table headers, footer text, and status spans.

- Light mode: #525252 (~7.4:1 on #f5f5f5)
- Dark mode: #a3a3a3 (~5.3:1 on #262626)
- Targets .wcdv-th, .wcdv-grid td.text-gray-500/.text-gray-600, .wcdv-table-footer span, .wcdv-agg-footer span
- Documents remaining submodule-only violations in header comment

Eliminates all color-contrast violations on Dashboard and DataVis NITRO stories in both light and dark modes.