### PR TITLE
fix(a11y): resolve accessibility violations in Messaging components

### DIFF
--- a/src/components/Messaging/ConversationHeader.tsx
+++ b/src/components/Messaging/ConversationHeader.tsx
@@ -230,6 +230,7 @@ const ConversationHeader = React.forwardRef<
                 'h-3 w-3 rounded-full',
                 'bg-green-500 ring-2 ring-white dark:ring-neutral-900'
               )}
+              role="status"
               aria-label="Online"
             />
           )}
@@ -245,7 +246,7 @@ const ConversationHeader = React.forwardRef<
               className={cn(
                 'truncate text-sm',
                 isOnline
-                  ? 'text-green-600 dark:text-green-400'
+                  ? 'text-green-700 dark:text-green-400'
                   : 'text-muted-foreground'
               )}
             >
@@ -391,7 +392,7 @@ const ConversationListItem = React.forwardRef<
             {title}
           </h3>
           {lastMessage && (
-            <span className="text-muted-foreground shrink-0 text-xs">
+            <span className="shrink-0 text-xs text-neutral-600 dark:text-neutral-400">
               {formatTime(lastMessage.timestamp)}
             </span>
           )}
@@ -402,7 +403,7 @@ const ConversationListItem = React.forwardRef<
               'truncate text-sm',
               isUnread
                 ? 'text-neutral-700 dark:text-neutral-300'
-                : 'text-muted-foreground'
+                : 'text-neutral-600 dark:text-neutral-400'
             )}
           >
             {lastMessage?.content || 'No messages yet'}

--- a/src/components/Messaging/MessageBubble.tsx
+++ b/src/components/Messaging/MessageBubble.tsx
@@ -374,7 +374,7 @@ const bubbleVariants = cva(
         ],
       },
       status: {
-        sending: 'opacity-70',
+        sending: '',
         sent: '',
         delivered: '',
         read: '',
@@ -617,7 +617,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
                 onClick={onRetry}
                 className={cn(
                   'flex items-center gap-1 rounded px-2 py-0.5',
-                  'text-xs font-medium text-red-500',
+                  'text-xs font-medium text-red-700 dark:text-red-400',
                   'hover:bg-red-50 dark:hover:bg-red-900/20',
                   'focus:ring-2 focus:ring-red-500 focus:outline-none'
                 )}

--- a/src/components/Messaging/MessageComposer.tsx
+++ b/src/components/Messaging/MessageComposer.tsx
@@ -54,10 +54,10 @@ function CharacterCounter({
       className={cn(
         'text-xs tabular-nums',
         isOver
-          ? 'font-medium text-red-500'
+          ? 'font-medium text-red-700 dark:text-red-400'
           : isWarning
-            ? 'text-amber-500'
-            : 'text-neutral-500',
+            ? 'text-amber-700 dark:text-amber-400'
+            : 'text-neutral-600 dark:text-neutral-400',
         className
       )}
       aria-live="polite"

--- a/src/components/Messaging/MessageList.tsx
+++ b/src/components/Messaging/MessageList.tsx
@@ -506,6 +506,7 @@ const MessageList = React.forwardRef<HTMLDivElement, MessageListProps>(
     if (isLoading) {
       return (
         <div
+          role="status"
           className={cn(
             'flex flex-1 flex-col gap-3 overflow-y-auto p-4',
             className

--- a/src/components/Messaging/Messaging.stories.tsx
+++ b/src/components/Messaging/Messaging.stories.tsx
@@ -548,7 +548,10 @@ export const HeaderWithBack: StoryObj<typeof ConversationHeader> = {
           // Back clicked
         }}
         actions={
-          <button className="rounded-full p-2 hover:bg-neutral-100">
+          <button
+            className="rounded-full p-2 hover:bg-neutral-100"
+            aria-label="More options"
+          >
             <svg
               className="h-5 w-5"
               fill="none"


### PR DESCRIPTION
ConversationHeader:
- Add role="status" to online indicator span (fixes aria-prohibited-attr)
- Change "Online" subtitle from text-green-600 to text-green-700 (4.8:1 contrast)
- Replace text-muted-foreground with text-neutral-600/dark:text-neutral-400 on ConversationListItem timestamp and message preview

MessageBubble:
- Remove opacity-70 on sending status (was reducing contrast to 2.99:1)
- Change retry button from text-red-500 to text-red-700/dark:text-red-400

MessageComposer:
- Fix character counter contrast: text-neutral-600/dark:text-neutral-400
- Add dark mode variants to warning (amber-700/400) and over-limit (red-700/400)

MessageList:
- Add role="status" to loading container (fixes aria-prohibited-attr)

Messaging.stories:
- Add aria-label="More options" to icon-only button in With Back story