### PR TITLE
a11y: disable heading-order rule in Storybook a11y config

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -256,6 +256,10 @@ const preview: Preview = {
           { id: 'landmark-one-main', enabled: false },
           { id: 'page-has-heading-one', enabled: false },
           { id: 'region', enabled: false },
+          // Components use <h3> (Card titles) correctly in context, but stories
+          // render in isolation without parent <h1>/<h2> elements, causing false
+          // positives. Host apps provide proper heading hierarchy.
+          { id: 'heading-order', enabled: false },
         ],
       },
     },


### PR DESCRIPTION
Components (e.g. Card) correctly use <h3> for their titles, but Storybook renders stories in isolation without parent <h1>/<h2> elements, causing ~40 false positive heading-order violations.

Host applications provide proper heading hierarchy, so this rule is not meaningful in the Storybook testing context — same rationale as the existing landmark-one-main and region disables.