### PR TITLE
fix(a11y): SiteHeader landmark-unique and color-contrast violations

### DIFF
--- a/src/components/SiteHeader/SiteHeader.stories.tsx
+++ b/src/components/SiteHeader/SiteHeader.stories.tsx
@@ -61,7 +61,9 @@ const meta: Meta<typeof SiteHeader> = {
       <div className="min-h-[300px] bg-gray-100 dark:bg-gray-950">
         <Story />
         <div className="p-8">
-          <p className="text-muted-foreground">Page content below header</p>
+          <p className="text-neutral-600 dark:text-neutral-400">
+            Page content below header
+          </p>
         </div>
       </div>
     ),
@@ -123,10 +125,18 @@ export const NavLinksDemo: StoryObj<typeof NavLinks> = {
   render: () => (
     <div className="space-y-4 p-4">
       <div className="bg-primary-800 rounded-lg p-4">
-        <NavLinks links={defaultLinks} variant="light" />
+        <NavLinks
+          links={defaultLinks}
+          variant="light"
+          aria-label="Light variant navigation"
+        />
       </div>
       <div className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
-        <NavLinks links={defaultLinks} variant="dark" />
+        <NavLinks
+          links={defaultLinks}
+          variant="dark"
+          aria-label="Dark variant navigation"
+        />
       </div>
     </div>
   ),

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -106,16 +106,19 @@ export interface NavLinksProps {
   links: NavLink[];
   variant?: 'light' | 'dark';
   className?: string;
+  'aria-label'?: string;
 }
 
 export function NavLinks({
   links,
   variant = 'light',
   className,
+  'aria-label': ariaLabel = 'Main navigation',
 }: NavLinksProps) {
   return (
     <nav
       data-slot="site-header-nav"
+      aria-label={ariaLabel}
       className={cn('hidden items-center gap-1 md:flex', className)}
     >
       {links.map((link) => (
@@ -364,7 +367,7 @@ export function UserMenu({
               'flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium',
               variant === 'light'
                 ? 'bg-white/20 text-white'
-                : 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400'
+                : 'bg-primary-100 text-primary-900 dark:bg-primary-900/30 dark:text-primary-400'
             )}
           >
             {initials}
@@ -556,7 +559,7 @@ export function MobileMenuPanel({
           {user ? (
             <div className="space-y-3">
               <div className="flex items-center gap-3 px-2">
-                <div className="bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 flex h-10 w-10 items-center justify-center rounded-full font-medium">
+                <div className="bg-primary-100 text-primary-900 dark:bg-primary-900/30 dark:text-primary-400 flex h-10 w-10 items-center justify-center rounded-full font-medium">
                   {user.name
                     .split(' ')
                     .map((w) => w[0])


### PR DESCRIPTION
## Changes

- Add `aria-label` prop to `NavLinks` component (defaults to `"Main navigation"`) to satisfy the `landmark-unique` rule when multiple `<nav>` elements coexist on a page
- Fix story decorator `text-muted-foreground` → `text-neutral-600 dark:text-neutral-400` on `bg-gray-100` for color-contrast compliance

## Testing

All 8 SiteHeader stories now pass with 0 a11y violations (NavLinksDemo previously had 2).