### PR TITLE
fix(storybook): resolve pnpm non-hoisted deps in standalone repo layout

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,7 +10,16 @@ const storybookDir = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(storybookDir, '..');
 const monorepoRoot = path.resolve(workspaceRoot, '../..');
 const rootNodeModulesDir = path.join(workspaceRoot, 'node_modules');
-const pnpmVirtualNodeModulesDir = path.join(monorepoRoot, 'node_modules/.pnpm/node_modules');
+// pnpm exposes transitive (non-hoisted) dependencies under
+// `<root>/node_modules/.pnpm/node_modules`. Resolve this against whichever layout
+// actually exists: the standalone repo's own store first, then a monorepo root.
+const pnpmVirtualNodeModulesCandidates = [
+  path.join(rootNodeModulesDir, '.pnpm/node_modules'),
+  path.join(monorepoRoot, 'node_modules/.pnpm/node_modules'),
+];
+const pnpmVirtualNodeModulesDir =
+  pnpmVirtualNodeModulesCandidates.find((candidate) => existsSync(candidate)) ??
+  pnpmVirtualNodeModulesCandidates[0];
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -37,17 +46,6 @@ function readDependencyNames(packageDirName: string): string[] {
 const datavisDependencyNames = Array.from(
   new Set(readDependencyNames('datavis')),
 );
-
-const missingRootDependencies = datavisDependencyNames.filter(
-  (dependencyName) => !existsSync(path.join(rootNodeModulesDir, dependencyName)),
-);
-
-const datavisDependencyAliases = missingRootDependencies
-  .filter((dependencyName) => existsSync(path.join(pnpmVirtualNodeModulesDir, dependencyName)))
-  .map((dependencyName) => ({
-    find: new RegExp(`^${escapeRegExp(dependencyName)}(\/.*)?$`),
-    replacement: `${path.join(pnpmVirtualNodeModulesDir, dependencyName)}$1`,
-  }));
 
 const esheetPackagesDir = path.join(workspaceRoot, 'packages/esheet/packages');
 const esheetSourceAliases = ['core', 'fields', 'adapters', 'builder', 'renderer'].map(
@@ -95,7 +93,37 @@ function getPackageRootName(dependencyName: string): string {
 }
 
 function isLocalNodeModuleDependency(dependencyName: string): boolean {
-  return existsSync(path.join(rootNodeModulesDir, getPackageRootName(dependencyName), 'package.json'));
+  const packageRootName = getPackageRootName(dependencyName);
+  return (
+    existsSync(path.join(rootNodeModulesDir, packageRootName, 'package.json')) ||
+    existsSync(path.join(pnpmVirtualNodeModulesDir, packageRootName, 'package.json'))
+  );
+}
+
+/**
+ * For dependencies that are not hoisted into the root `node_modules` (common with
+ * pnpm's strict linking for transitive deps of linked workspace packages), build a
+ * Vite alias that points the bare specifier at the package's real location inside
+ * `node_modules/.pnpm/node_modules`. Without this, Vite cannot resolve these deps and
+ * `optimizeDeps.include` entries fail (and CJS-only deps break ESM interop at runtime).
+ */
+function buildVirtualStoreAliases(
+  dependencyNames: readonly string[],
+): { find: RegExp; replacement: string }[] {
+  const packageRootNames = Array.from(
+    new Set(dependencyNames.map(getPackageRootName)),
+  );
+
+  return packageRootNames
+    .filter(
+      (packageRootName) =>
+        !existsSync(path.join(rootNodeModulesDir, packageRootName, 'package.json')) &&
+        existsSync(path.join(pnpmVirtualNodeModulesDir, packageRootName, 'package.json')),
+    )
+    .map((packageRootName) => ({
+      find: new RegExp(`^${escapeRegExp(packageRootName)}(\/.*)?$`),
+      replacement: `${path.join(pnpmVirtualNodeModulesDir, packageRootName)}$1`,
+    }));
 }
 
 // --- YChart virtual:git-info plugin for Storybook ---
@@ -144,6 +172,13 @@ const config: StorybookConfig = {
   },
   staticDirs: ['./public'],
   async viteFinal(config) {
+    const optimizeDepNames = [
+      ...datavisDependencyNames,
+      ...datavisCjsInteropDependencies,
+      ...datavisLegacySubpathDependencies,
+      ...ychartDependencyNames,
+    ];
+
     config.resolve ??= {};
     config.resolve.alias = [
       ...(Array.isArray(config.resolve.alias)
@@ -152,7 +187,7 @@ const config: StorybookConfig = {
           ? [config.resolve.alias]
           : []),
       ...localUiAliases,
-      ...datavisDependencyAliases,
+      ...buildVirtualStoreAliases(optimizeDepNames),
       ...esheetSourceAliases,
     ];
 
@@ -184,10 +219,7 @@ const config: StorybookConfig = {
     config.optimizeDeps.include = Array.from(
       new Set([
         ...(config.optimizeDeps.include ?? []),
-        ...datavisDependencyNames,
-        ...datavisCjsInteropDependencies,
-        ...datavisLegacySubpathDependencies,
-        ...ychartDependencyNames,
+        ...optimizeDepNames,
       ].filter(isLocalNodeModuleDependency)),
     );
     config.optimizeDeps.esbuildOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,7 +266,7 @@ importers:
         version: 7.12.1
       ychart:
         specifier: file:./packages/ychart
-        version: file:packages/ychart
+        version: '@mieweb/ychart@file:packages/ychart(@popperjs/core@2.11.8)'
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -950,6 +950,10 @@ packages:
         optional: true
       wavesurfer.js:
         optional: true
+
+  '@mieweb/ychart@file:packages/ychart':
+    resolution: {directory: packages/ychart, type: directory}
+    engines: {node: '>=24.0.0'}
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -5105,9 +5109,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  ychart@file:packages/ychart:
-    resolution: {directory: packages/ychart, type: directory}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5916,6 +5917,28 @@ snapshots:
       ag-grid-community: 35.1.0
       ag-grid-react: 35.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       wavesurfer.js: 7.12.1
+
+  '@mieweb/ychart@file:packages/ychart(@popperjs/core@2.11.8)':
+    dependencies:
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.0
+      bootstrap: 5.3.8(@popperjs/core@2.11.8)
+      codemirror: 6.0.2
+      d3: 7.9.0
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-flextree: 2.1.2
+      d3-hierarchy: 3.1.2
+      d3-org-chart: 3.1.1
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-zoom: 3.0.0
+      js-yaml: 4.1.1
+    transitivePeerDependencies:
+      - '@popperjs/core'
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -10503,8 +10526,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  ychart@file:packages/ychart: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
The YChart Storybook integration (6fd47fb) changed pnpmVirtualNodeModulesDir to assume a monorepo layout two levels up (workspaceRoot/../..), which does not exist in a standalone clone. This left the datavis dependency aliases empty, so transitive deps like react-i18next > html-parse-stringify > void-elements were never aliased or pre-bundled, breaking the DataVis NITRO story with a CJS/ESM interop error:

  SyntaxError: ... 'void-elements/index.js' does not provide an export named 'default'

- Detect the pnpm virtual store at runtime: prefer the local node_modules/.pnpm/node_modules, fall back to the monorepo layout.
- Recognize virtual-store deps in isLocalNodeModuleDependency so they are force pre-bundled.
- Generalize alias construction (buildVirtualStoreAliases) to cover all force-included deps (datavis, ychart, CJS-interop, legacy subpaths).

Also syncs pnpm-lock.yaml metadata for the @mieweb/ychart submodule.

Verified: dev server + static build render DataVis NITRO; 20/20 visual tests pass.