### PR TITLE
fix(a11y): ServiceGeneralSettings button-name and error text contrast

### DIFF
--- a/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
+++ b/src/components/ServiceGeneralSettings/ServiceGeneralSettings.tsx
@@ -105,7 +105,7 @@ export function ServiceGeneralSettings({
             className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20"
             data-slot="service-settings-error"
           >
-            <p className="text-sm text-red-600 dark:text-red-400">
+            <p className="text-sm text-red-700 dark:text-red-400">
               {errorMessage}
             </p>
           </div>
@@ -117,7 +117,11 @@ export function ServiceGeneralSettings({
           data-slot="service-settings-toggles"
         >
           <div className="flex items-center gap-3">
-            <Switch checked={isActive} onCheckedChange={onIsActiveChange} />
+            <Switch
+              aria-label="Active"
+              checked={isActive}
+              onCheckedChange={onIsActiveChange}
+            />
             <div>
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Active
@@ -129,7 +133,11 @@ export function ServiceGeneralSettings({
           </div>
 
           <div className="flex items-center gap-3">
-            <Switch checked={isFeatured} onCheckedChange={onIsFeaturedChange} />
+            <Switch
+              aria-label="Featured"
+              checked={isFeatured}
+              onCheckedChange={onIsFeaturedChange}
+            />
             <div>
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 Featured


### PR DESCRIPTION
## Summary

Fixes WCAG 2.1 AA violations in ServiceGeneralSettings (6 stories now pass with 0 violations).

**This completes all medium-priority a11y items!** 🎉

## Violations Fixed

### button-name — Switch components (all stories)
- **Element**: 2 Switch toggles without discernible text
- **Fix**: Added `aria-label="Active"` and `aria-label="Featured"`

### color-contrast — Error message text (WithError story)
- **Element**: `text-red-600` on `bg-red-50`
- **Issue**: #e7000b on #fef2f2 = 4.46:1 (needs 4.5:1)
- **Fix**: `text-red-700`

## Testing

- `pnpm test:storybook -- '--testPathPatterns=ServiceGeneralSettings'` → 6/6 pass, 0 violations
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm format:fix` ✓