### PR TITLE
docs(Table): direct users to DataVis NITRO for most table use cases

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -33,6 +33,12 @@ const meta: Meta<typeof Table> = {
   component: Table,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '> 💡 **Prefer [DataVis NITRO](?path=/docs/components-text-data-display-datavis-nitro--docs) in most cases.** NITRO is designed to be simple out of the box while exposing power-user features for the click-curious — use `Table` only in lightweight situations where that overhead is genuinely unneeded.',
+      },
+    },
   },
   tags: ['autodocs'],
   argTypes: {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -13,8 +13,9 @@ export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> 
 /**
  * An accessible table component.
  *
- * Prefer {@link ?path=/docs/components-text-data-display-datavis-nitro--docs DataVis NITRO} in most cases — it is simple out of the box
- * while exposing power-user features for click-curious users. Use `Table` only in lightweight situations where that overhead is genuinely unneeded.
+ * Prefer DataVis NITRO in most cases -- it is designed to be simple out of the box while
+ * exposing power-user features for click-curious users. Use `Table` only in lightweight
+ * situations where that overhead is genuinely unneeded.
  *
  * @example
  * ```tsx

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -13,6 +13,9 @@ export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> 
 /**
  * An accessible table component.
  *
+ * Prefer {@link ?path=/docs/components-text-data-display-datavis-nitro--docs DataVis NITRO} in most cases — it is simple out of the box
+ * while exposing power-user features for click-curious users. Use `Table` only in lightweight situations where that overhead is genuinely unneeded.
+ *
  * @example
  * ```tsx
  * <Table>


### PR DESCRIPTION
Developers reaching for `Table` often don't realize that DataVis NITRO covers the same ground with less manual wiring and exposes sorting, filtering, and other power-user features progressively -- so it fits both simple and complex cases. Without any guidance at the point of discovery, teams default to `Table` even when NITRO would serve them better.

This adds a short nudge in two places:

- **Storybook docs banner** (`Table.stories.tsx`) -- a callout rendered at the top of the Table docs page linking directly to the NITRO docs and explaining when `Table` is still the right choice (genuinely lightweight situations where NITRO's overhead is unneeded).
- **JSDoc on `Table`** (`Table.tsx`) -- the same guidance in-editor so it surfaces in IDE hover tooltips without opening Storybook.

No runtime behavior is changed.