### PR TITLE
fix(build): pass --max-old-space-size as node CLI flag so tsup DTS wo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # Pinned to 20 to match ci.yml. Node 24's tsup DTS worker OOMs
-          # (ERR_WORKER_OUT_OF_MEMORY) even with NODE_OPTIONS=--max-old-space-size=8192,
-          # because the worker thread does not reliably inherit the heap limit.
+          # Pinned to 20 to match ci.yml.
           node-version: '20'
           check-latest: true
           cache: 'pnpm'

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "postinstall": "if [ -z \"$_DATAVIS_RELINK\" ] && [ ! -f node_modules/datavis/package.json ] && [ -f packages/datavis/package.json ]; then echo '⚠️  Stale datavis link detected — re-linking submodule...'; _DATAVIS_RELINK=1 pnpm install; fi",
     "dev": "tsup --watch",
     "prebuild": "npm run build:esheet",
-    "build": "tsup && npm run build:css && npm run copy:brand-css && npm run copy:style-css",
+    "build": "node --max-old-space-size=8192 ./node_modules/tsup/dist/cli-default.js && npm run build:css && npm run copy:brand-css && npm run copy:style-css",
     "build:esheet": "if [ ! -f packages/esheet/packages/core/dist/index.d.ts ]; then cd packages/esheet && npm ci && npx nx run-many --target=build --projects=@esheet/core,@esheet/fields,@esheet/adapters,@esheet/builder,@esheet/renderer --parallel; fi",
     "build:css": "npx @tailwindcss/cli -i ./src/styles/base.css -o ./dist/styles.css --minify",
     "copy:brand-css": "cp src/brands/*.css dist/brands/ 2>/dev/null || true",


### PR DESCRIPTION
…rker inherits it

The tsup DTS step runs rollup-plugin-dts in a worker thread. The worker inherits node's execArgv (CLI flags) but NOT the NODE_OPTIONS env var, so the CI NODE_OPTIONS=--max-old-space-size=8192 never reached it. On low-RAM runners (ubuntu-latest ~7GB) the worker fell back to its RAM-derived default (~2GB), below the ~3GB DTS peak, causing ERR_WORKER_OUT_OF_MEMORY.

Invoke tsup via 'node --max-old-space-size=8192 cli-default.js' so the heap limit propagates into the worker. Verified locally: reproduced the OOM with a low CLI flag, and confirmed a full build passes with NODE_OPTIONS unset.

Also remove the now-incorrect Node-24 comment from release.yml (node version was a red herring; the worker heap mechanism is the real cause).