### PR TITLE
fix(stories): move AlertDialog, FloatingWindow, Sheet to Overlays & Layering

### DIFF
--- a/src/components/AlertDialog/AlertDialog.stories.tsx
+++ b/src/components/AlertDialog/AlertDialog.stories.tsx
@@ -4,7 +4,7 @@ import { AlertDialog } from './AlertDialog';
 import { Button } from '../Button';
 
 const meta: Meta<typeof AlertDialog> = {
-  title: 'Components/Overlays/AlertDialog',
+  title: 'Components/Overlays & Layering/AlertDialog',
   component: AlertDialog,
   parameters: {
     layout: 'centered',

--- a/src/components/FloatingWindow/FloatingWindow.stories.tsx
+++ b/src/components/FloatingWindow/FloatingWindow.stories.tsx
@@ -4,7 +4,7 @@ import { FloatingWindow, MinimizedWindow } from './FloatingWindow';
 import { Button } from '../Button';
 
 const meta: Meta<typeof FloatingWindow> = {
-  title: 'Components/Overlays/FloatingWindow',
+  title: 'Components/Overlays & Layering/FloatingWindow',
   component: FloatingWindow,
   parameters: {
     layout: 'fullscreen',

--- a/src/components/Sheet/Sheet.stories.tsx
+++ b/src/components/Sheet/Sheet.stories.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '../Button';
 
 const meta: Meta<typeof Sheet> = {
-  title: 'Components/Overlays/Sheet',
+  title: 'Components/Overlays & Layering/Sheet',
   component: Sheet,
   parameters: {
     layout: 'centered',


### PR DESCRIPTION
PR #245 accidentally introduced a new "Overlays" Storybook nav section when we already had "Overlays & Layering". This moves AlertDialog, FloatingWindow, and Sheet to the correct existing section.