### PR TITLE
fix(a11y): InventoryManager and SetupServiceModal contrast, heading-order, button-name

### DIFF
--- a/src/components/InventoryManager/InventoryManager.tsx
+++ b/src/components/InventoryManager/InventoryManager.tsx
@@ -146,7 +146,7 @@ export function InventoryManager({
           <button
             type="button"
             onClick={onUpdateClick}
-            className="text-primary hover:text-primary/80 flex items-center gap-1 text-sm font-medium"
+            className="text-primary-800 hover:text-primary-900 dark:text-primary-300 dark:hover:text-primary-200 flex items-center gap-1 text-sm font-medium"
           >
             Update Inventory
             <svg
@@ -208,8 +208,8 @@ export function InventoryManager({
                       <span
                         className={`inline-flex items-center gap-1 ${
                           entry.type === 'credit'
-                            ? 'text-green-600 dark:text-green-400'
-                            : 'text-red-600 dark:text-red-400'
+                            ? 'text-green-700 dark:text-green-400'
+                            : 'text-red-700 dark:text-red-400'
                         }`}
                       >
                         {entry.type === 'credit' ? (
@@ -293,15 +293,15 @@ export function InventoryManager({
         </ModalHeader>
         <ModalBody className="space-y-4">
           <div>
-            <h4 className="text-foreground text-lg font-semibold">
+            <h3 className="text-foreground text-lg font-semibold">
               {serviceName}
-            </h4>
+            </h3>
           </div>
 
           <div>
-            <h5 className="text-muted-foreground mb-2 text-sm font-medium">
+            <h4 className="text-muted-foreground mb-2 text-sm font-medium">
               Update Inventory
-            </h5>
+            </h4>
           </div>
 
           {/* Add/Remove Toggle */}

--- a/src/components/SetupServiceModal/SetupServiceModal.tsx
+++ b/src/components/SetupServiceModal/SetupServiceModal.tsx
@@ -130,7 +130,7 @@ export function SetupServiceModal({
               data-slot="setup-service-error"
               className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20"
             >
-              <p className="text-sm text-red-600 dark:text-red-400">
+              <p className="text-sm text-red-700 dark:text-red-400">
                 {errorMessage}
               </p>
             </div>
@@ -247,6 +247,7 @@ export function SetupServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Currently Offered"
                 className="flex-shrink-0"
                 checked={formData.currentlyOffered}
                 onCheckedChange={(checked) =>
@@ -271,6 +272,7 @@ export function SetupServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Limited Inventory"
                 className="flex-shrink-0"
                 checked={formData.limitedInventory}
                 onCheckedChange={(checked) =>
@@ -316,6 +318,7 @@ export function SetupServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Auto-Accept Referrals"
                 className="flex-shrink-0"
                 checked={formData.autoAcceptReferrals}
                 onCheckedChange={(checked) =>


### PR DESCRIPTION
## Summary

Fixes WCAG 2.1 AA violations in InventoryManager (5 stories) and SetupServiceModal (6 stories) — all now pass with 0 violations.

## InventoryManager Violations Fixed

### color-contrast — "Update Inventory" link button
- **Element**: `text-primary` on white background
- **Issue**: #27aae1 on #ffffff = 2.65:1 (needs 4.5:1)
- **Fix**: `text-primary-800 hover:text-primary-900 dark:text-primary-300 dark:hover:text-primary-200`

### color-contrast — Log entry quantity colors
- **Element**: `text-green-600` / `text-red-600` on white
- **Fix**: `text-green-700` / `text-red-700` (dark mode unchanged)

### heading-order — Modal body headings
- **Element**: `<h4>` service name and `<h5>` "Update Inventory" inside modal (ModalTitle = `<h2>`)
- **Fix**: `<h3>` and `<h4>` respectively

## SetupServiceModal Violations Fixed

### button-name — Switch components (all stories)
- **Element**: 3 Switch toggles without discernible text
- **Fix**: Added `aria-label` to each: "Currently Offered", "Limited Inventory", "Auto-Accept Referrals"

### color-contrast — Error message text (WithError story)
- **Element**: `text-red-600` on `bg-red-50`
- **Issue**: #e7000b on #fef2f2 = 4.46:1 (needs 4.5:1)
- **Fix**: `text-red-700`

## Testing

- `pnpm test:storybook -- '--testPathPatterns=InventoryManager'` → 5/5 pass, 0 violations
- `pnpm test:storybook -- '--testPathPatterns=SetupServiceModal'` → 6/6 pass, 0 violations
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm format:fix` ✓