### PR TITLE
feat: add talkToText prop to AIChat with RecordButton in input

### DIFF
--- a/scripts/ccme-scan.mjs
+++ b/scripts/ccme-scan.mjs
@@ -1,0 +1,41 @@
+import { chromium } from '@playwright/test';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+const resp = await page.goto('http://localhost:6006/index.json');
+const data = await resp.json();
+const storyIds = Object.keys(data.entries).filter(k => data.entries[k].type === 'story');
+
+const AXE = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.0/axe.min.js';
+const violations = [];
+
+for (let i = 0; i < storyIds.length; i++) {
+  const id = storyIds[i];
+  try {
+    await page.goto(`http://localhost:6006/iframe.html?id=${id}&viewMode=story&globals=brand:ccme`, { waitUntil: 'networkidle', timeout: 10000 });
+    await page.waitForTimeout(500);
+    await page.addScriptTag({ url: AXE });
+    await page.waitForFunction(() => typeof window.axe !== 'undefined');
+    const results = await page.evaluate(async () => {
+      return await window.axe.run(document.body, { runOnly: ['color-contrast'] });
+    });
+    if (results.violations.length > 0) {
+      for (const v of results.violations) {
+        for (const n of v.nodes) {
+          violations.push({
+            story: id,
+            html: n.html.substring(0, 150),
+            message: (n.any?.[0]?.message || '').substring(0, 250),
+            target: n.target?.[0]
+          });
+        }
+      }
+    }
+    if ((i + 1) % 100 === 0) process.stderr.write(`  ${i+1}/${storyIds.length}...\n`);
+  } catch(e) {}
+}
+
+console.log(JSON.stringify(violations, null, 2));
+process.stderr.write(`Total violations: ${violations.length} across ${storyIds.length} stories\n`);
+await browser.close();

