### PR TITLE
fix(a11y): fix color contrast on AGGrid TagsRenderer badges

### DIFF
--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -708,7 +708,7 @@ export function TagsRenderer(props: ICellRendererParams): React.ReactElement {
       {value.slice(0, 3).map((tag: string, index: number) => (
         <span
           key={index}
-          className="text-muted-foreground inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium dark:bg-gray-800"
+          className="text-foreground inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium dark:bg-gray-800"
         >
           {tag}
         </span>


### PR DESCRIPTION
Replace text-muted-foreground with text-foreground on tag badge spans in TagsRenderer. Tags sit on bg-gray-100 background, so muted text (#737373 with brand overrides) drops to 4.34:1 — below WCAG AA 4.5:1. Using text-foreground ensures full contrast on the muted background.