### PR TITLE
feat(DateRangePicker): add yesterday/quarter/year presets, expose helpers

### DIFF
--- a/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  calculateDateRange,
+  getDefaultPresets,
+  getExtendedPresets,
+} from './DateRangePicker';
+
+// Pin "now" to Wed May 14, 2025 14:30:00 local time so calendar math is stable.
+const FROZEN_NOW = new Date(2025, 4, 14, 14, 30, 0, 0);
+
+describe('calculateDateRange', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null range for unknown preset key', () => {
+    expect(calculateDateRange('not-a-real-key')).toEqual({
+      start: null,
+      end: null,
+    });
+  });
+
+  it('today spans the current calendar day', () => {
+    const r = calculateDateRange('today');
+    expect(r.start).toEqual(new Date(2025, 4, 14, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 4, 14, 23, 59, 59, 999));
+  });
+
+  it('yesterday spans the previous calendar day', () => {
+    const r = calculateDateRange('yesterday');
+    expect(r.start).toEqual(new Date(2025, 4, 13, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 4, 13, 23, 59, 59, 999));
+  });
+
+  it('this-week starts on Sunday and ends Saturday end-of-day', () => {
+    const r = calculateDateRange('this-week');
+    expect(r.start).toEqual(new Date(2025, 4, 11, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 4, 17, 23, 59, 59, 999));
+  });
+
+  it('last-week is the prior Sunday-Saturday window', () => {
+    const r = calculateDateRange('last-week');
+    expect(r.start).toEqual(new Date(2025, 4, 4, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 4, 10, 23, 59, 59, 999));
+  });
+
+  it('this-month spans the first to last day of the current month', () => {
+    const r = calculateDateRange('this-month');
+    expect(r.start).toEqual(new Date(2025, 4, 1, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 4, 31, 23, 59, 59, 999));
+  });
+
+  it('last-month spans the prior month', () => {
+    const r = calculateDateRange('last-month');
+    expect(r.start).toEqual(new Date(2025, 3, 1, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 3, 30, 23, 59, 59, 999));
+  });
+
+  it('this-quarter covers Q2 (Apr-Jun) when now is in May', () => {
+    const r = calculateDateRange('this-quarter');
+    expect(r.start).toEqual(new Date(2025, 3, 1, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 5, 30, 23, 59, 59, 999));
+  });
+
+  it('last-quarter covers Q1 (Jan-Mar) when now is in May', () => {
+    const r = calculateDateRange('last-quarter');
+    expect(r.start).toEqual(new Date(2025, 0, 1, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2025, 2, 31, 23, 59, 59, 999));
+  });
+
+  it('last-quarter rolls back across year boundary in Q1', () => {
+    vi.setSystemTime(new Date(2025, 1, 15, 10, 0, 0, 0));
+    const r = calculateDateRange('last-quarter');
+    expect(r.start).toEqual(new Date(2024, 9, 1, 0, 0, 0, 0));
+    expect(r.end).toEqual(new Date(2024, 11, 31, 23, 59, 59, 999));
+  });
+
+  it('this-year and last-year span full calendar years', () => {
+    expect(calculateDateRange('this-year').start).toEqual(
+      new Date(2025, 0, 1, 0, 0, 0, 0)
+    );
+    expect(calculateDateRange('this-year').end).toEqual(
+      new Date(2025, 11, 31, 23, 59, 59, 999)
+    );
+    expect(calculateDateRange('last-year').start).toEqual(
+      new Date(2024, 0, 1, 0, 0, 0, 0)
+    );
+    expect(calculateDateRange('last-year').end).toEqual(
+      new Date(2024, 11, 31, 23, 59, 59, 999)
+    );
+  });
+
+  it('rolling-window keys are trailing from now', () => {
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    const cases: Array<[string, number]> = [
+      ['last-24-hours', 1],
+      ['last-7-days', 7],
+      ['last-30-days', 30],
+      ['last-90-days', 90],
+      ['last-365-days', 365],
+    ];
+    for (const [key, days] of cases) {
+      const r = calculateDateRange(key);
+      expect(r.end).toEqual(FROZEN_NOW);
+      expect(r.start).toEqual(new Date(FROZEN_NOW.getTime() - days * oneDayMs));
+    }
+  });
+});
+
+describe('preset list helpers', () => {
+  it('getDefaultPresets is stable and excludes extended keys', () => {
+    const keys = getDefaultPresets().map((p) => p.key);
+    expect(keys).toEqual([
+      'today',
+      'this-week',
+      'this-month',
+      'last-month',
+      'last-24-hours',
+      'last-7-days',
+      'last-30-days',
+    ]);
+  });
+
+  it('getExtendedPresets includes the new keys', () => {
+    const keys = new Set(getExtendedPresets().map((p) => p.key));
+    for (const k of [
+      'yesterday',
+      'last-week',
+      'this-quarter',
+      'last-quarter',
+      'this-year',
+      'last-year',
+      'last-90-days',
+      'last-365-days',
+    ]) {
+      expect(keys.has(k)).toBe(true);
+    }
+  });
+
+  it('respects custom labels', () => {
+    const list = getExtendedPresets({ yesterday: 'Ayer' });
+    const yesterday = list.find((p) => p.key === 'yesterday');
+    expect(yesterday?.label).toBe('Ayer');
+  });
+});

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -159,15 +159,7 @@ export function getExtendedPresets(
 
 /** Last millisecond of the given calendar day (local time). */
 function endOfDay(d: Date): Date {
-  return new Date(
-    d.getFullYear(),
-    d.getMonth(),
-    d.getDate(),
-    23,
-    59,
-    59,
-    999
-  );
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
 }
 
 /**

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -14,12 +14,20 @@ import { Calendar, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 
 export type DateRangePresetKey =
   | 'today'
+  | 'yesterday'
   | 'this-week'
+  | 'last-week'
   | 'this-month'
   | 'last-month'
+  | 'this-quarter'
+  | 'last-quarter'
+  | 'this-year'
+  | 'last-year'
   | 'last-24-hours'
   | 'last-7-days'
-  | 'last-30-days';
+  | 'last-30-days'
+  | 'last-90-days'
+  | 'last-365-days';
 
 export interface DateRangePreset {
   key: DateRangePresetKey | string;
@@ -51,12 +59,20 @@ export interface DateRangePickerProps {
   /** Labels for i18n */
   labels?: {
     today?: string;
+    yesterday?: string;
     thisWeek?: string;
+    lastWeek?: string;
     thisMonth?: string;
     lastMonth?: string;
+    thisQuarter?: string;
+    lastQuarter?: string;
+    thisYear?: string;
+    lastYear?: string;
     last24Hours?: string;
     last7Days?: string;
     last30Days?: string;
+    last90Days?: string;
+    last365Days?: string;
     filter?: string;
     done?: string;
   };
@@ -66,7 +82,13 @@ export interface DateRangePickerProps {
 // Helper Functions
 // ============================================================================
 
-function getDefaultPresets(
+/**
+ * Returns the default set of presets shown in the picker. Stable across
+ * releases — adding a new preset key to the {@link DateRangePresetKey} union
+ * does NOT add it to this default list. Use {@link getExtendedPresets} or
+ * compose your own list to surface additional ranges.
+ */
+export function getDefaultPresets(
   labels: DateRangePickerProps['labels'] = {}
 ): DateRangePreset[] {
   const {
@@ -90,16 +112,84 @@ function getDefaultPresets(
   ];
 }
 
-function calculateDateRange(presetKey: string): DateRange {
+/**
+ * Returns an extended set of presets including yesterday, last week, quarters,
+ * years, and longer trailing windows. Suitable for analytics dashboards that
+ * need deeper historical drill-down.
+ */
+export function getExtendedPresets(
+  labels: DateRangePickerProps['labels'] = {}
+): DateRangePreset[] {
+  const {
+    today = 'Today',
+    yesterday = 'Yesterday',
+    thisWeek = 'This Week',
+    lastWeek = 'Last Week',
+    thisMonth = 'This Month',
+    lastMonth = 'Last Month',
+    thisQuarter = 'This Quarter',
+    lastQuarter = 'Last Quarter',
+    thisYear = 'This Year',
+    lastYear = 'Last Year',
+    last24Hours = 'Last 24 Hours',
+    last7Days = 'Last 7 Days',
+    last30Days = 'Last 30 Days',
+    last90Days = 'Last 90 Days',
+    last365Days = 'Last 365 Days',
+  } = labels;
+
+  return [
+    { key: 'today', label: today },
+    { key: 'yesterday', label: yesterday },
+    { key: 'last-24-hours', label: last24Hours },
+    { key: 'this-week', label: thisWeek },
+    { key: 'last-week', label: lastWeek },
+    { key: 'last-7-days', label: last7Days },
+    { key: 'this-month', label: thisMonth },
+    { key: 'last-month', label: lastMonth },
+    { key: 'last-30-days', label: last30Days },
+    { key: 'this-quarter', label: thisQuarter },
+    { key: 'last-quarter', label: lastQuarter },
+    { key: 'last-90-days', label: last90Days },
+    { key: 'this-year', label: thisYear },
+    { key: 'last-year', label: lastYear },
+    { key: 'last-365-days', label: last365Days },
+  ];
+}
+
+/** Last millisecond of the given calendar day (local time). */
+function endOfDay(d: Date): Date {
+  return new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+}
+
+/**
+ * Resolve a preset key into a concrete {@link DateRange}. Exported so consumers
+ * can build their own preset menus, recompute on demand (e.g. when "today"
+ * rolls over), or implement custom keys by composing with their own switch.
+ *
+ * Unknown keys return `{ start: null, end: null }`.
+ */
+export function calculateDateRange(presetKey: string): DateRange {
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
   switch (presetKey) {
     case 'today':
-      return {
-        start: today,
-        end: new Date(today.getTime() + 24 * 60 * 60 * 1000 - 1),
-      };
+      return { start: today, end: endOfDay(today) };
+
+    case 'yesterday': {
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      return { start: yesterday, end: endOfDay(yesterday) };
+    }
 
     case 'this-week': {
       const dayOfWeek = today.getDay();
@@ -107,19 +197,54 @@ function calculateDateRange(presetKey: string): DateRange {
       sunday.setDate(today.getDate() - dayOfWeek);
       const saturday = new Date(sunday);
       saturday.setDate(sunday.getDate() + 6);
-      return { start: sunday, end: saturday };
+      return { start: sunday, end: endOfDay(saturday) };
+    }
+
+    case 'last-week': {
+      const dayOfWeek = today.getDay();
+      const lastSunday = new Date(today);
+      lastSunday.setDate(today.getDate() - dayOfWeek - 7);
+      const lastSaturday = new Date(lastSunday);
+      lastSaturday.setDate(lastSunday.getDate() + 6);
+      return { start: lastSunday, end: endOfDay(lastSaturday) };
     }
 
     case 'this-month': {
       const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
       const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-      return { start: firstDay, end: lastDay };
+      return { start: firstDay, end: endOfDay(lastDay) };
     }
 
     case 'last-month': {
       const firstDay = new Date(now.getFullYear(), now.getMonth() - 1, 1);
       const lastDay = new Date(now.getFullYear(), now.getMonth(), 0);
-      return { start: firstDay, end: lastDay };
+      return { start: firstDay, end: endOfDay(lastDay) };
+    }
+
+    case 'this-quarter': {
+      const quarter = Math.floor(now.getMonth() / 3);
+      const firstDay = new Date(now.getFullYear(), quarter * 3, 1);
+      const lastDay = new Date(now.getFullYear(), quarter * 3 + 3, 0);
+      return { start: firstDay, end: endOfDay(lastDay) };
+    }
+
+    case 'last-quarter': {
+      const quarter = Math.floor(now.getMonth() / 3);
+      const firstDay = new Date(now.getFullYear(), (quarter - 1) * 3, 1);
+      const lastDay = new Date(now.getFullYear(), quarter * 3, 0);
+      return { start: firstDay, end: endOfDay(lastDay) };
+    }
+
+    case 'this-year': {
+      const firstDay = new Date(now.getFullYear(), 0, 1);
+      const lastDay = new Date(now.getFullYear(), 11, 31);
+      return { start: firstDay, end: endOfDay(lastDay) };
+    }
+
+    case 'last-year': {
+      const firstDay = new Date(now.getFullYear() - 1, 0, 1);
+      const lastDay = new Date(now.getFullYear() - 1, 11, 31);
+      return { start: firstDay, end: endOfDay(lastDay) };
     }
 
     case 'last-24-hours':
@@ -137,6 +262,18 @@ function calculateDateRange(presetKey: string): DateRange {
     case 'last-30-days':
       return {
         start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+        end: now,
+      };
+
+    case 'last-90-days':
+      return {
+        start: new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000),
+        end: now,
+      };
+
+    case 'last-365-days':
+      return {
+        start: new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000),
         end: now,
       };
 

--- a/src/components/DateRangePicker/index.ts
+++ b/src/components/DateRangePicker/index.ts
@@ -1,6 +1,9 @@
 export {
   DateRangePicker,
   DateRangeFilter,
+  calculateDateRange,
+  getDefaultPresets,
+  getExtendedPresets,
   type DateRangePickerProps,
   type DateRangeFilterProps,
   type DateRange,


### PR DESCRIPTION
## Summary

Extends `DateRangePicker` / `DateRangeFilter` with longer drill-down presets and exposes the range-math helpers so consumers can build their own preset menus on top of the same logic.

While integrating the date picker into an analytics dashboard, I found I couldn't render presets like "Yesterday" or "This Quarter" without re-implementing the date math, because `calculateDateRange` was a private function — any preset key not in its built-in `switch` returned `{ start: null, end: null }`. This PR makes the helpers public and adds the obvious missing keys.

## Screenshots
<img width="1063" height="808" alt="Screenshot 2026-05-14 at 2 17 18 PM" src="https://github.com/user-attachments/assets/cded3a30-7088-4104-af68-9e1d11312be2" />
<img width="1067" height="816" alt="Screenshot 2026-05-14 at 2 16 44 PM" src="https://github.com/user-attachments/assets/ec70c6f6-2655-4d65-828b-935afeb2589a" />



## New preset keys

Added to the `DateRangePresetKey` union and implemented in `calculateDateRange`:

- `yesterday`
- `last-week`
- `this-quarter`
- `last-quarter`
- `this-year`
- `last-year`
- `last-90-days`
- `last-365-days`

All bounded-day presets (`today`, `yesterday`, `this-week`, `last-week`, `this-month`, `last-month`, the quarter/year keys) now end at `23:59:59.999` of the last day. Previously some used midnight, which excluded same-day events. The trailing-window keys (`last-N-days`, `last-24-hours`) continue to end at `now`.

## New exports

```ts
import {
  calculateDateRange,    // (key: string) => DateRange
  getDefaultPresets,     // unchanged default list
  getExtendedPresets,    // full list incl. yesterday/quarter/year/etc.
} from '@mieweb/ui';
```

This unlocks usage like:

```tsx
<DateRangePicker
  presets={getExtendedPresets()}
  value={range}
  activePreset={presetKey}
  onChange={(r, key) => {
    setRange(r);
    setPresetKey(key);
  }}
/>
```

Or for custom UIs that just need the math:

```ts
const range = calculateDateRange('this-quarter');
```

## Backward compatibility

- The default preset list returned by `DateRangePicker` / `DateRangeFilter` when no `presets` prop is passed is **unchanged**. Existing consumers see no visual or behavioral diff.
- All previously supported keys still resolve to the same ranges, with the only difference being that "this/last-month" and friends now extend through end-of-day (a strict improvement for inclusive range queries).
- New `labels?: { yesterday, lastWeek, thisQuarter, ... }` keys are all optional with English defaults.

## Tests

Added `DateRangePicker.test.tsx` with 15 unit tests using `vi.useFakeTimers()` to pin "now" to a stable date. Covers every preset key, including the Q1-rolls-back-across-year-boundary edge case for `last-quarter`.

```
✓ src/components/DateRangePicker/DateRangePicker.test.tsx (15 tests)
Test Files  1 passed (1)
     Tests  15 passed (15)
```

## Checks

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test src/components/DateRangePicker` — 15/15 pass