--- a/scripts/esheet-a11y-audit.mjs
+++ b/scripts/esheet-a11y-audit.mjs
@@ -1,0 +1,69 @@
+import { chromium } from '@playwright/test';
+
+const STORIES = [
+  { name: 'BUILDER DEFAULT', id: 'components-forms-inputs-esheet-builder--default', root: '.ms-builder-root' },
+  { name: 'BUILDER EMPTY FORM', id: 'components-forms-inputs-esheet-builder--empty-form', root: '.ms-builder-root' },
+  { name: 'RENDERER DEFAULT', id: 'components-forms-inputs-esheet-renderer--default', root: '.esheet-renderer-root' },
+  { name: 'RENDERER PRE-FILLED', id: 'components-forms-inputs-esheet-renderer--pre-filled', root: '.esheet-renderer-root' },
+];
+
+const BRANDS = ['bluehive', 'default', 'enterprise-health', 'waggleline', 'webchart', 'mieweb'];
+const THEMES = ['light', 'dark'];
+
+const AXE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.0/axe.min.js';
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  let totalViolations = 0;
+
+  for (const brand of BRANDS) {
+    for (const theme of THEMES) {
+      for (const story of STORIES) {
+        const url = `http://localhost:6006/iframe.html?id=${story.id}&viewMode=story&globals=brand:${brand};theme:${theme}`;
+        await page.goto(url, { waitUntil: 'networkidle' });
+        await page.waitForTimeout(2000);
+        await page.addScriptTag({ url: AXE_CDN });
+        await page.waitForFunction(() => typeof window.axe !== 'undefined');
+
+        const results = await page.evaluate(async (selector) => {
+          const el = document.querySelector(selector);
+          return await window.axe.run(el || document.body);
+        }, story.root);
+
+        if (results.violations.length === 0) continue;
+        totalViolations += results.violations.length;
+
+        console.log(`\n${'='.repeat(60)}`);
+        console.log(`=== ${story.name} | ${brand} / ${theme} === (${results.violations.length} violations)`);
+        console.log(`${'='.repeat(60)}`);
+
+        for (const v of results.violations) {
+          console.log(`\n  ❌ [${v.impact?.toUpperCase()}] ${v.id}`);
+          console.log(`     ${v.help}`);
+          console.log(`     ${v.helpUrl}`);
+          for (const n of v.nodes) {
+            console.log(`     ─ Target: ${JSON.stringify(n.target)}`);
+            console.log(`       HTML: ${n.html.substring(0, 250)}`);
+            if (n.failureSummary) {
+              console.log(`       ${n.failureSummary.replace(/\n/g, '\n       ')}`);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (totalViolations === 0) {
+    console.log('\n✅ All stories pass across all brands and themes!');
+  } else {
+    console.log(`\n❌ Total violation types: ${totalViolations}`);
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/AI/AI.stories.tsx
+++ b/src/components/AI/AI.stories.tsx
@@ -401,6 +401,23 @@ export const GeneratingResponse: StoryObj<typeof AIChat> = {
   },
 };
 
+export const TalkToText: StoryObj<typeof AIChat> = {
+  render: () => (
+    <div className="h-[600px]">
+      <AIChat
+        messages={[]}
+        suggestions={suggestedActions}
+        height="100%"
+        talkToText
+        onSendMessage={(msg) => console.log('Send:', msg)}
+        onRecordingComplete={(blob, duration) =>
+          console.log('Recording complete:', { size: blob.size, duration })
+        }
+      />
+    </div>
+  ),
+};
+
 // ============================================================================
 // Floating Chat Stories
 // ============================================================================

--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -28,6 +28,7 @@ import {
   EmptyState as MessagingEmptyState,
   type EmptyStateProps as MessagingEmptyStateProps,
 } from '../Messaging/MessageList';
+import { RecordButton } from '../RecordButton';
 import { SparklesIcon, CloseIcon, RefreshIcon } from './icons';
 
 // ============================================================================
@@ -269,6 +270,10 @@ export interface AIChatProps
   height?: string | number;
   /** Props to pass to the MessageComposer */
   composerProps?: Partial<MessageComposerProps>;
+  /** Enable talk-to-text microphone button inside the input */
+  talkToText?: boolean;
+  /** Callback when recording completes (receives audio blob and duration) */
+  onRecordingComplete?: (blob: Blob, duration: number) => void;
   /** Callback when close button is clicked (shows close button when provided) */
   onClose?: () => void;
   /**
@@ -298,6 +303,8 @@ export function AIChat({
   size,
   height,
   composerProps,
+  talkToText = false,
+  onRecordingComplete,
   className,
   onSendMessage,
   onToolCall: _onToolCall,
@@ -462,6 +469,18 @@ export function AIChat({
           showCameraButton={false}
           showCharacterCount={false}
           variant="minimal"
+          inputTrailing={
+            talkToText ? (
+              <RecordButton
+                variant="ghost"
+                size="sm"
+                showPulse={false}
+                showWaveform
+                disabled={isGenerating}
+                onRecordingComplete={onRecordingComplete}
+              />
+            ) : undefined
+          }
           {...composerProps}
         />
       </div>

--- a/src/components/Messaging/MessageComposer.tsx
+++ b/src/components/Messaging/MessageComposer.tsx
@@ -218,6 +218,8 @@ export interface MessageComposerProps {
   onCancelReply?: () => void;
   /** Visual variant - 'default' shows border-t, 'minimal' has no border */
   variant?: 'default' | 'minimal';
+  /** Content to render inside the input wrapper (e.g. a mic button) */
+  inputTrailing?: React.ReactNode;
   /** Additional class name */
   className?: string;
 }
@@ -259,6 +261,7 @@ const MessageComposer = React.forwardRef<
       replyTo = null,
       onCancelReply,
       variant = 'default',
+      inputTrailing,
       className,
     },
     ref
@@ -539,7 +542,8 @@ const MessageComposer = React.forwardRef<
                 disabled={disabled || isSending}
                 rows={1}
                 className={cn(
-                  'w-full resize-none rounded-2xl px-4 py-2.5',
+                  'w-full resize-none rounded-2xl py-2.5',
+                  inputTrailing ? 'pr-10 pl-4' : 'px-4',
                   'bg-neutral-100 dark:bg-neutral-800',
                   'text-neutral-900 dark:text-neutral-100',
                   'placeholder:text-neutral-400 dark:placeholder:text-neutral-500',
@@ -551,6 +555,16 @@ const MessageComposer = React.forwardRef<
                 aria-label="Message"
                 aria-describedby={showCharacterCount ? 'char-count' : undefined}
               />
+
+              {/* Trailing content (e.g. record button) */}
+              {inputTrailing && (
+                <div
+                  data-slot="composer-input-trailing"
+                  className="pointer-events-none absolute top-0 right-1 flex h-[44px] items-center [&>*]:pointer-events-auto"
+                >
+                  {inputTrailing}
+                </div>
+              )}
 
               {/* Character count */}
               {showCharacterCount && (


### PR DESCRIPTION
- Add inputTrailing slot to MessageComposer for rendering content inside the text input wrapper (right-aligned)
- Add talkToText boolean prop to AIChat that renders a ghost/sm RecordButton with waveform inside the composer input
- Add onRecordingComplete callback prop to AIChat
- Add TalkToText story to AI.stories.tsx