### PR TITLE
fix(a11y): HRISProviderSelector color-contrast, link-in-text-block, i…

### DIFF
--- a/src/components/HRISProviderSelector/HRISProviderSelector.tsx
+++ b/src/components/HRISProviderSelector/HRISProviderSelector.tsx
@@ -109,7 +109,7 @@ export function HRISProviderSelector({
               <div className="flex-shrink-0">
                 <img
                   src={currentProvider.logoUrl}
-                  alt={currentProvider.displayName}
+                  alt=""
                   className="h-16 w-auto object-contain"
                   data-slot="hris-connected-logo"
                 />
@@ -134,7 +134,7 @@ export function HRISProviderSelector({
                 email{' '}
                 <a
                   href={`mailto:${supportEmail}`}
-                  className="text-primary hover:underline"
+                  className="text-primary-800 dark:text-primary-300 underline"
                 >
                   {supportEmail}
                 </a>
@@ -143,7 +143,7 @@ export function HRISProviderSelector({
 
               <div className="mt-2 text-sm" data-slot="hris-connected-sync">
                 <strong>{lastSync}:</strong>{' '}
-                <span className="text-primary">
+                <span className="text-primary-800 dark:text-primary-300">
                   {formatLastSync(currentProvider.lastSync)}
                 </span>
               </div>
@@ -277,7 +277,7 @@ export function HRISProviderSelector({
                   <>
                     <img
                       src={provider.logoUrl}
-                      alt={provider.displayName}
+                      alt=""
                       className="max-h-full max-w-full object-contain"
                       onError={(e) => {
                         // Hide broken image and show fallback

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -257,6 +257,11 @@ export const miewebUISafelist = [
   'border-chart-5',
   // Switch component
   'bg-primary-500',
+  // Primary scale (a11y contrast)
+  'text-primary-800',
+  'dark:text-primary-300',
+  // Text decoration
+  'underline',
   'h-5',
   'w-9',
   'h-6',


### PR DESCRIPTION
…mage-redundant-alt

- Fix color-contrast: text-primary on bg-muted/50 → text-primary-800 dark:text-primary-300
- Fix link-in-text-block: add permanent underline to email link (not just hover)
- Fix image-redundant-alt: provider logo alt='' (decorative, name is in visible text)

Resolves: color-contrast (Serious), link-in-text-block (Serious), image-redundant-alt (Minor)