### PR TITLE
fix(a11y): EmployerServiceModal button-name and error text contrast

### DIFF
--- a/src/components/EmployerServiceModal/EmployerServiceModal.tsx
+++ b/src/components/EmployerServiceModal/EmployerServiceModal.tsx
@@ -115,7 +115,9 @@ export function EmployerServiceModal({
               className="border-destructive/30 bg-destructive/10 rounded-lg border p-3"
               data-slot="employer-service-error"
             >
-              <p className="text-destructive text-sm">{errorMessage}</p>
+              <p className="text-destructive-700 dark:text-destructive-300 text-sm">
+                {errorMessage}
+              </p>
             </div>
           )}
 
@@ -160,6 +162,7 @@ export function EmployerServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Use Base Price"
                 checked={config.useBasePrice}
                 onCheckedChange={(checked) =>
                   setConfig((prev) => ({
@@ -241,6 +244,7 @@ export function EmployerServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Auto-Accept Orders"
                 checked={config.autoAccept}
                 onCheckedChange={(checked) =>
                   setConfig((prev) => ({ ...prev, autoAccept: checked }))
@@ -259,6 +263,7 @@ export function EmployerServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Requires Approval"
                 checked={config.requiresApproval}
                 onCheckedChange={(checked) =>
                   setConfig((prev) => ({ ...prev, requiresApproval: checked }))
@@ -287,6 +292,7 @@ export function EmployerServiceModal({
                 </p>
               </div>
               <Switch
+                aria-label="Notify on New Orders"
                 checked={config.notifyOnOrder}
                 onCheckedChange={(checked) =>
                   setConfig((prev) => ({ ...prev, notifyOnOrder: checked }))


### PR DESCRIPTION
## Summary

Fixes WCAG 2.1 AA violations in EmployerServiceModal (5 stories now pass with 0 violations).

## Violations Fixed

### button-name — Switch components (all stories)
- **Element**: 4 Switch toggles without discernible text
- **Fix**: Added `aria-label` to each: "Use Base Price", "Auto-Accept Orders", "Requires Approval", "Notify on New Orders"

### color-contrast — Error message text (WithError story)
- **Element**: `text-destructive` on `bg-destructive/10`
- **Issue**: #dc2626 on #fce9e9 = 4.13:1 (needs 4.5:1)
- **Fix**: `text-destructive-700 dark:text-destructive-300` (already safelisted)

## Testing

- `pnpm test:storybook -- '--testPathPatterns=EmployerServiceModal'` → 5/5 pass, 0 violations
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm format:fix` ✓