### PR TITLE
a11y: suppress structural rules that only fire in Storybook iframes

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -247,6 +247,18 @@ const preview: Preview = {
     },
   },
   parameters: {
+    a11y: {
+      config: {
+        rules: [
+          // These rules fire on every story because Storybook renders components
+          // in an iframe without <main>, <h1>, or landmark regions. They are not
+          // real-world issues — host applications provide these structural elements.
+          { id: 'landmark-one-main', enabled: false },
+          { id: 'page-has-heading-one', enabled: false },
+          { id: 'region', enabled: false },
+        ],
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,


### PR DESCRIPTION
## Summary

Disables three axe-core rules globally in `.storybook/preview.tsx` that produce false-positive warnings on **every** story:

| Rule | Why it fires | Why it's safe to suppress |
|------|-------------|--------------------------|
| `landmark-one-main` | Storybook iframe has no `<main>` | Host apps provide `<main>` |
| `page-has-heading-one` | Storybook iframe has no `<h1>` | Host apps provide page headings |
| `region` | Story content isn't wrapped in a landmark | Host apps wrap content in landmarks |

## Impact

Eliminates **~200 false-positive warnings** from the a11y test suite, reducing noise from 272 total warnings to ~40-50 real component violations that need actual fixes.

## Changes

- `.storybook/preview.tsx`: Added `a11y.config.rules` to the global `parameters` object

## Testing

- `pnpm lint` — passes
- `pnpm typecheck` — passes
- CI `pnpm test:storybook` will validate the warning reduction