### PR TITLE
fix(release): pin release workflow to Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          # Pinned to 20 to match ci.yml. Node 24's tsup DTS worker OOMs
+          # (ERR_WORKER_OUT_OF_MEMORY) even with NODE_OPTIONS=--max-old-space-size=8192,
+          # because the worker thread does not reliably inherit the heap limit.
+          node-version: '20'
           check-latest: true
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
The release job ran on Node 24 and OOM'd in the tsup DTS worker (ERR_WORKER_OUT_OF_MEMORY) even with NODE_OPTIONS=--max-old-space-size=8192, because the worker thread does not reliably inherit the heap limit on Node 24. ci.yml builds the same commit on Node 20 successfully, so pin release.yml to match. This unblocks the auto dev-prerelease publish.