### PR TITLE
feat(AudioRecorder): count-up timer and hide waveform/time when idle

### DIFF
--- a/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/components/AudioRecorder/AudioRecorder.tsx
@@ -315,8 +315,12 @@ function TimeDisplay({
   return (
     <div className="flex items-center gap-1 font-mono text-sm text-neutral-600 dark:text-neutral-400">
       <span>{formatTime(currentTime)}</span>
-      <span>/</span>
-      <span>{formatTime(showMax && maxDuration ? maxDuration : duration)}</span>
+      {!showMax && (
+        <>
+          <span>/</span>
+          <span>{formatTime(duration)}</span>
+        </>
+      )}
     </div>
   );
 }
@@ -823,7 +827,7 @@ function AudioRecorder({
       aria-label={ariaLabel}
     >
       {/* Waveform / Visualizer */}
-      {showWaveform && (
+      {showWaveform && state !== 'idle' && (
         <div
           className={cn(waveformContainerVariants({ state }))}
           style={{ height: waveformHeight }}
@@ -842,7 +846,7 @@ function AudioRecorder({
       )}
 
       {/* Status and Time */}
-      {showTime && (
+      {showTime && state !== 'idle' && (
         <div className="flex items-center justify-between">
           <RecordingIndicator isRecording={isRecording} isPaused={isPaused} />
           <TimeDisplay


### PR DESCRIPTION
## Summary

Refines the `AudioRecorder` component to match the production `beta.ozwell.ai` recording UX.

## Changes

- **Count-up timer only** — during recording, `TimeDisplay` shows only the elapsed time (e.g. `0:07`). The `/ <max>` portion is no longer rendered while recording, removing the implied hard cap.
- **Hide waveform + time when idle** — the waveform and the time row now render only when `state !== 'idle'`, so the component is clean before recording starts.

## Notes

- Consumed by `mieweb/ozwell-workspace` (chat home page). A companion PR there bumps the submodule pointer and wires up the recorder state.

Related: mieweb/ozwell-workspace#99