### PR TITLE
a11y: fix edge-case contrast, opacity, and accessible name issues

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -527,8 +527,8 @@ const CardStat = React.forwardRef<HTMLDivElement, CardStatProps>(
               className={cn(
                 'mt-1 flex items-center gap-1 text-sm',
                 trend.value >= 0
-                  ? 'text-success-700 dark:text-success'
-                  : 'text-destructive-700 dark:text-destructive'
+                  ? 'text-success-700 dark:text-success-300'
+                  : 'text-destructive-700 dark:text-destructive-400'
               )}
             >
               <svg

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -526,7 +526,7 @@ const CardStat = React.forwardRef<HTMLDivElement, CardStatProps>(
             <div
               className={cn(
                 'mt-1 flex items-center gap-1 text-sm',
-                trend.value >= 0 ? 'text-success' : 'text-destructive'
+                trend.value >= 0 ? 'text-success-700 dark:text-success' : 'text-destructive-700 dark:text-destructive'
               )}
             >
               <svg

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -526,7 +526,9 @@ const CardStat = React.forwardRef<HTMLDivElement, CardStatProps>(
             <div
               className={cn(
                 'mt-1 flex items-center gap-1 text-sm',
-                trend.value >= 0 ? 'text-success-700 dark:text-success' : 'text-destructive-700 dark:text-destructive'
+                trend.value >= 0
+                  ? 'text-success-700 dark:text-success'
+                  : 'text-destructive-700 dark:text-destructive'
               )}
             >
               <svg

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -173,7 +173,7 @@ export function ErrorPage({
       {/* Error Code */}
       {displayCode && (
         <div
-          className="dark:text-muted-foreground mb-4 text-6xl font-bold text-gray-300 sm:text-8xl"
+          className="text-muted-foreground mb-4 text-6xl font-bold sm:text-8xl"
           data-slot="error-page-code"
         >
           {displayCode}
@@ -492,7 +492,7 @@ interface DefaultIllustrationProps {
 }
 
 function DefaultIllustration({ type }: DefaultIllustrationProps) {
-  const iconClasses = 'h-24 w-24 text-gray-300 dark:text-muted-foreground';
+  const iconClasses = 'h-24 w-24 text-muted-foreground';
 
   switch (type) {
     case '404':

--- a/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/src/components/NotificationCenter/NotificationCenter.tsx
@@ -290,7 +290,7 @@ export function NotificationCenter({
               role="button"
               tabIndex={0}
               data-slot="notification-center-item"
-              className={`cursor-pointer px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 ${
+              className={`group cursor-pointer px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 ${
                 !notification.isRead ? 'bg-blue-50/50 dark:bg-blue-900/10' : ''
               }`}
               onClick={() => {
@@ -392,7 +392,7 @@ export function NotificationCenter({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-auto p-1 text-xs opacity-0 group-hover:opacity-100"
+                          className="h-auto p-1 text-xs opacity-0 group-hover:opacity-100 focus:opacity-100"
                           aria-label="Dismiss notification"
                           onClick={(e) => {
                             e.stopPropagation();

--- a/src/components/ProductVersion/ProductVersion.tsx
+++ b/src/components/ProductVersion/ProductVersion.tsx
@@ -130,9 +130,7 @@ export function ProductVersion({
             )}
           </div>
           {build && (
-            <span className="text-muted-foreground">
-              Build: {build}
-            </span>
+            <span className="text-muted-foreground">Build: {build}</span>
           )}
           {(author || copyright) && (
             <span className="text-muted-foreground">{copyrightText}</span>
@@ -149,9 +147,7 @@ export function ProductVersion({
       >
         <span className="font-medium">{name}</span>
         <span className="text-muted-foreground">{versionDisplay}</span>
-        {build && (
-          <span className="text-muted-foreground">({build})</span>
-        )}
+        {build && <span className="text-muted-foreground">({build})</span>}
         {environment && (
           <span
             className={cn(

--- a/src/components/ProductVersion/ProductVersion.tsx
+++ b/src/components/ProductVersion/ProductVersion.tsx
@@ -130,7 +130,7 @@ export function ProductVersion({
             )}
           </div>
           {build && (
-            <span className="text-muted-foreground opacity-60">
+            <span className="text-muted-foreground">
               Build: {build}
             </span>
           )}
@@ -150,7 +150,7 @@ export function ProductVersion({
         <span className="font-medium">{name}</span>
         <span className="text-muted-foreground">{versionDisplay}</span>
         {build && (
-          <span className="text-muted-foreground opacity-60">({build})</span>
+          <span className="text-muted-foreground">({build})</span>
         )}
         {environment && (
           <span
@@ -165,7 +165,7 @@ export function ProductVersion({
         )}
         {(author || copyright) && (
           <>
-            <span className="text-muted-foreground/50">•</span>
+            <span className="text-muted-foreground">•</span>
             <span className="text-muted-foreground">{copyrightText}</span>
           </>
         )}

--- a/src/components/ProductVersion/ProductVersion.tsx
+++ b/src/components/ProductVersion/ProductVersion.tsx
@@ -103,7 +103,7 @@ export function ProductVersion({
           data-slot="product-version-minimal"
         >
           {name} {versionDisplay}
-          {build && <span className="ml-1 opacity-60">({build})</span>}
+          {build && <span className="ml-1">({build})</span>}
         </span>
       );
     }

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -84,7 +84,9 @@ export const DisabledChecked: Story = {
 };
 
 export const NoLabel: Story = {
-  args: {},
+  args: {
+    'aria-label': 'Toggle setting',
+  },
 };
 
 function ControlledSwitchDemo() {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -73,6 +73,7 @@ export const miewebUISafelist = [
   'border-success',
   'focus:ring-success/20',
   'focus:ring-destructive/20',
+  'focus:opacity-100',
   // Opacity-modifier variants for semantic colors used by components
   'bg-background/60',
   'bg-background/80',

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -73,6 +73,8 @@ export const miewebUISafelist = [
   'border-success',
   'focus:ring-success/20',
   'focus:ring-destructive/20',
+  'opacity-0',
+  'group-hover:opacity-100',
   'focus:opacity-100',
   // Opacity-modifier variants for semantic colors used by components
   'bg-background/60',


### PR DESCRIPTION
- ErrorPage: text-gray-300 → text-muted-foreground for error codes/icons
- Card: text-destructive → text-destructive-700 for stat trend (4.5:1+)
- ProductVersion: remove opacity-60 and /50 modifiers on muted text
- NotificationCenter: add group class + focus:opacity-100 on dismiss btn
- Switch: add aria-label to No Label story

Fixes remaining ~15 a11y violations.