### PR TITLE
fix(a11y): CookieConsent story decorator contrast and heading order

### DIFF
--- a/src/components/CookieConsent/CookieConsent.stories.tsx
+++ b/src/components/CookieConsent/CookieConsent.stories.tsx
@@ -90,7 +90,7 @@ const meta: Meta<typeof CookieConsentBanner> = {
           <h1 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
             Welcome to BlueHive
           </h1>
-          <p className="text-muted-foreground">
+          <p className="text-neutral-600 dark:text-neutral-400">
             Page content to demonstrate the cookie consent banner.
           </p>
         </div>
@@ -157,10 +157,10 @@ function InteractiveDemo() {
   return (
     <div className="space-y-4">
       <div className="rounded-lg bg-white p-4 dark:bg-gray-800">
-        <h3 className="mb-2 font-medium text-gray-900 dark:text-white">
+        <h2 className="mb-2 font-medium text-gray-900 dark:text-white">
           Consent Status
-        </h3>
-        <p className="text-muted-foreground text-sm">
+        </h2>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
           Has consented: <strong>{hasConsented ? 'Yes' : 'No'}</strong>
         </p>
         <button


### PR DESCRIPTION
## Summary

Fixes WCAG 2.1 AA violations in CookieConsent stories (all 6 variants now pass clean).

## Violations Fixed

### color-contrast (all stories)
- **Element**: Story decorator paragraph `text-muted-foreground` on `bg-gray-100`
- **Issue**: #737373 on #f5f5f5 = 4.34:1 (needs 4.5:1)
- **Fix**: Replace with `text-neutral-600 dark:text-neutral-400`

### heading-order (Interactive story)
- **Element**: `<h3>` "Consent Status" with no preceding `<h2>` (page has `<h1>`)
- **Fix**: Changed to `<h2>`; also fixed `text-muted-foreground` in same block

## Testing

- `pnpm test:storybook -- --testPathPatterns='CookieConsent'` → 6/6 pass, 0 violations
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm format:fix` ✓