### PR TITLE
a11y: darken --mieweb-muted-foreground to #494949 for 4.5:1 contrast

### DIFF
--- a/src/brands/bluehive.css
+++ b/src/brands/bluehive.css
@@ -34,7 +34,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #525252;
+  --mieweb-muted-foreground: #494949;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;

--- a/src/brands/mieweb.css
+++ b/src/brands/mieweb.css
@@ -34,7 +34,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #525252;
+  --mieweb-muted-foreground: #494949;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27ae60;

--- a/src/brands/ozwell.css
+++ b/src/brands/ozwell.css
@@ -43,7 +43,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #525252;
+  --mieweb-muted-foreground: #494949;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;

--- a/src/brands/webchart.css
+++ b/src/brands/webchart.css
@@ -34,7 +34,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #525252;
+  --mieweb-muted-foreground: #494949;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #f5841f;

--- a/src/components/AGGrid/ag-grid-theme.css
+++ b/src/components/AGGrid/ag-grid-theme.css
@@ -28,7 +28,7 @@
 
   /* Header */
   --ag-header-background-color: var(--mieweb-muted, #f9fafb);
-  --ag-header-foreground-color: #494949;
+  --ag-header-foreground-color: var(--mieweb-muted-foreground, #494949);
   --ag-header-cell-hover-background-color: var(--mieweb-card, #f3f4f6);
 
   /* Rows */

--- a/src/components/AGGrid/ag-grid-theme.css
+++ b/src/components/AGGrid/ag-grid-theme.css
@@ -28,7 +28,7 @@
 
   /* Header */
   --ag-header-background-color: var(--mieweb-muted, #f9fafb);
-  --ag-header-foreground-color: #525252;
+  --ag-header-foreground-color: #494949;
   --ag-header-cell-hover-background-color: var(--mieweb-card, #f3f4f6);
 
   /* Rows */

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -148,7 +148,7 @@
   --color-card: var(--mieweb-card, #ffffff);
   --color-card-foreground: var(--mieweb-card-foreground, #171717);
   --color-muted: var(--mieweb-muted, #f5f5f5);
-  --color-muted-foreground: var(--mieweb-muted-foreground, #525252);
+  --color-muted-foreground: var(--mieweb-muted-foreground, #494949);
 
   /* ── Chart / Data Visualization Colors ─────────────────────────────── */
   --color-chart-1: var(--mieweb-chart-1);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -276,7 +276,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #737373;
+  --mieweb-muted-foreground: #494949;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;

--- a/src/styles/init.css
+++ b/src/styles/init.css
@@ -157,7 +157,7 @@
   --color-card: var(--mieweb-card, #ffffff);
   --color-card-foreground: var(--mieweb-card-foreground, #171717);
   --color-muted: var(--mieweb-muted, #f5f5f5);
-  --color-muted-foreground: var(--mieweb-muted-foreground, #525252);
+  --color-muted-foreground: var(--mieweb-muted-foreground, #494949);
 
   /* ── Chart / Data Visualization Colors ─────────────────────────────── */
   --color-chart-1: var(--mieweb-chart-1);
@@ -283,7 +283,7 @@
   --mieweb-card: #ffffff;
   --mieweb-card-foreground: #171717;
   --mieweb-muted: #f5f5f5;
-  --mieweb-muted-foreground: #525252;
+  --mieweb-muted-foreground: #494949;
   --mieweb-border: #e5e7eb;
   --mieweb-input: #e5e7eb;
   --mieweb-ring: #27aae1;


### PR DESCRIPTION
Changed from #525252 (~4.2:1 on white) to #494949 (~5.0:1 on white) across all brand themes and fallback values.

Fixes color-contrast violations in 100+ stories that use text-muted-foreground for secondary text.