### PR TITLE
fix(release): add eSheet submodule build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build eSheet submodule
+        run: cd packages/esheet && npm ci && npx nx run-many --target=build --projects=@esheet/core,@esheet/fields,@esheet/adapters,@esheet/builder,@esheet/renderer --parallel
+
       - name: Lint
         run: pnpm lint
 


### PR DESCRIPTION
The release workflow was missing the 'Build eSheet submodule' step that CI already has. Without it, tsup fails to resolve @esheet/core, @esheet/builder, and @esheet/renderer imports during the build, blocking all npm publishes since the eSheet submodule was added in PR #227 (May 11).