### PR TITLE
a11y: add aria-hidden="true" to decorative inline SVGs

### DIFF
--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -45,6 +45,7 @@ export interface SuggestedActionsProps {
 const ACTION_ICONS: Record<string, React.ReactNode> = {
   patient: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -60,6 +61,7 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   ),
   search: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -75,6 +77,7 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   ),
   appointment: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -90,6 +93,7 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   ),
   document: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -105,6 +109,7 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   ),
   help: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -120,6 +125,7 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   ),
   default: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/AI/AIMessage.tsx
+++ b/src/components/AI/AIMessage.tsx
@@ -71,6 +71,7 @@ function MessageAvatar({
         <span className="font-medium">{getInitials(userName)}</span>
       ) : role === 'system' ? (
         <svg
+          aria-hidden="true"
           className="h-4 w-4"
           fill="none"
           viewBox="0 0 24 24"
@@ -85,6 +86,7 @@ function MessageAvatar({
         </svg>
       ) : (
         <svg
+          aria-hidden="true"
           className="h-4 w-4"
           fill="none"
           viewBox="0 0 24 24"
@@ -197,6 +199,7 @@ function ContentBlock({ content, onLinkClick }: ContentBlockProps) {
         >
           <span className="text-muted-foreground flex items-center gap-2 text-sm">
             <svg
+              aria-hidden="true"
               className="h-4 w-4"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/AI/MCPToolCall.tsx
+++ b/src/components/AI/MCPToolCall.tsx
@@ -50,6 +50,7 @@ function ToolStatusIcon({ status, className }: ToolStatusIconProps) {
     >
       {status === 'pending' && (
         <svg
+          aria-hidden="true"
           className="h-3 w-3 text-neutral-500"
           fill="currentColor"
           viewBox="0 0 20 20"
@@ -59,6 +60,7 @@ function ToolStatusIcon({ status, className }: ToolStatusIconProps) {
       )}
       {status === 'running' && (
         <svg
+          aria-hidden="true"
           className="text-primary-800 dark:text-primary-400 h-3 w-3 animate-spin"
           fill="none"
           viewBox="0 0 24 24"
@@ -80,6 +82,7 @@ function ToolStatusIcon({ status, className }: ToolStatusIconProps) {
       )}
       {status === 'success' && (
         <svg
+          aria-hidden="true"
           className="h-3 w-3 text-green-600 dark:text-green-400"
           fill="none"
           viewBox="0 0 24 24"
@@ -95,6 +98,7 @@ function ToolStatusIcon({ status, className }: ToolStatusIconProps) {
       )}
       {status === 'error' && (
         <svg
+          aria-hidden="true"
           className="h-3 w-3 text-red-600 dark:text-red-400"
           fill="none"
           viewBox="0 0 24 24"
@@ -110,6 +114,7 @@ function ToolStatusIcon({ status, className }: ToolStatusIconProps) {
       )}
       {status === 'cancelled' && (
         <svg
+          aria-hidden="true"
           className="h-3 w-3 text-neutral-500"
           fill="none"
           viewBox="0 0 24 24"
@@ -131,6 +136,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   // Patient tools
   create_patient: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -146,6 +152,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   ),
   get_patient: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -161,6 +168,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   ),
   search_patients: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -177,6 +185,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   // Appointment tools
   schedule_appointment: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -193,6 +202,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   // Document tools
   create_document: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -209,6 +219,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   // Provider tools
   search_providers: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -230,6 +241,7 @@ const TOOL_ICONS: Record<string, React.ReactNode> = {
   // Default tool icon
   default: (
     <svg
+      aria-hidden="true"
       className="h-4 w-4"
       fill="none"
       viewBox="0 0 24 24"
@@ -270,6 +282,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
   const linkTypeIcons: Record<string, React.ReactNode> = {
     patient: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -285,6 +298,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
     ),
     document: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -300,6 +314,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
     ),
     appointment: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -315,6 +330,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
     ),
     order: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -330,6 +346,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
     ),
     provider: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -350,6 +367,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
     ),
     external: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -365,6 +383,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
     ),
     internal: (
       <svg
+        aria-hidden="true"
         className="h-4 w-4"
         fill="none"
         viewBox="0 0 24 24"
@@ -400,6 +419,7 @@ export function ResourceLink({ link, onClick, className }: ResourceLinkProps) {
       <span>{link.label}</span>
       {link.type === 'external' && (
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-60"
           fill="none"
           viewBox="0 0 24 24"
@@ -490,6 +510,7 @@ function ToolResultDisplay({
             className="flex items-center gap-1 text-xs text-neutral-600 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"
           >
             <svg
+              aria-hidden="true"
               className={cn(
                 'h-3 w-3 transition-transform',
                 showJson && 'rotate-90'
@@ -754,6 +775,7 @@ export function MCPToolCallDisplay({
               className="mt-2 flex items-center gap-1 text-xs text-neutral-600 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"
             >
               <svg
+                aria-hidden="true"
                 className={cn(
                   'h-3 w-3 transition-transform',
                   showDetails && 'rotate-90'

--- a/src/components/AI/icons.tsx
+++ b/src/components/AI/icons.tsx
@@ -30,6 +30,7 @@ const sizeClasses = {
 export function SparklesIcon({ className, size = 'md' }: SparklesIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn(sizeClasses[size], className)}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -70,6 +71,7 @@ export interface AILogoIconProps {
 export function AILogoIcon({ className, size = 'md' }: AILogoIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn(sizeClasses[size], className)}
       viewBox="0 0 24 24"
       fill="none"
@@ -112,6 +114,7 @@ export interface CloseIconProps {
 export function CloseIcon({ className }: CloseIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('h-5 w-5', className)}
       fill="none"
       viewBox="0 0 24 24"
@@ -138,6 +141,7 @@ export interface RefreshIconProps {
 export function RefreshIcon({ className }: RefreshIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('h-5 w-5', className)}
       fill="none"
       viewBox="0 0 24 24"
@@ -175,6 +179,7 @@ export function ChevronIcon({
 }: ChevronIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('h-4 w-4', chevronRotation[direction], className)}
       fill="none"
       viewBox="0 0 24 24"
@@ -197,6 +202,7 @@ export interface SendIconProps {
 export function SendIcon({ className }: SendIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('h-5 w-5', className)}
       fill="none"
       viewBox="0 0 24 24"
@@ -223,6 +229,7 @@ export interface SpinnerIconProps {
 export function SpinnerIcon({ className }: SpinnerIconProps) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('h-5 w-5 animate-spin', className)}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -269,6 +269,7 @@ export interface AppHeaderSearchProps {
 
 const SearchIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -422,6 +423,7 @@ export function AppHeaderUserMenu({
 
       {/* Chevron */}
       <svg
+        aria-hidden="true"
         className={cn(
           'hidden h-4 w-4 text-gray-400 transition-transform lg:block',
           isOpen && 'rotate-180'

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -835,6 +835,7 @@ function SocialButton({ provider, onClick, disabled }: SocialButtonProps) {
 function CloseIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -853,6 +854,7 @@ function CloseIcon({ className }: { className?: string }) {
 function EyeIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -876,6 +878,7 @@ function EyeIcon({ className }: { className?: string }) {
 function EyeOffIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -894,6 +897,7 @@ function EyeOffIcon({ className }: { className?: string }) {
 function MailIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -912,6 +916,7 @@ function MailIcon({ className }: { className?: string }) {
 function Spinner({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('animate-spin', className)}
       fill="none"
       viewBox="0 0 24 24"
@@ -935,7 +940,7 @@ function Spinner({ className }: { className?: string }) {
 
 function GoogleIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24">
+    <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
       <path
         fill="#4285F4"
         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -958,7 +963,7 @@ function GoogleIcon({ className }: { className?: string }) {
 
 function MicrosoftIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24">
+    <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
       <path fill="#F25022" d="M1 1h10v10H1z" />
       <path fill="#00A4EF" d="M13 1h10v10H13z" />
       <path fill="#7FBA00" d="M1 13h10v10H1z" />
@@ -969,7 +974,12 @@ function MicrosoftIcon({ className }: { className?: string }) {
 
 function LinkedInIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="#0077B5">
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="#0077B5"
+    >
       <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
     </svg>
   );
@@ -977,7 +987,12 @@ function LinkedInIcon({ className }: { className?: string }) {
 
 function AppleIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
     </svg>
   );

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -106,6 +106,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
           initials
         ) : (
           <svg
+            aria-hidden="true"
             className="h-[60%] w-[60%] text-white/80"
             fill="currentColor"
             viewBox="0 0 24 24"

--- a/src/components/BookingDialog/BookingDialog.tsx
+++ b/src/components/BookingDialog/BookingDialog.tsx
@@ -873,6 +873,7 @@ export function QuickBookCard({
 function CloseIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -893,6 +894,7 @@ function CloseIcon({ className }: { className?: string }) {
 function ChevronDownIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -913,6 +915,7 @@ function ChevronDownIcon({ className }: { className?: string }) {
 function PhoneIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -927,6 +930,7 @@ function PhoneIcon({ className }: { className?: string }) {
 function CalendarIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -941,6 +945,7 @@ function CalendarIcon({ className }: { className?: string }) {
 function LoadingSpinner({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={cn('animate-spin', className)}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/BusinessHours/BusinessHours.tsx
+++ b/src/components/BusinessHours/BusinessHours.tsx
@@ -696,6 +696,7 @@ export function HoursSummary({
         </div>
         {hasStructuredHours && (
           <svg
+            aria-hidden="true"
             className={cn(
               'h-5 w-5 text-neutral-400 transition-transform',
               isExpanded && 'rotate-180'

--- a/src/components/CSVColumnMapper/CSVColumnMapper.tsx
+++ b/src/components/CSVColumnMapper/CSVColumnMapper.tsx
@@ -272,6 +272,7 @@ function CSVColumnCard({
           (isMapped ? (
             <span className="bg-success-700 text-success-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
               <svg
+                aria-hidden="true"
                 className="h-3 w-3"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -287,7 +288,12 @@ function CSVColumnCard({
             </span>
           ) : (
             <span className="bg-warning-700 text-warning-50 flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
-              <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+              <svg
+                aria-hidden="true"
+                className="h-3 w-3"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
                 <circle cx="12" cy="12" r="10" fill="currentColor" />
                 <circle cx="12" cy="12" r="4" className="fill-warning" />
               </svg>
@@ -394,6 +400,7 @@ function CSVColumnCard({
         >
           {column.ignored ? (
             <svg
+              aria-hidden="true"
               className="h-3 w-3"
               fill="none"
               viewBox="0 0 24 24"
@@ -408,6 +415,7 @@ function CSVColumnCard({
             </svg>
           ) : (
             <svg
+              aria-hidden="true"
               className="h-3 w-3"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -453,6 +453,7 @@ const CardCollapsible = React.forwardRef<HTMLDivElement, CardCollapsibleProps>(
             <>
               {expanded ? 'Show less' : trigger}
               <svg
+                aria-hidden="true"
                 className={cn(
                   'h-4 w-4 transition-transform',
                   expanded && 'rotate-180'
@@ -529,6 +530,7 @@ const CardStat = React.forwardRef<HTMLDivElement, CardStatProps>(
               )}
             >
               <svg
+                aria-hidden="true"
                 className={cn('h-4 w-4', trend.value < 0 && 'rotate-180')}
                 fill="none"
                 stroke="currentColor"

--- a/src/components/CheckrIntegration/CheckrIntegration.tsx
+++ b/src/components/CheckrIntegration/CheckrIntegration.tsx
@@ -299,6 +299,7 @@ export function CheckrIntegration({
             className="bg-success/10 flex h-12 w-12 items-center justify-center rounded-lg"
           >
             <svg
+              aria-hidden="true"
               className="text-success-700 dark:text-success-300 h-6 w-6"
               fill="none"
               viewBox="0 0 24 24"
@@ -332,6 +333,7 @@ export function CheckrIntegration({
         ) : (
           <Button variant="primary" onClick={onConnect}>
             <svg
+              aria-hidden="true"
               className="mr-2 h-4 w-4"
               fill="none"
               viewBox="0 0 24 24"
@@ -356,6 +358,7 @@ export function CheckrIntegration({
           className="bg-destructive/10 border-destructive/20 text-destructive-700 dark:text-destructive-300 mb-4 rounded-lg border p-4"
         >
           <svg
+            aria-hidden="true"
             className="mr-2 inline-block h-4 w-4"
             fill="none"
             viewBox="0 0 24 24"
@@ -403,6 +406,7 @@ export function CheckrIntegration({
           <div data-slot="checkr-actions" className="mb-6 flex flex-wrap gap-3">
             <Button variant="primary" onClick={() => setShowInviteModal(true)}>
               <svg
+                aria-hidden="true"
                 className="mr-2 h-4 w-4"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -419,6 +423,7 @@ export function CheckrIntegration({
             </Button>
             <Button variant="outline" onClick={onRefresh}>
               <svg
+                aria-hidden="true"
                 className="mr-2 h-4 w-4"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -479,6 +484,7 @@ export function CheckrIntegration({
                         >
                           {selectedReports.has(report.id) && (
                             <svg
+                              aria-hidden="true"
                               className="text-primary-foreground h-3 w-3"
                               fill="none"
                               viewBox="0 0 24 24"
@@ -574,6 +580,7 @@ export function CheckrIntegration({
                 className="text-muted-foreground py-8 text-center"
               >
                 <svg
+                  aria-hidden="true"
                   className="text-muted-foreground/30 mx-auto mb-2 h-12 w-12"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -600,6 +607,7 @@ export function CheckrIntegration({
           className="border-border rounded-lg border border-dashed p-8 text-center"
         >
           <svg
+            aria-hidden="true"
             className="text-muted-foreground/30 mx-auto mb-4 h-12 w-12"
             fill="none"
             viewBox="0 0 24 24"
@@ -617,6 +625,7 @@ export function CheckrIntegration({
           </p>
           <Button variant="primary" onClick={onConnect}>
             <svg
+              aria-hidden="true"
               className="mr-2 h-4 w-4"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/ClaimProviderForm/ClaimProviderForm.tsx
+++ b/src/components/ClaimProviderForm/ClaimProviderForm.tsx
@@ -318,6 +318,7 @@ export function ClaimProviderForm({
               {isSubmitting ? (
                 <>
                   <svg
+                    aria-hidden="true"
                     className="mr-2 -ml-1 h-4 w-4 animate-spin"
                     fill="none"
                     viewBox="0 0 24 24"

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
 
 const SearchIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -30,6 +31,7 @@ const SearchIcon = () => (
 
 const XIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"
@@ -45,7 +47,12 @@ const XIcon = () => (
 );
 
 const SpinnerIcon = () => (
-  <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+  <svg
+    aria-hidden="true"
+    className="h-4 w-4 animate-spin"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
     <circle
       className="opacity-25"
       cx="12"

--- a/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -447,6 +447,7 @@ function ConnectionIcon({
   if (status === 'connected') {
     return (
       <svg
+        aria-hidden="true"
         className={cn('text-green-500', className)}
         fill="none"
         viewBox="0 0 24 24"
@@ -472,6 +473,7 @@ function ConnectionIcon({
 
   return (
     <svg
+      aria-hidden="true"
       className={cn(colorClass, animateClass, className)}
       fill="none"
       viewBox="0 0 24 24"
@@ -490,6 +492,7 @@ function ConnectionIcon({
 function ReloadIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -508,6 +511,7 @@ function ReloadIcon({ className }: { className?: string }) {
 function UpdateIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/CreateInvoiceModal/CreateInvoiceModal.tsx
+++ b/src/components/CreateInvoiceModal/CreateInvoiceModal.tsx
@@ -256,6 +256,7 @@ export function CreateInvoiceModal({
                   className="border-border rounded-lg border border-dashed py-8 text-center"
                 >
                   <svg
+                    aria-hidden="true"
                     data-slot="invoice-modal-empty-icon"
                     className="text-muted-foreground/60 mx-auto mb-2 h-10 w-10"
                     fill="none"
@@ -303,6 +304,7 @@ export function CreateInvoiceModal({
                           >
                             {isSelected && (
                               <svg
+                                aria-hidden="true"
                                 className="text-primary-foreground h-3 w-3"
                                 fill="none"
                                 stroke="currentColor"
@@ -469,6 +471,7 @@ export function CreateInvoiceModal({
                   {isSubmitting ? (
                     <>
                       <svg
+                        aria-hidden="true"
                         className="mr-2 -ml-1 h-4 w-4 animate-spin"
                         fill="none"
                         viewBox="0 0 24 24"

--- a/src/components/CreateReferralModal/CreateReferralModal.tsx
+++ b/src/components/CreateReferralModal/CreateReferralModal.tsx
@@ -220,6 +220,7 @@ export function CreateReferralModal({
                           >
                             {isSelected && (
                               <svg
+                                aria-hidden="true"
                                 className="text-primary-foreground h-3 w-3"
                                 fill="none"
                                 stroke="currentColor"
@@ -350,6 +351,7 @@ export function CreateReferralModal({
             {isSubmitting ? (
               <>
                 <svg
+                  aria-hidden="true"
                   className="mr-2 -ml-1 h-4 w-4 animate-spin"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/components/DashboardWidget/DashboardWidget.tsx
+++ b/src/components/DashboardWidget/DashboardWidget.tsx
@@ -134,6 +134,7 @@ const DashboardWidget = React.forwardRef<HTMLDivElement, DashboardWidgetProps>(
                   aria-label={addLabel}
                 >
                   <svg
+                    aria-hidden="true"
                     className="h-4 w-4"
                     fill="none"
                     stroke="currentColor"

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -593,6 +593,7 @@ DateInput.displayName = 'DateInput';
 function ChevronLeftIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="16"
       height="16"
       viewBox="0 0 24 24"
@@ -610,6 +611,7 @@ function ChevronLeftIcon() {
 function ChevronRightIcon() {
   return (
     <svg
+      aria-hidden="true"
       width="16"
       height="16"
       viewBox="0 0 24 24"

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -675,6 +675,7 @@ function DropdownItemCheckbox({
     >
       {indeterminate ? (
         <svg
+          aria-hidden="true"
           className="h-3 w-3"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
@@ -689,6 +690,7 @@ function DropdownItemCheckbox({
         </svg>
       ) : (
         <svg
+          aria-hidden="true"
           className="h-3 w-3"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"

--- a/src/components/EditUserRoleModal/EditUserRoleModal.tsx
+++ b/src/components/EditUserRoleModal/EditUserRoleModal.tsx
@@ -98,6 +98,7 @@ export function EditUserRoleModal({
           <div className="border-destructive/30 bg-destructive/10 rounded-lg border p-3">
             <div className="flex items-center gap-2">
               <svg
+                aria-hidden="true"
                 className="text-destructive h-5 w-5"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -178,6 +179,7 @@ export function EditUserRoleModal({
           {isSubmitting ? (
             <>
               <svg
+                aria-hidden="true"
                 className="mr-2 -ml-1 h-4 w-4 animate-spin"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/components/EmployerContactCard/EmployerContactCard.tsx
+++ b/src/components/EmployerContactCard/EmployerContactCard.tsx
@@ -82,6 +82,7 @@ export function EmployerContactCard({
         {showActions && onAddContact && (
           <Button variant="ghost" size="sm" onClick={onAddContact}>
             <svg
+              aria-hidden="true"
               className="mr-1 h-4 w-4"
               fill="none"
               stroke="currentColor"
@@ -102,6 +103,7 @@ export function EmployerContactCard({
         {contacts.length === 0 ? (
           <div data-slot="employer-contact-empty" className="py-6 text-center">
             <svg
+              aria-hidden="true"
               className="text-muted-foreground dark:text-muted-foreground mx-auto mb-2 h-10 w-10"
               fill="none"
               stroke="currentColor"
@@ -178,6 +180,7 @@ export function EmployerContactCard({
                         title={`Email ${contact.name}`}
                       >
                         <svg
+                          aria-hidden="true"
                           className="h-4 w-4"
                           fill="none"
                           stroke="currentColor"
@@ -202,6 +205,7 @@ export function EmployerContactCard({
                         title={`Call ${contact.name}`}
                       >
                         <svg
+                          aria-hidden="true"
                           className="h-4 w-4"
                           fill="none"
                           stroke="currentColor"

--- a/src/components/EmployerList/EmployerList.tsx
+++ b/src/components/EmployerList/EmployerList.tsx
@@ -109,6 +109,7 @@ export function EmployerList({
         {showSearch && (
           <div data-slot="employer-list-search" className="relative flex-1">
             <svg
+              aria-hidden="true"
               className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
               fill="none"
               stroke="currentColor"
@@ -133,6 +134,7 @@ export function EmployerList({
         {onAddEmployer && (
           <Button onClick={onAddEmployer} size="sm">
             <svg
+              aria-hidden="true"
               className="mr-1 h-4 w-4"
               fill="none"
               stroke="currentColor"
@@ -157,6 +159,7 @@ export function EmployerList({
           className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700"
         >
           <svg
+            aria-hidden="true"
             className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
             fill="none"
             stroke="currentColor"
@@ -268,6 +271,7 @@ export function EmployerList({
                 {/* Arrow */}
                 {onEmployerClick && (
                   <svg
+                    aria-hidden="true"
                     className="h-5 w-5 text-gray-400"
                     fill="none"
                     stroke="currentColor"

--- a/src/components/EmployerPricingCard/EmployerPricingCard.tsx
+++ b/src/components/EmployerPricingCard/EmployerPricingCard.tsx
@@ -148,6 +148,7 @@ export function EmployerPricingCard({
             {onEdit && (
               <Button variant="outline" size="sm" onClick={onEdit}>
                 <svg
+                  aria-hidden="true"
                   className="mr-1 h-3.5 w-3.5"
                   fill="none"
                   stroke="currentColor"
@@ -166,6 +167,7 @@ export function EmployerPricingCard({
             {onRemove && (
               <Button variant="ghost" size="sm" onClick={onRemove}>
                 <svg
+                  aria-hidden="true"
                   className="mr-1 h-3.5 w-3.5 text-red-500"
                   fill="none"
                   stroke="currentColor"

--- a/src/components/EmployerServiceModal/EmployerServiceModal.tsx
+++ b/src/components/EmployerServiceModal/EmployerServiceModal.tsx
@@ -357,6 +357,7 @@ export function EmployerServiceModal({
             {isSubmitting ? (
               <>
                 <svg
+                  aria-hidden="true"
                   className="mr-2 -ml-1 h-4 w-4 animate-spin"
                   data-slot="employer-service-spinner"
                   fill="none"

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -518,6 +518,7 @@ function DefaultIllustration({ type }: DefaultIllustrationProps) {
 function Search404Icon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -541,6 +542,7 @@ function Search404Icon({ className }: { className?: string }) {
 function ServerErrorIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -559,6 +561,7 @@ function ServerErrorIcon({ className }: { className?: string }) {
 function LockIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -577,6 +580,7 @@ function LockIcon({ className }: { className?: string }) {
 function WifiOffIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -596,6 +600,7 @@ function WifiOffIcon({ className }: { className?: string }) {
 function WrenchIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -619,6 +624,7 @@ function WrenchIcon({ className }: { className?: string }) {
 function AlertIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -74,6 +74,7 @@ function getFileIcon(extension: string): React.ReactNode {
   if (['pdf'].includes(ext)) {
     return (
       <svg
+        aria-hidden="true"
         className="h-5 w-5 text-red-500"
         fill="currentColor"
         viewBox="0 0 20 20"
@@ -90,6 +91,7 @@ function getFileIcon(extension: string): React.ReactNode {
   if (['doc', 'docx'].includes(ext)) {
     return (
       <svg
+        aria-hidden="true"
         className="h-5 w-5 text-blue-500"
         fill="currentColor"
         viewBox="0 0 20 20"
@@ -106,6 +108,7 @@ function getFileIcon(extension: string): React.ReactNode {
   if (['xls', 'xlsx', 'csv'].includes(ext)) {
     return (
       <svg
+        aria-hidden="true"
         className="h-5 w-5 text-green-500"
         fill="currentColor"
         viewBox="0 0 20 20"
@@ -123,6 +126,7 @@ function getFileIcon(extension: string): React.ReactNode {
   if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'].includes(ext)) {
     return (
       <svg
+        aria-hidden="true"
         className="h-5 w-5 text-purple-500"
         fill="currentColor"
         viewBox="0 0 20 20"
@@ -139,6 +143,7 @@ function getFileIcon(extension: string): React.ReactNode {
   // Default file icon
   return (
     <svg
+      aria-hidden="true"
       className="h-5 w-5 text-gray-400"
       fill="currentColor"
       viewBox="0 0 20 20"
@@ -233,6 +238,7 @@ export function FileManager({
               }`}
             >
               <svg
+                aria-hidden="true"
                 className={`h-6 w-6 ${isDragging ? 'text-blue-500' : 'text-gray-400'}`}
                 fill="none"
                 viewBox="0 0 24 24"
@@ -366,6 +372,7 @@ export function FileManager({
                 <TableCell colSpan={hasActions ? 4 : 3} className="py-8">
                   <div data-slot="file-manager-empty" className="text-center">
                     <svg
+                      aria-hidden="true"
                       className="dark:text-muted-foreground mx-auto mb-3 h-12 w-12 text-gray-300"
                       fill="none"
                       viewBox="0 0 24 24"

--- a/src/components/HelpSupportPanel/HelpSupportPanel.tsx
+++ b/src/components/HelpSupportPanel/HelpSupportPanel.tsx
@@ -89,6 +89,7 @@ export function HelpSupportPanel({
       case 'email':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -105,6 +106,7 @@ export function HelpSupportPanel({
       case 'phone':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -121,6 +123,7 @@ export function HelpSupportPanel({
       case 'chat':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -159,6 +162,7 @@ export function HelpSupportPanel({
               onClick={() => window.open(docsUrl, '_blank')}
             >
               <svg
+                aria-hidden="true"
                 className="mr-2 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -177,6 +181,7 @@ export function HelpSupportPanel({
           {onStartChat && chatAvailable && (
             <Button onClick={onStartChat}>
               <svg
+                aria-hidden="true"
                 className="mr-2 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -238,6 +243,7 @@ export function HelpSupportPanel({
                             {faq.question}
                           </span>
                           <svg
+                            aria-hidden="true"
                             className={`h-5 w-5 text-gray-400 transition-transform ${
                               expandedFaq === faq.id ? 'rotate-180' : ''
                             }`}
@@ -418,6 +424,7 @@ export function HelpSupportPanel({
                 className="flex w-full items-center gap-2 rounded-lg p-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-4 w-4"
                   fill="none"
                   stroke="currentColor"
@@ -437,6 +444,7 @@ export function HelpSupportPanel({
                 className="flex w-full items-center gap-2 rounded-lg p-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-4 w-4"
                   fill="none"
                   stroke="currentColor"
@@ -456,6 +464,7 @@ export function HelpSupportPanel({
                 className="flex w-full items-center gap-2 rounded-lg p-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-4 w-4"
                   fill="none"
                   stroke="currentColor"
@@ -475,6 +484,7 @@ export function HelpSupportPanel({
                 className="flex w-full items-center gap-2 rounded-lg p-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-4 w-4"
                   fill="none"
                   stroke="currentColor"

--- a/src/components/InventoryManager/InventoryManager.tsx
+++ b/src/components/InventoryManager/InventoryManager.tsx
@@ -150,6 +150,7 @@ export function InventoryManager({
           >
             Update Inventory
             <svg
+              aria-hidden="true"
               className="h-4 w-4"
               fill="none"
               viewBox="0 0 24 24"
@@ -214,6 +215,7 @@ export function InventoryManager({
                       >
                         {entry.type === 'credit' ? (
                           <svg
+                            aria-hidden="true"
                             className="h-3.5 w-3.5"
                             fill="none"
                             viewBox="0 0 24 24"
@@ -228,6 +230,7 @@ export function InventoryManager({
                           </svg>
                         ) : (
                           <svg
+                            aria-hidden="true"
                             className="h-3.5 w-3.5"
                             fill="none"
                             viewBox="0 0 24 24"
@@ -262,6 +265,7 @@ export function InventoryManager({
       ) : (
         <div className="text-muted-foreground py-8 text-center">
           <svg
+            aria-hidden="true"
             className="text-muted-foreground/50 mx-auto mb-3 h-12 w-12"
             fill="none"
             viewBox="0 0 24 24"
@@ -316,6 +320,7 @@ export function InventoryManager({
               } `}
             >
               <svg
+                aria-hidden="true"
                 className="mr-1 inline-block h-4 w-4"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -340,6 +345,7 @@ export function InventoryManager({
               } `}
             >
               <svg
+                aria-hidden="true"
                 className="mr-1 inline-block h-4 w-4"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/components/InviteUserModal/InviteUserModal.tsx
+++ b/src/components/InviteUserModal/InviteUserModal.tsx
@@ -124,6 +124,7 @@ export function InviteUserModal({
             >
               <div className="flex items-center gap-2">
                 <svg
+                  aria-hidden="true"
                   className="h-5 w-5 text-green-500"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -151,6 +152,7 @@ export function InviteUserModal({
             >
               <div className="flex items-center gap-2">
                 <svg
+                  aria-hidden="true"
                   className="h-5 w-5 text-red-500"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -260,6 +262,7 @@ export function InviteUserModal({
             {isSubmitting ? (
               <>
                 <svg
+                  aria-hidden="true"
                   className="mr-2 -ml-1 h-4 w-4 animate-spin"
                   data-slot="invite-user-spinner"
                   fill="none"

--- a/src/components/InvoiceList/InvoiceList.tsx
+++ b/src/components/InvoiceList/InvoiceList.tsx
@@ -157,6 +157,7 @@ export function InvoiceList({
       >
         <div data-slot="invoice-list-search" className="relative flex-1">
           <svg
+            aria-hidden="true"
             className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
             fill="none"
             stroke="currentColor"
@@ -200,6 +201,7 @@ export function InvoiceList({
           {onCreateInvoice && (
             <Button onClick={onCreateInvoice} size="sm">
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -258,6 +260,7 @@ export function InvoiceList({
           className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700"
         >
           <svg
+            aria-hidden="true"
             className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
             fill="none"
             stroke="currentColor"

--- a/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
+++ b/src/components/InvoicePaymentPage/InvoicePaymentPage.tsx
@@ -162,6 +162,7 @@ export function InvoicePaymentPage({
         >
           <CardContent className="py-12">
             <svg
+              aria-hidden="true"
               className="text-muted-foreground dark:text-muted-foreground mx-auto mb-4 h-16 w-16"
               fill="none"
               stroke="currentColor"
@@ -203,6 +204,7 @@ export function InvoicePaymentPage({
               className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30"
             >
               <svg
+                aria-hidden="true"
                 className="h-8 w-8 text-green-600 dark:text-green-400"
                 fill="none"
                 stroke="currentColor"
@@ -460,6 +462,7 @@ export function InvoicePaymentPage({
                     {isProcessing ? (
                       <>
                         <svg
+                          aria-hidden="true"
                           className="mr-2 -ml-1 h-4 w-4 animate-spin"
                           fill="none"
                           viewBox="0 0 24 24"

--- a/src/components/InvoiceView/InvoiceView.tsx
+++ b/src/components/InvoiceView/InvoiceView.tsx
@@ -126,6 +126,7 @@ export function InvoiceView({
           {onBack && (
             <Button variant="ghost" size="sm" onClick={onBack}>
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -166,6 +167,7 @@ export function InvoiceView({
               disabled={actionsDisabled}
             >
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -189,6 +191,7 @@ export function InvoiceView({
               disabled={actionsDisabled}
             >
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -222,6 +225,7 @@ export function InvoiceView({
               disabled={actionsDisabled}
             >
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -240,6 +244,7 @@ export function InvoiceView({
           {onSend && canSend && (
             <Button size="sm" onClick={onSend} disabled={actionsDisabled}>
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"

--- a/src/components/Messaging/AttachmentPicker.tsx
+++ b/src/components/Messaging/AttachmentPicker.tsx
@@ -133,6 +133,7 @@ function AttachmentPreviewItem({
           {isVideo && (
             <div className="absolute inset-0 flex items-center justify-center">
               <svg
+                aria-hidden="true"
                 className="h-6 w-6 text-white drop-shadow"
                 fill="currentColor"
                 viewBox="0 0 24 24"
@@ -146,6 +147,7 @@ function AttachmentPreviewItem({
         /* File preview */
         <div className="flex h-20 w-20 flex-col items-center justify-center p-2">
           <svg
+            aria-hidden="true"
             className="h-8 w-8 text-neutral-500"
             fill="none"
             viewBox="0 0 24 24"
@@ -169,6 +171,7 @@ function AttachmentPreviewItem({
         <div className="absolute inset-0 flex items-center justify-center bg-black/50">
           <div className="text-center text-white">
             <svg
+              aria-hidden="true"
               className="mx-auto h-6 w-6 animate-spin"
               fill="none"
               viewBox="0 0 24 24"
@@ -197,6 +200,7 @@ function AttachmentPreviewItem({
         <div className="absolute inset-0 flex items-center justify-center bg-black/50">
           <div className="text-center">
             <svg
+              aria-hidden="true"
               className="mx-auto h-6 w-6 text-red-400"
               fill="none"
               viewBox="0 0 24 24"
@@ -237,6 +241,7 @@ function AttachmentPreviewItem({
         aria-label={`Remove ${file.name}`}
       >
         <svg
+          aria-hidden="true"
           className="h-3 w-3"
           fill="none"
           viewBox="0 0 24 24"
@@ -380,6 +385,7 @@ const AttachmentPicker = React.forwardRef<
         >
           {children || (
             <svg
+              aria-hidden="true"
               className="h-5 w-5"
               fill="none"
               viewBox="0 0 24 24"
@@ -520,6 +526,7 @@ function DragDropZone({
         >
           <div className="text-center">
             <svg
+              aria-hidden="true"
               className="text-primary-800 mx-auto h-12 w-12"
               fill="none"
               viewBox="0 0 24 24"
@@ -611,6 +618,7 @@ function CameraButton({
         aria-label="Take a photo"
       >
         <svg
+          aria-hidden="true"
           className="h-5 w-5"
           fill="none"
           viewBox="0 0 24 24"

--- a/src/components/Messaging/ConversationHeader.tsx
+++ b/src/components/Messaging/ConversationHeader.tsx
@@ -186,6 +186,7 @@ const ConversationHeader = React.forwardRef<
               aria-label="Go back"
             >
               <svg
+                aria-hidden="true"
                 className="h-5 w-5"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -427,6 +428,7 @@ const ConversationListItem = React.forwardRef<
       <div className="flex shrink-0 flex-col items-center gap-1">
         {conversation.isPinned && (
           <svg
+            aria-hidden="true"
             className="text-primary-800 h-4 w-4"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -436,6 +438,7 @@ const ConversationListItem = React.forwardRef<
         )}
         {conversation.isMuted && (
           <svg
+            aria-hidden="true"
             className="h-4 w-4 text-neutral-500"
             fill="none"
             viewBox="0 0 24 24"

--- a/src/components/Messaging/MessageBubble.tsx
+++ b/src/components/Messaging/MessageBubble.tsx
@@ -47,6 +47,7 @@ function MessageStatusIcon({ status, className }: MessageStatusIconProps) {
     >
       {status === 'sending' && (
         <svg
+          aria-hidden="true"
           className="h-3.5 w-3.5 animate-spin"
           fill="none"
           viewBox="0 0 24 24"
@@ -68,6 +69,7 @@ function MessageStatusIcon({ status, className }: MessageStatusIconProps) {
       )}
       {status === 'sent' && (
         <svg
+          aria-hidden="true"
           className="h-3.5 w-3.5"
           fill="none"
           viewBox="0 0 24 24"
@@ -83,6 +85,7 @@ function MessageStatusIcon({ status, className }: MessageStatusIconProps) {
       )}
       {(status === 'delivered' || status === 'read') && (
         <svg
+          aria-hidden="true"
           className="h-4 w-4"
           fill="none"
           viewBox="0 0 24 24"
@@ -104,6 +107,7 @@ function MessageStatusIcon({ status, className }: MessageStatusIconProps) {
       )}
       {status === 'failed' && (
         <svg
+          aria-hidden="true"
           className="h-3.5 w-3.5"
           fill="none"
           viewBox="0 0 24 24"
@@ -241,6 +245,7 @@ function AttachmentPreview({
           <div className="absolute inset-0 flex items-center justify-center bg-black/30">
             <div className="rounded-full bg-white/90 p-3">
               <svg
+                aria-hidden="true"
                 className="h-6 w-6 text-neutral-900"
                 fill="currentColor"
                 viewBox="0 0 24 24"
@@ -255,6 +260,7 @@ function AttachmentPreview({
             <div className="absolute inset-0 flex items-center justify-center bg-black/50">
               <div className="text-center text-white">
                 <svg
+                  aria-hidden="true"
                   className="mx-auto h-8 w-8 animate-spin"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -281,6 +287,7 @@ function AttachmentPreview({
           <div className="absolute inset-0 flex items-center justify-center bg-black/50">
             <div className="text-center text-white">
               <svg
+                aria-hidden="true"
                 className="mx-auto h-8 w-8 text-red-400"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -316,6 +323,7 @@ function AttachmentPreview({
     >
       <div className="rounded-lg bg-white/20 p-2">
         <svg
+          aria-hidden="true"
           className="h-6 w-6"
           fill="none"
           viewBox="0 0 24 24"
@@ -624,6 +632,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
                 aria-label="Retry sending message"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-3 w-3"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/components/Messaging/MessageComposer.tsx
+++ b/src/components/Messaging/MessageComposer.tsx
@@ -130,7 +130,12 @@ const SendButton = React.forwardRef<HTMLButtonElement, SendButtonProps>(
         {...props}
       >
         {isLoading ? (
-          <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+          <svg
+            aria-hidden="true"
+            className="h-5 w-5 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
             <circle
               className="opacity-25"
               cx="12"
@@ -147,6 +152,7 @@ const SendButton = React.forwardRef<HTMLButtonElement, SendButtonProps>(
           </svg>
         ) : (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             viewBox="0 0 24 24"
@@ -456,6 +462,7 @@ const MessageComposer = React.forwardRef<
                 aria-label="Cancel reply"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-4 w-4"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/components/Messaging/MessageList.tsx
+++ b/src/components/Messaging/MessageList.tsx
@@ -274,6 +274,7 @@ function EmptyState({
           className="mb-4 rounded-full bg-neutral-100 p-4 dark:bg-neutral-800"
         >
           <svg
+            aria-hidden="true"
             className="h-12 w-12 text-neutral-500"
             fill="none"
             viewBox="0 0 24 24"
@@ -341,6 +342,7 @@ function LoadMoreButton({
         {isLoading ? (
           <span className="flex items-center gap-2">
             <svg
+              aria-hidden="true"
               className="h-4 w-4 animate-spin"
               fill="none"
               viewBox="0 0 24 24"
@@ -628,6 +630,7 @@ const MessageList = React.forwardRef<HTMLDivElement, MessageListProps>(
             aria-label="Scroll to bottom"
           >
             <svg
+              aria-hidden="true"
               className="h-5 w-5 text-neutral-600 dark:text-neutral-300"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/Messaging/MessageThread.tsx
+++ b/src/components/Messaging/MessageThread.tsx
@@ -84,6 +84,7 @@ function LightboxModal({ attachment, onClose }: LightboxModalProps) {
         aria-label="Close"
       >
         <svg
+          aria-hidden="true"
           className="h-6 w-6"
           fill="none"
           viewBox="0 0 24 24"

--- a/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/src/components/NotificationCenter/NotificationCenter.tsx
@@ -81,6 +81,7 @@ export function NotificationCenter({
       case 'order':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -97,6 +98,7 @@ export function NotificationCenter({
       case 'invoice':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -113,6 +115,7 @@ export function NotificationCenter({
       case 'claim':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -129,6 +132,7 @@ export function NotificationCenter({
       case 'message':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -145,6 +149,7 @@ export function NotificationCenter({
       case 'alert':
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -161,6 +166,7 @@ export function NotificationCenter({
       default:
         return (
           <svg
+            aria-hidden="true"
             className="h-5 w-5"
             fill="none"
             stroke="currentColor"
@@ -258,6 +264,7 @@ export function NotificationCenter({
           className="py-12 text-center"
         >
           <svg
+            aria-hidden="true"
             className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
             fill="none"
             stroke="currentColor"

--- a/src/components/OrderCard/OrderCard.tsx
+++ b/src/components/OrderCard/OrderCard.tsx
@@ -248,6 +248,7 @@ export function OrderCard({
         {scheduledDate && (
           <div className="text-muted-foreground mb-3 flex items-center gap-2 text-sm">
             <svg
+              aria-hidden="true"
               className="h-4 w-4"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
+++ b/src/components/OrderConfirmationWizard/OrderConfirmationWizard.tsx
@@ -116,6 +116,7 @@ export function OrderConfirmationWizard({
                   >
                     {isComplete ? (
                       <svg
+                        aria-hidden="true"
                         className="h-5 w-5"
                         fill="none"
                         stroke="currentColor"
@@ -380,6 +381,7 @@ export function OrderConfirmationWizard({
                   >
                     <div className="flex items-center gap-3">
                       <svg
+                        aria-hidden="true"
                         className="h-5 w-5 text-green-600 dark:text-green-400"
                         fill="none"
                         stroke="currentColor"
@@ -410,6 +412,7 @@ export function OrderConfirmationWizard({
                   >
                     <div className="flex items-center gap-3">
                       <svg
+                        aria-hidden="true"
                         className="h-5 w-5 text-green-600 dark:text-green-400"
                         fill="none"
                         stroke="currentColor"
@@ -440,6 +443,7 @@ export function OrderConfirmationWizard({
                   >
                     <div className="flex items-center gap-3">
                       <svg
+                        aria-hidden="true"
                         className="h-5 w-5 text-green-600 dark:text-green-400"
                         fill="none"
                         stroke="currentColor"
@@ -499,6 +503,7 @@ export function OrderConfirmationWizard({
               disabled={isSubmitting}
             >
               <svg
+                aria-hidden="true"
                 className="mr-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -532,6 +537,7 @@ export function OrderConfirmationWizard({
             >
               Continue
               <svg
+                aria-hidden="true"
                 className="ml-1 h-4 w-4"
                 fill="none"
                 stroke="currentColor"
@@ -553,6 +559,7 @@ export function OrderConfirmationWizard({
               {isSubmitting ? (
                 <>
                   <svg
+                    aria-hidden="true"
                     className="mr-2 -ml-1 h-4 w-4 animate-spin"
                     fill="none"
                     viewBox="0 0 24 24"
@@ -577,6 +584,7 @@ export function OrderConfirmationWizard({
                 <>
                   Start Service
                   <svg
+                    aria-hidden="true"
                     className="ml-1 h-4 w-4"
                     fill="none"
                     stroke="currentColor"

--- a/src/components/OrderList/OrderList.tsx
+++ b/src/components/OrderList/OrderList.tsx
@@ -161,6 +161,7 @@ export function OrderList<T>({
             {showSearch && (
               <div className="relative" data-slot="order-list-search">
                 <svg
+                  aria-hidden="true"
                   className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -195,6 +196,7 @@ export function OrderList<T>({
             data-slot="order-list-loading"
           >
             <svg
+              aria-hidden="true"
               className="h-8 w-8 animate-spin text-blue-500"
               fill="none"
               viewBox="0 0 24 24"
@@ -221,6 +223,7 @@ export function OrderList<T>({
           >
             {emptyIcon || (
               <svg
+                aria-hidden="true"
                 className="mb-4 h-12 w-12 text-gray-400"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/components/OrderLookupForm/OrderLookupForm.tsx
+++ b/src/components/OrderLookupForm/OrderLookupForm.tsx
@@ -79,7 +79,12 @@ export function OrderLookupForm({
           />
         ) : (
           <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-white/20">
-            <svg className="h-10 w-10" fill="currentColor" viewBox="0 0 24 24">
+            <svg
+              aria-hidden="true"
+              className="h-10 w-10"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
             </svg>
           </div>
@@ -159,6 +164,7 @@ export function OrderLookupForm({
               {isSubmitting ? (
                 <>
                   <svg
+                    aria-hidden="true"
                     className="mr-2 -ml-1 h-4 w-4 animate-spin"
                     fill="none"
                     viewBox="0 0 24 24"

--- a/src/components/OrderSidebar/OrderSidebar.tsx
+++ b/src/components/OrderSidebar/OrderSidebar.tsx
@@ -137,6 +137,7 @@ export function OrderSidebar({
             aria-label="Close sidebar"
           >
             <svg
+              aria-hidden="true"
               className="text-muted-foreground h-5 w-5"
               fill="none"
               stroke="currentColor"

--- a/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
+++ b/src/components/PaymentHistoryTable/PaymentHistoryTable.tsx
@@ -91,6 +91,7 @@ export function PaymentHistoryTable({
       case 'credit_card':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -107,6 +108,7 @@ export function PaymentHistoryTable({
       case 'ach':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -123,6 +125,7 @@ export function PaymentHistoryTable({
       case 'check':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -139,6 +142,7 @@ export function PaymentHistoryTable({
       default:
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -175,6 +179,7 @@ export function PaymentHistoryTable({
         className={`rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700 ${className}`}
       >
         <svg
+          aria-hidden="true"
           className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
           fill="none"
           stroke="currentColor"

--- a/src/components/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/PaymentMethod/PaymentMethod.tsx
@@ -570,6 +570,7 @@ PaymentMethodList.displayName = 'PaymentMethodList';
 function BankIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -588,6 +589,7 @@ function BankIcon({ className }: { className?: string }) {
 function TrashIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -606,6 +608,7 @@ function TrashIcon({ className }: { className?: string }) {
 function WarningIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/PendingClaimsTable/PendingClaimsTable.tsx
+++ b/src/components/PendingClaimsTable/PendingClaimsTable.tsx
@@ -83,6 +83,7 @@ export function PendingClaimsTable({
         className={`rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700 ${className}`}
       >
         <svg
+          aria-hidden="true"
           className="text-muted-foreground dark:text-muted-foreground mx-auto mb-3 h-12 w-12"
           fill="none"
           stroke="currentColor"

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -298,6 +298,7 @@ function PhoneInputGroup({
                 aria-label="Add phone number"
               >
                 <svg
+                  aria-hidden="true"
                   data-slot="phone-add-icon"
                   className="h-5 w-5"
                   fill="none"
@@ -328,6 +329,7 @@ function PhoneInputGroup({
                 aria-label="Remove phone number"
               >
                 <svg
+                  aria-hidden="true"
                   data-slot="phone-remove-icon"
                   className="h-5 w-5"
                   fill="none"

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -252,6 +252,7 @@ function CircularProgress({
       className={cn(circularProgressVariants({ size }), className)}
     >
       <svg
+        aria-hidden="true"
         className={cn('-rotate-90 transform', indeterminate && 'animate-spin')}
         width={svgSize}
         height={svgSize}

--- a/src/components/ProviderCard/ProviderCard.tsx
+++ b/src/components/ProviderCard/ProviderCard.tsx
@@ -131,6 +131,7 @@ const DistanceBadge: React.FC<{ distance?: number }> = ({ distance }) => {
   return (
     <span className="text-muted-foreground inline-flex items-center gap-1 text-xs">
       <svg
+        aria-hidden="true"
         className="h-3 w-3"
         fill="none"
         viewBox="0 0 24 24"
@@ -159,7 +160,12 @@ const SafeFromWildfiresNotice: React.FC = () => (
       data-slot="provider-card-safe-notice"
       className="inline-flex items-center gap-1.5 rounded-md bg-green-100 px-2 py-1 text-xs text-green-700 dark:bg-green-900/30 dark:text-green-300"
     >
-      <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+      <svg
+        aria-hidden="true"
+        className="h-4 w-4"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
         <path
           fillRule="evenodd"
           d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
@@ -177,7 +183,12 @@ const VerifiedBadge: React.FC = () => (
       data-slot="provider-card-verified"
       className="inline-flex items-center gap-1 text-xs text-green-700 dark:text-green-300"
     >
-      <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20">
+      <svg
+        aria-hidden="true"
+        className="h-3.5 w-3.5"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
         <path
           fillRule="evenodd"
           d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
@@ -518,6 +529,7 @@ export const ProviderCardGrid: React.FC<ProviderCardGridProps> = ({
         {emptyState || (
           <div className="text-muted-foreground">
             <svg
+              aria-hidden="true"
               className="mx-auto mb-4 h-12 w-12 opacity-50"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader/ProviderDetailHeader.tsx
@@ -939,6 +939,7 @@ export function ProviderDetailHeaderSkeleton({
 function DirectionsIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -953,6 +954,7 @@ function DirectionsIcon({ className }: { className?: string }) {
 function PhoneIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -967,6 +969,7 @@ function PhoneIcon({ className }: { className?: string }) {
 function WebsiteIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -981,6 +984,7 @@ function WebsiteIcon({ className }: { className?: string }) {
 function ShareIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -995,6 +999,7 @@ function ShareIcon({ className }: { className?: string }) {
 function CopyIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1009,6 +1014,7 @@ function CopyIcon({ className }: { className?: string }) {
 function ChevronRightIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1023,6 +1029,7 @@ function ChevronRightIcon({ className }: { className?: string }) {
 function ChevronLeftIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1037,6 +1044,7 @@ function ChevronLeftIcon({ className }: { className?: string }) {
 function CheckCircleIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1051,6 +1059,7 @@ function CheckCircleIcon({ className }: { className?: string }) {
 function FlagIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1065,6 +1074,7 @@ function FlagIcon({ className }: { className?: string }) {
 function CalendarCheckIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1079,6 +1089,7 @@ function CalendarCheckIcon({ className }: { className?: string }) {
 function LinkedInIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1093,6 +1104,7 @@ function LinkedInIcon({ className }: { className?: string }) {
 function FacebookIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1107,6 +1119,7 @@ function FacebookIcon({ className }: { className?: string }) {
 function InstagramIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1121,6 +1134,7 @@ function InstagramIcon({ className }: { className?: string }) {
 function TwitterIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1135,6 +1149,7 @@ function TwitterIcon({ className }: { className?: string }) {
 function TikTokIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1149,6 +1164,7 @@ function TikTokIcon({ className }: { className?: string }) {
 function YelpIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1163,6 +1179,7 @@ function YelpIcon({ className }: { className?: string }) {
 function YouTubeIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1177,6 +1194,7 @@ function YouTubeIcon({ className }: { className?: string }) {
 function PinterestIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -1191,6 +1209,7 @@ function PinterestIcon({ className }: { className?: string }) {
 function BlogIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"

--- a/src/components/ProviderOverview/ProviderOverview.tsx
+++ b/src/components/ProviderOverview/ProviderOverview.tsx
@@ -92,6 +92,7 @@ export function ProviderOverview({
       case 'order':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -108,6 +109,7 @@ export function ProviderOverview({
       case 'appointment':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -124,6 +126,7 @@ export function ProviderOverview({
       case 'invoice':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -140,6 +143,7 @@ export function ProviderOverview({
       case 'employer':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -156,6 +160,7 @@ export function ProviderOverview({
       case 'user':
         return (
           <svg
+            aria-hidden="true"
             className="h-4 w-4"
             fill="none"
             stroke="currentColor"
@@ -237,6 +242,7 @@ export function ProviderOverview({
           value={stats.pendingOrders}
           icon={
             <svg
+              aria-hidden="true"
               className="h-5 w-5"
               fill="none"
               stroke="currentColor"
@@ -258,6 +264,7 @@ export function ProviderOverview({
           value={stats.completedToday}
           icon={
             <svg
+              aria-hidden="true"
               className="h-5 w-5"
               fill="none"
               stroke="currentColor"
@@ -279,6 +286,7 @@ export function ProviderOverview({
           value={stats.upcomingAppointments}
           icon={
             <svg
+              aria-hidden="true"
               className="h-5 w-5"
               fill="none"
               stroke="currentColor"
@@ -300,6 +308,7 @@ export function ProviderOverview({
           value={stats.linkedEmployers}
           icon={
             <svg
+              aria-hidden="true"
               className="h-5 w-5"
               fill="none"
               stroke="currentColor"
@@ -339,6 +348,7 @@ export function ProviderOverview({
                     <span className="text-muted-foreground">
                       {action.icon || (
                         <svg
+                          aria-hidden="true"
                           className="h-5 w-5"
                           fill="none"
                           stroke="currentColor"

--- a/src/components/ProviderSearchBar/ProviderSearchBar.tsx
+++ b/src/components/ProviderSearchBar/ProviderSearchBar.tsx
@@ -54,6 +54,7 @@ const searchBarVariants = cva('', {
 
 const CrosshairsIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
+    aria-hidden="true"
     className={className}
     fill="none"
     viewBox="0 0 24 24"
@@ -71,6 +72,7 @@ const CrosshairsIcon: React.FC<{ className?: string }> = ({ className }) => (
 
 const SearchIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
+    aria-hidden="true"
     className={className}
     fill="none"
     viewBox="0 0 24 24"
@@ -87,6 +89,7 @@ const SearchIcon: React.FC<{ className?: string }> = ({ className }) => (
 
 const SpinnerIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
+    aria-hidden="true"
     className={cn('animate-spin', className)}
     fill="none"
     viewBox="0 0 24 24"
@@ -109,6 +112,7 @@ const SpinnerIcon: React.FC<{ className?: string }> = ({ className }) => (
 
 const CheckIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
+    aria-hidden="true"
     className={className}
     fill="none"
     viewBox="0 0 24 24"
@@ -121,6 +125,7 @@ const CheckIcon: React.FC<{ className?: string }> = ({ className }) => (
 
 const WarningIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
+    aria-hidden="true"
     className={className}
     fill="none"
     viewBox="0 0 24 24"

--- a/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
+++ b/src/components/ProviderSearchFilters/ProviderSearchFilters.tsx
@@ -493,6 +493,7 @@ export function ServiceMultiSelect({
                           >
                             {isSelected && (
                               <svg
+                                aria-hidden="true"
                                 className="h-3 w-3"
                                 viewBox="0 0 12 12"
                                 fill="currentColor"
@@ -843,7 +844,11 @@ export function CompactFilterBar({
         >
           {loading ? (
             <span className="flex items-center gap-2">
-              <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24">
+              <svg
+                aria-hidden="true"
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+              >
                 <circle
                   className="opacity-25"
                   cx="12"

--- a/src/components/ProviderSelector/ProviderSelector.tsx
+++ b/src/components/ProviderSelector/ProviderSelector.tsx
@@ -164,6 +164,7 @@ export function ProviderSelector({
         {isLoading ? (
           <div className="flex flex-1 items-center gap-2">
             <svg
+              aria-hidden="true"
               className="text-muted-foreground h-5 w-5 animate-spin"
               fill="none"
               viewBox="0 0 24 24"
@@ -225,6 +226,7 @@ export function ProviderSelector({
 
         {/* Dropdown arrow */}
         <svg
+          aria-hidden="true"
           data-slot="provider-selector-arrow"
           className={cn(
             'text-muted-foreground h-4 w-4 flex-shrink-0 transition-transform',
@@ -254,6 +256,7 @@ export function ProviderSelector({
             <div className="border-border border-b p-2">
               <div className="relative">
                 <svg
+                  aria-hidden="true"
                   className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -356,6 +359,7 @@ export function ProviderSelector({
                   {/* Selected checkmark */}
                   {selectedProvider?.id === provider.id && (
                     <svg
+                      aria-hidden="true"
                       className="text-primary h-5 w-5 flex-shrink-0"
                       fill="none"
                       viewBox="0 0 24 24"

--- a/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/src/components/ProviderSettings/ProviderSettings.tsx
@@ -645,6 +645,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
+                          aria-hidden="true"
                           className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
@@ -672,6 +673,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
+                          aria-hidden="true"
                           className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
@@ -699,6 +701,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
+                          aria-hidden="true"
                           className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"
@@ -726,6 +729,7 @@ export function ProviderSettings({
                     <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-800">
                       <div className="flex items-center gap-3">
                         <svg
+                          aria-hidden="true"
                           className="text-muted-foreground h-8 w-8"
                           fill="none"
                           stroke="currentColor"

--- a/src/components/ProviderUsersTable/ProviderUsersTable.tsx
+++ b/src/components/ProviderUsersTable/ProviderUsersTable.tsx
@@ -173,6 +173,7 @@ export function ProviderUsersTable({
     return (
       <div className={`text-muted-foreground py-12 text-center ${className}`}>
         <svg
+          aria-hidden="true"
           className="mx-auto h-12 w-12 text-gray-400"
           fill="none"
           stroke="currentColor"

--- a/src/components/QuickAction/QuickAction.tsx
+++ b/src/components/QuickAction/QuickAction.tsx
@@ -177,6 +177,7 @@ QuickAction.displayName = 'QuickAction';
 export const QuickActionIcons = {
   Calendar: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -194,6 +195,7 @@ export const QuickActionIcons = {
   ),
   Clipboard: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -211,6 +213,7 @@ export const QuickActionIcons = {
   ),
   User: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -228,6 +231,7 @@ export const QuickActionIcons = {
   ),
   Document: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -245,6 +249,7 @@ export const QuickActionIcons = {
   ),
   Settings: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -268,6 +273,7 @@ export const QuickActionIcons = {
   ),
   Help: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -285,6 +291,7 @@ export const QuickActionIcons = {
   ),
   Search: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"
@@ -302,6 +309,7 @@ export const QuickActionIcons = {
   ),
   Bell: (props: React.SVGProps<globalThis.SVGSVGElement>) => (
     <svg
+      aria-hidden="true"
       className="h-5 w-5"
       fill="none"
       stroke="currentColor"

--- a/src/components/QuickLinksCard/QuickLinksCard.tsx
+++ b/src/components/QuickLinksCard/QuickLinksCard.tsx
@@ -106,6 +106,7 @@ export function QuickLinksCard({
               )}
               {link.badge == null && layout !== 'grid' && (
                 <svg
+                  aria-hidden="true"
                   data-slot="quick-links-chevron"
                   className="text-muted-foreground h-4 w-4"
                   fill="none"

--- a/src/components/RecurringServiceCard/RecurringServiceCard.tsx
+++ b/src/components/RecurringServiceCard/RecurringServiceCard.tsx
@@ -127,6 +127,7 @@ export function RecurringServiceCard({
       icon: (
         <span className="bg-success text-success-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
           <svg
+            aria-hidden="true"
             className="h-3 w-3"
             fill="none"
             viewBox="0 0 24 24"
@@ -148,6 +149,7 @@ export function RecurringServiceCard({
       icon: (
         <span className="bg-primary-800 text-primary-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
           <svg
+            aria-hidden="true"
             className="h-3 w-3"
             fill="none"
             viewBox="0 0 24 24"
@@ -168,7 +170,12 @@ export function RecurringServiceCard({
       border: 'border-warning/30',
       icon: (
         <span className="bg-warning text-warning-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
-          <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+          <svg
+            aria-hidden="true"
+            className="h-3 w-3"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
             <circle cx="12" cy="12" r="10" fill="currentColor" />
             <circle cx="12" cy="12" r="4" className="fill-warning" />
           </svg>
@@ -181,6 +188,7 @@ export function RecurringServiceCard({
       icon: (
         <span className="bg-destructive text-destructive-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full">
           <svg
+            aria-hidden="true"
             className="h-3 w-3"
             fill="none"
             viewBox="0 0 24 24"
@@ -305,6 +313,7 @@ export function RecurringServiceCard({
             className="text-muted-foreground hover:text-destructive relative z-10 mx-auto flex items-center gap-1 text-xs transition-colors"
           >
             <svg
+              aria-hidden="true"
               className="h-3 w-3"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/components/RejectionModal/RejectionModal.tsx
+++ b/src/components/RejectionModal/RejectionModal.tsx
@@ -138,6 +138,7 @@ export function RejectionModal({
               data-slot="rejection-modal-warning"
             >
               <svg
+                aria-hidden="true"
                 className="text-destructive-700 dark:text-destructive-300 mt-0.5 h-5 w-5 flex-shrink-0"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -238,6 +239,7 @@ export function RejectionModal({
             {isSubmitting ? (
               <>
                 <svg
+                  aria-hidden="true"
                   className="mr-2 -ml-1 h-4 w-4 animate-spin"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/components/ReportDashboard/ReportDashboard.tsx
+++ b/src/components/ReportDashboard/ReportDashboard.tsx
@@ -106,6 +106,7 @@ export function ReportDashboard({
     if (trend === 'up') {
       return (
         <svg
+          aria-hidden="true"
           className="h-4 w-4"
           fill="none"
           stroke="currentColor"
@@ -123,6 +124,7 @@ export function ReportDashboard({
     if (trend === 'down') {
       return (
         <svg
+          aria-hidden="true"
           className="h-4 w-4"
           fill="none"
           stroke="currentColor"
@@ -203,6 +205,7 @@ export function ReportDashboard({
           {onExport && (
             <Button variant="outline" onClick={onExport}>
               <svg
+                aria-hidden="true"
                 className="mr-2 h-4 w-4"
                 fill="none"
                 stroke="currentColor"

--- a/src/components/ResultsEntryForm/ResultsEntryForm.tsx
+++ b/src/components/ResultsEntryForm/ResultsEntryForm.tsx
@@ -589,6 +589,7 @@ export function ResultsEntryModal({
           {isSubmitting ? (
             <>
               <svg
+                aria-hidden="true"
                 className="mr-2 -ml-1 h-4 w-4 animate-spin"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/components/ScheduleCalendar/ScheduleCalendar.tsx
+++ b/src/components/ScheduleCalendar/ScheduleCalendar.tsx
@@ -198,6 +198,7 @@ export function ScheduleCalendar({
             aria-label="Previous"
           >
             <svg
+              aria-hidden="true"
               className="h-4 w-4"
               fill="none"
               stroke="currentColor"
@@ -218,6 +219,7 @@ export function ScheduleCalendar({
             aria-label="Next"
           >
             <svg
+              aria-hidden="true"
               className="h-4 w-4"
               fill="none"
               stroke="currentColor"

--- a/src/components/ServiceBadge/ServiceBadge.tsx
+++ b/src/components/ServiceBadge/ServiceBadge.tsx
@@ -474,6 +474,7 @@ export function DOTBadge({
 function CloseIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -494,6 +495,7 @@ function CloseIcon({ className }: { className?: string }) {
 function TestTubeIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -508,6 +510,7 @@ function TestTubeIcon({ className }: { className?: string }) {
 function MedicalIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -522,6 +525,7 @@ function MedicalIcon({ className }: { className?: string }) {
 function BriefcaseIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -536,6 +540,7 @@ function BriefcaseIcon({ className }: { className?: string }) {
 function HeartIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -550,6 +555,7 @@ function HeartIcon({ className }: { className?: string }) {
 function LabIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -564,6 +570,7 @@ function LabIcon({ className }: { className?: string }) {
 function TagIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
@@ -578,6 +585,7 @@ function TagIcon({ className }: { className?: string }) {
 function DOTIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"

--- a/src/components/ServiceGrid/ServiceGrid.tsx
+++ b/src/components/ServiceGrid/ServiceGrid.tsx
@@ -105,6 +105,7 @@ export function ServiceGrid({
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <svg
+          aria-hidden="true"
           className="text-muted-foreground mb-4 h-12 w-12"
           fill="none"
           viewBox="0 0 24 24"

--- a/src/components/ServicePicker/ServicePicker.tsx
+++ b/src/components/ServicePicker/ServicePicker.tsx
@@ -557,6 +557,7 @@ function ServiceItem({
 function CheckIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -571,6 +572,7 @@ function CheckIcon({ className }: { className?: string }) {
 function SearchIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -588,7 +590,12 @@ function SearchIcon({ className }: { className?: string }) {
 
 function SpinnerIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} fill="none" viewBox="0 0 24 24">
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+    >
       <circle
         className="opacity-25"
         cx="12"
@@ -609,6 +616,7 @@ function SpinnerIcon({ className }: { className?: string }) {
 function ChevronIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/SetupServiceModal/SetupServiceModal.tsx
+++ b/src/components/SetupServiceModal/SetupServiceModal.tsx
@@ -345,6 +345,7 @@ export function SetupServiceModal({
             {isSubmitting ? (
               <>
                 <svg
+                  aria-hidden="true"
                   className="mr-2 -ml-1 h-4 w-4 animate-spin"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import { useSidebar } from './SidebarProvider';
 
 const ChevronLeftIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"
@@ -26,6 +27,7 @@ const ChevronLeftIcon = () => (
 
 const ChevronRightIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"
@@ -38,6 +40,7 @@ const ChevronRightIcon = () => (
 
 const ChevronDownIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-3 w-3"
     fill="none"
     viewBox="0 0 24 24"
@@ -50,6 +53,7 @@ const ChevronDownIcon = () => (
 
 const XIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -66,6 +70,7 @@ const XIcon = () => (
 
 const MenuIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -82,6 +87,7 @@ const MenuIcon = () => (
 
 const SearchIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -37,6 +37,7 @@ export interface SocialLink {
 function InstagramIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -51,6 +52,7 @@ function InstagramIcon({ className }: { className?: string }) {
 function LinkedInIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -65,6 +67,7 @@ function LinkedInIcon({ className }: { className?: string }) {
 function TwitterIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -79,6 +82,7 @@ function TwitterIcon({ className }: { className?: string }) {
 function FacebookIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -93,6 +97,7 @@ function FacebookIcon({ className }: { className?: string }) {
 function YouTubeIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -107,6 +112,7 @@ function YouTubeIcon({ className }: { className?: string }) {
 function TikTokIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -121,6 +127,7 @@ function TikTokIcon({ className }: { className?: string }) {
 function GitHubIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
@@ -760,6 +767,7 @@ export function SimpleFooter({
 function ExternalLinkIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -838,6 +838,7 @@ export function CompactHeader({
 function MenuIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -858,6 +859,7 @@ function MenuIcon({ className }: { className?: string }) {
 function CloseIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -878,6 +880,7 @@ function CloseIcon({ className }: { className?: string }) {
 function ChevronDownIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -898,6 +901,7 @@ function ChevronDownIcon({ className }: { className?: string }) {
 function ChevronLeftIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -918,6 +922,7 @@ function ChevronLeftIcon({ className }: { className?: string }) {
 function ExternalLinkIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -938,6 +943,7 @@ function ExternalLinkIcon({ className }: { className?: string }) {
 function UserIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -958,6 +964,7 @@ function UserIcon({ className }: { className?: string }) {
 function SettingsIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"
@@ -984,6 +991,7 @@ function SettingsIcon({ className }: { className?: string }) {
 function LogoutIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       stroke="currentColor"

--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -37,6 +37,7 @@ export interface StepIndicatorProps {
 function CheckIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -55,6 +56,7 @@ function CheckIcon({ className }: { className?: string }) {
 function ErrorIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/StripeBadge/StripeBadge.tsx
+++ b/src/components/StripeBadge/StripeBadge.tsx
@@ -25,6 +25,7 @@ export interface StripeBadgeProps {
 function StripeLogo({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
+      aria-hidden="true"
       viewBox="0 0 60 25"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
@@ -186,6 +187,7 @@ export function StripeSecureBadge({
       aria-label="Secure payments powered by Stripe"
     >
       <svg
+        aria-hidden="true"
         className={cn(
           sizeClasses[size].icon,
           'text-green-600 dark:text-green-500'

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -575,6 +575,7 @@ OrderConfirmation.displayName = 'OrderConfirmation';
 function CheckIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -593,6 +594,7 @@ function CheckIcon({ className }: { className?: string }) {
 function XIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -611,6 +613,7 @@ function XIcon({ className }: { className?: string }) {
 function MessageIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -629,6 +632,7 @@ function MessageIcon({ className }: { className?: string }) {
 function StatusIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -647,6 +651,7 @@ function StatusIcon({ className }: { className?: string }) {
 function AttachmentIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -665,6 +670,7 @@ function AttachmentIcon({ className }: { className?: string }) {
 function UserIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -683,6 +689,7 @@ function UserIcon({ className }: { className?: string }) {
 function NoteIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"
@@ -701,6 +708,7 @@ function NoteIcon({ className }: { className?: string }) {
 function PlaneIcon({ className }: { className?: string }) {
   return (
     <svg
+      aria-hidden="true"
       className={className}
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -8,6 +8,7 @@ import type { ToastData, ToastVariant, ToastPosition } from './ToastProvider';
 
 const CheckIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -20,6 +21,7 @@ const CheckIcon = () => (
 
 const XCircleIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -36,6 +38,7 @@ const XCircleIcon = () => (
 
 const ExclamationIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -52,6 +55,7 @@ const ExclamationIcon = () => (
 
 const InfoIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-5 w-5"
     fill="none"
     viewBox="0 0 24 24"
@@ -68,6 +72,7 @@ const InfoIcon = () => (
 
 const XIcon = () => (
   <svg
+    aria-hidden="true"
     className="h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"

--- a/src/components/WebsiteInput/WebsiteInput.tsx
+++ b/src/components/WebsiteInput/WebsiteInput.tsx
@@ -331,6 +331,7 @@ function WebsiteInputGroup({
                 aria-label="Add website"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-5 w-5"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -359,6 +360,7 @@ function WebsiteInputGroup({
                 aria-label="Remove website"
               >
                 <svg
+                  aria-hidden="true"
                   className="h-5 w-5"
                   fill="none"
                   viewBox="0 0 24 24"


### PR DESCRIPTION
Bulk-added aria-hidden to ~360 inline SVGs across 77 component files. These are all decorative icons rendered alongside text labels — screen readers should skip them.

Fixes svg-img-alt violations in ~40+ stories.