### PR TITLE
fix(a11y): improve contrast ratio on GitHub source links

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -177,10 +177,9 @@ const withGitHubSource: Decorator = (Story, context) => {
             marginTop: '12px',
             fontSize: '11px',
             textAlign: 'right',
-            opacity: 0.5,
           }}
         >
-          <a href={githubUrl} target="_blank" rel="noopener noreferrer">
+          <a href={githubUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--mieweb-muted-foreground, #636363)', textDecoration: 'none' }}>
             View source on GitHub ↗
           </a>
         </div>


### PR DESCRIPTION
Replace opacity: 0.5 with explicit color #636363 (~5.9:1 ratio) to meet WCAG AA 4.5:1 minimum for the recently added "View source on GitHub" link.

<img width="1191" height="420" alt="image" src="https://github.com/user-attachments/assets/0342f587-5a1c-4e54-93ed-2695b4c41450" />
