### PR TITLE
docs: fix Getting Started steps for Storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,19 @@ npm install
 
 Use one package manager consistently per clone. The commands below use npm.
 
-3. **Build eSheet packages** (required before first Storybook run, and after eSheet submodule updates):
+3. **Build eSheet packages** (required before first Storybook run):
 
 ```bash
 npm run build:esheet
 ```
 
 This installs eSheet's own dependencies and compiles all `@esheet/*` packages.
+
+If `packages/esheet` is updated later (submodule update, branch switch, or pull), force a fresh rebuild:
+
+```bash
+npm run rebuild:esheet
+```
 
 4. **Start Storybook:**
 
@@ -167,7 +173,8 @@ This watches for source changes and rebuilds automatically. It does **not** star
 | Script                    | Description                                               |
 | ------------------------- | --------------------------------------------------------- |
 | `npm run dev`             | Watch & rebuild the library (for local consumers, not Storybook) |
-| `npm run build:esheet`    | Build eSheet submodule packages (run after clone and whenever `packages/esheet` changes) |
+| `npm run build:esheet`    | Build eSheet submodule packages for first-time setup (skips when already built) |
+| `npm run rebuild:esheet`  | Force a full eSheet rebuild after `packages/esheet` changes |
 | `npm run build`           | Build the library for production                          |
 | `npm run storybook`       | Start Storybook development server                        |
 | `npm run build-storybook` | Build Storybook for static hosting                        |

--- a/README.md
+++ b/README.md
@@ -120,13 +120,21 @@ git clone --recurse-submodules https://github.com/mieweb/ui.git
 cd ui
 ```
 
-> `--recurse-submodules` is required to populate `packages/esheet` and `packages/datavis`, which are git submodules. Without it, eSheet and DataVis stories will not work.
+> `--recurse-submodules` is required to populate `packages/esheet`, `packages/datavis`, and `packages/ychart`, which are git submodules. Without it, eSheet, DataVis, and YChart stories will not work.
+
+If you already cloned without submodules, run:
+
+```bash
+git submodule update --init --recursive
+```
 
 2. **Install dependencies:**
 
 ```bash
 npm install
 ```
+
+Use one package manager consistently per clone. The commands below use npm.
 
 3. **Build eSheet packages** (required before running Storybook or building the library):
 
@@ -142,7 +150,7 @@ This installs eSheet's own dependencies and compiles all `@esheet/*` packages.
 npm run storybook
 ```
 
-This starts the Storybook development server at [http://localhost:6006](http://localhost:6006) with all components, including eSheet and DataVis.
+This starts the Storybook development server at [http://localhost:6006](http://localhost:6006) with all components, including eSheet, DataVis, and YChart.
 
 ### Library Development (watch mode)
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ import { Button } from '@mieweb/ui';
 
 ### Getting Started
 
-1. **Clone the repository:**
+1. **Clone the repository (including submodules):**
 
 ```bash
-git clone https://github.com/mieweb/ui.git
+git clone --recurse-submodules https://github.com/mieweb/ui.git
 cd ui
 ```
+
+> `--recurse-submodules` is required to populate `packages/esheet` and `packages/datavis`, which are git submodules. Without it, eSheet and DataVis stories will not work.
 
 2. **Install dependencies:**
 
@@ -126,22 +128,41 @@ cd ui
 npm install
 ```
 
-3. **Start development mode:**
+3. **Build eSheet packages** (required before running Storybook or building the library):
+
+```bash
+npm run build:esheet
+```
+
+This installs eSheet's own dependencies and compiles all `@esheet/*` packages.
+
+4. **Start Storybook:**
+
+```bash
+npm run storybook
+```
+
+This starts the Storybook development server at [http://localhost:6006](http://localhost:6006) with all components, including eSheet and DataVis.
+
+### Library Development (watch mode)
+
+To rebuild the library on file changes (for consumers that link this repo locally):
 
 ```bash
 npm run dev
 ```
 
-This will watch for changes and rebuild the library automatically.
+This watches for source changes and rebuilds automatically. It does **not** start Storybook.
 
 ### Available Scripts
 
-| Script                    | Description                         |
-| ------------------------- | ----------------------------------- |
-| `npm run dev`             | Start development mode with watch   |
-| `npm run build`           | Build the library for production    |
-| `npm run storybook`       | Start Storybook development server  |
-| `npm run build-storybook` | Build Storybook for static hosting  |
+| Script                    | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `npm run dev`             | Watch & rebuild the library (for local consumers, not Storybook) |
+| `npm run build:esheet`    | Build eSheet submodule packages (run once after cloning)  |
+| `npm run build`           | Build the library for production                          |
+| `npm run storybook`       | Start Storybook development server                        |
+| `npm run build-storybook` | Build Storybook for static hosting                        |
 | `npm run typecheck`       | Run TypeScript type checking        |
 | `npm run lint`            | Run ESLint                          |
 | `npm run lint:fix`        | Run ESLint with auto-fix            |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ git clone --recurse-submodules https://github.com/mieweb/ui.git
 cd ui
 ```
 
-> `--recurse-submodules` is required to populate `packages/esheet`, `packages/datavis`, and `packages/ychart`, which are git submodules. Without it, eSheet, DataVis, and YChart stories will not work.
+> `--recurse-submodules` is strongly recommended for first clone so `packages/esheet`, `packages/datavis`, and `packages/ychart` are populated immediately. Without these submodules, eSheet, DataVis, and YChart stories will not work.
 
 If you already cloned without submodules, run:
 
@@ -136,7 +136,7 @@ npm install
 
 Use one package manager consistently per clone. The commands below use npm.
 
-3. **Build eSheet packages** (required before running Storybook or building the library):
+3. **Build eSheet packages** (required before first Storybook run, and after eSheet submodule updates):
 
 ```bash
 npm run build:esheet
@@ -167,7 +167,7 @@ This watches for source changes and rebuilds automatically. It does **not** star
 | Script                    | Description                                               |
 | ------------------------- | --------------------------------------------------------- |
 | `npm run dev`             | Watch & rebuild the library (for local consumers, not Storybook) |
-| `npm run build:esheet`    | Build eSheet submodule packages (run once after cloning)  |
+| `npm run build:esheet`    | Build eSheet submodule packages (run after clone and whenever `packages/esheet` changes) |
 | `npm run build`           | Build the library for production                          |
 | `npm run storybook`       | Start Storybook development server                        |
 | `npm run build-storybook` | Build Storybook for static hosting                        |


### PR DESCRIPTION
- Add --recurse-submodules to clone command (esheet and datavis are submodules)
- Add explicit `npm run build:esheet` step before running Storybook
- Clarify that `npm run dev` is for library watch mode, not Storybook
- Update scripts table to include build:esheet and improve descriptions