### PR TITLE
fix(ci): resolve lint and format failures blocking release

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,6 +79,7 @@ export default [
         ArrayBuffer: 'readonly',
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
+        queueMicrotask: 'readonly',
         getComputedStyle: 'readonly',
         // File APIs
         File: 'readonly',

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -227,13 +227,7 @@ export function CommandPalette({
       : [];
 
     return [...pinned, ...filteredItems, ...recents];
-  }, [
-    pinnedItems,
-    recentItems,
-    filteredItems,
-    activeCategory,
-    query,
-  ]);
+  }, [pinnedItems, recentItems, filteredItems, activeCategory, query]);
 
   // Group items by category
   const groupedItems = useMemo(() => {

--- a/src/components/Messaging/MessageBubble.tsx
+++ b/src/components/Messaging/MessageBubble.tsx
@@ -533,7 +533,7 @@ const MessageBubble = React.forwardRef<HTMLDivElement, MessageBubbleProps>(
          */}
         <div
           className={cn(
-            'flex flex-1 flex-col min-w-0',
+            'flex min-w-0 flex-1 flex-col',
             isOutgoing ? 'items-end' : 'items-start'
           )}
         >


### PR DESCRIPTION
queueMicrotask is a standard Web/Node API (available since Node 11 and all modern browsers) but was missing from the ESLint globals config, causing a no-undef error in CommandPalette.test.tsx.

This was blocking CI lint and preventing the Release workflow from publishing new npm versions since the CommandPalette PR was merged.