### PR TITLE
feat(storybook): add global GitHub source link to every story

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -149,15 +149,22 @@ function applyBrandStyles(brand: BrandConfig, isDark: boolean) {
 // Appends a "View source on GitHub" link below each story, derived from the
 // story file's absolute path on disk (context.parameters.fileName).
 const withGitHubSource: Decorator = (Story, context) => {
-  const fileName = context.parameters?.fileName as string | undefined;
+  const rawFileName = context.parameters?.fileName as string | undefined;
+  // Normalize Windows backslashes to forward slashes before any path operations
+  const fileName = rawFileName ? rawFileName.replace(/\\/g, '/') : undefined;
   const srcIndex = fileName ? fileName.indexOf('/src/') : -1;
 
-  const githubUrl =
-    srcIndex >= 0
-      ? `https://github.com/mieweb/ui/blob/main/${fileName!
-          .slice(srcIndex + 1)
-          .replace(/\.stories(\.[^.]+)$/, '$1')}`
-      : null;
+  const githubUrl = (() => {
+    if (srcIndex < 0 || !fileName) return null;
+    const relPath = fileName.slice(srcIndex + 1);
+    const basename = relPath.split('/').pop() ?? '';
+    // Only strip `.stories` when the basename is strictly `Name.stories.(ts|tsx|js|jsx)`
+    // (no extra dot-segments before `.stories`). Otherwise link to the stories file itself.
+    const stripped = /^[^.]+\.stories\.(tsx?|jsx?)$/.test(basename)
+      ? relPath.replace(/\.stories(\.[^.]+)$/, '$1')
+      : relPath;
+    return `https://github.com/mieweb/ui/blob/main/${stripped}`;
+  })();
 
   return (
     <>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -146,6 +146,40 @@ function applyBrandStyles(brand: BrandConfig, isDark: boolean) {
   document.head.appendChild(styleTag);
 }
 
+// Appends a "View source on GitHub" link below each story, derived from the
+// story file's absolute path on disk (context.parameters.fileName).
+const withGitHubSource: Decorator = (Story, context) => {
+  const fileName = context.parameters?.fileName as string | undefined;
+  const srcIndex = fileName ? fileName.indexOf('/src/') : -1;
+
+  const githubUrl =
+    srcIndex >= 0
+      ? `https://github.com/mieweb/ui/blob/main/${fileName!
+          .slice(srcIndex + 1)
+          .replace(/\.stories(\.[^.]+)$/, '$1')}`
+      : null;
+
+  return (
+    <>
+      <Story />
+      {githubUrl && (
+        <div
+          style={{
+            marginTop: '12px',
+            fontSize: '11px',
+            textAlign: 'right',
+            opacity: 0.5,
+          }}
+        >
+          <a href={githubUrl} target="_blank" rel="noopener noreferrer">
+            View source on GitHub ↗
+          </a>
+        </div>
+      )}
+    </>
+  );
+};
+
 // Brand switcher decorator
 const withBrand: Decorator = (Story, context) => {
   const brandName = context.globals.brand || 'bluehive';
@@ -300,7 +334,7 @@ const preview: Preview = {
       },
     },
   },
-  decorators: [withBrand],
+  decorators: [withGitHubSource, withBrand],
 };
 
 export default preview;


### PR DESCRIPTION
Every story page in Storybook is a potential entry point for a developer who wants to dig into the source. Today there is no fast path from a Storybook page to the actual component file on GitHub -- you have to know the repo layout and navigate there yourself.

This adds a `withGitHubSource` global decorator in `.storybook/preview.tsx` that automatically appends a small, low-opacity "View source on GitHub ↗" link below every story. The link is derived at runtime from `context.parameters.fileName` (the absolute on-disk path Storybook already provides), so no per-story configuration is needed:

- Strips the machine-local prefix up to `/src/` to get the repo-relative path.
- Replaces `.stories.tsx` with `.tsx` so the link points to the component source file, not the stories file.
- Renders outside the brand-styled wrapper (outermost decorator position) so it is unaffected by theme/brand switching.

Works on every canvas tab and within each story preview in the docs tab, with zero changes to individual story files.