### PR TITLE
fix(a11y): add aria-labels to PermissionsEditor toggle buttons and fix contrast

### DIFF
--- a/src/components/PermissionsEditor/PermissionsEditor.tsx
+++ b/src/components/PermissionsEditor/PermissionsEditor.tsx
@@ -121,8 +121,14 @@ function PermissionItem({
         {hasChildren && (
           <button
             type="button"
-            onClick={() => setIsExpanded(!isExpanded)}
+            onClick={() => setIsExpanded((prev) => !prev)}
             className="hover:bg-muted rounded p-0.5"
+            aria-expanded={isExpanded}
+            aria-label={
+              isExpanded
+                ? `Collapse ${permission.name}`
+                : `Expand ${permission.name}`
+            }
             data-slot="perm-item-toggle"
           >
             {isExpanded ? (
@@ -450,7 +456,7 @@ export function PermissionsEditor({
               >
                 {employerAccess}:
               </h5>
-              <div className="text-muted-foreground text-sm italic">
+              <div className="text-foreground/80 text-sm italic">
                 {selectedEmployers.length === 0 ? (
                   <span>{all}</span>
                 ) : (


### PR DESCRIPTION
- Add dynamic aria-label (Expand/Collapse + name) to permission item toggle buttons
- Change summary italic text from text-muted-foreground to text-foreground/80 for sufficient contrast on bg-info/10 background

Resolves: button-name (Critical), color-contrast (Serious)