### PR TITLE
docs: add local Storybook setup guide and align sub-package wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ git clone --recurse-submodules https://github.com/mieweb/ui.git
 cd ui
 ```
 
-> `--recurse-submodules` is strongly recommended for first clone so the `packages/esheet` and `packages/ychart` submodules are populated immediately. Without them, the eSheet and YChart stories will not work. (DataVis NITRO now ships as the published `@mieweb/datavis` npm package, so it no longer needs a submodule build.)
+> `--recurse-submodules` is strongly recommended for first clone so the `packages/esheet` and `packages/ychart` submodules are populated immediately. Without them, the eSheet and YChart stories will not work. A `packages/datavis` submodule is still declared in `.gitmodules` and gets cloned too, but DataVis NITRO now ships as the published `@mieweb/datavis` npm package, so that submodule is no longer required by the build.
 
 If you already cloned without submodules, run:
 
@@ -157,9 +157,9 @@ This starts the Storybook development server at [http://localhost:6006](http://l
 
 Storybook integrates three sibling MIE projects, each sourced differently:
 
-- **DataVis NITRO** — npm package `@mieweb/datavis`. No build step; consumed as a published package (no submodule build needed).
+- **DataVis NITRO** — npm package `@mieweb/datavis`. No build step; consumed as a published package (no submodule build needed). The legacy `packages/datavis` submodule is still cloned but unused by the build.
 - **eSheet** — git submodule `packages/esheet`. Built automatically by the `prestorybook` hook; rebuilds only when its artifacts are missing.
-- **YChart** — git submodule `packages/ychart`. No build step; linked from source and aliased into Storybook's Vite config.
+- **YChart** — git submodule `packages/ychart`. No build step; the story imports it directly from source via a relative dynamic import, and Storybook's Vite config adds a `virtual:git-info` plugin, a `__YCHART_VERSION__` define, and dependency pre-bundling (`optimizeDeps`).
 
 ### Library Development (watch mode)
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ git clone --recurse-submodules https://github.com/mieweb/ui.git
 cd ui
 ```
 
-> `--recurse-submodules` is strongly recommended for first clone so `packages/esheet`, `packages/datavis`, and `packages/ychart` are populated immediately. Without these submodules, eSheet, DataVis, and YChart stories will not work.
+> `--recurse-submodules` is strongly recommended for first clone so the `packages/esheet` and `packages/ychart` submodules are populated immediately. Without them, the eSheet and YChart stories will not work. (DataVis NITRO now ships as the published `@mieweb/datavis` npm package, so it no longer needs a submodule build.)
 
 If you already cloned without submodules, run:
 
@@ -136,18 +136,13 @@ npm install
 
 Use one package manager consistently per clone. The commands below use npm.
 
-3. **Build eSheet packages** (required before first Storybook run):
+3. **eSheet packages build automatically.** A `prestorybook` hook runs `npm run build:esheet` before Storybook starts, so the `@esheet/*` packages are compiled on first run with no manual step. It's a near-instant no-op on later runs once the artifacts exist.
+
+If `packages/esheet` is updated later (submodule update, branch switch, or pull) and you need to force a fresh rebuild, remove the built artifacts and run the build again:
 
 ```bash
+rm -f packages/esheet/packages/core/dist/index.d.ts packages/esheet/packages/renderer/src/index.output.css
 npm run build:esheet
-```
-
-This installs eSheet's own dependencies and compiles all `@esheet/*` packages.
-
-If `packages/esheet` is updated later (submodule update, branch switch, or pull), force a fresh rebuild:
-
-```bash
-npm run rebuild:esheet
 ```
 
 4. **Start Storybook:**
@@ -156,7 +151,15 @@ npm run rebuild:esheet
 npm run storybook
 ```
 
-This starts the Storybook development server at [http://localhost:6006](http://localhost:6006) with all components, including eSheet, DataVis, and YChart.
+This starts the Storybook development server at [http://localhost:6006](http://localhost:6006) with all components, including eSheet, DataVis NITRO, and YChart.
+
+### How the Sub-Packages Are Wired
+
+Storybook integrates three sibling MIE projects, each sourced differently:
+
+- **DataVis NITRO** — npm package `@mieweb/datavis`. No build step; consumed as a published package (no submodule build needed).
+- **eSheet** — git submodule `packages/esheet`. Built automatically by the `prestorybook` hook; rebuilds only when its artifacts are missing.
+- **YChart** — git submodule `packages/ychart`. No build step; linked from source and aliased into Storybook's Vite config.
 
 ### Library Development (watch mode)
 
@@ -173,8 +176,7 @@ This watches for source changes and rebuilds automatically. It does **not** star
 | Script                    | Description                                               |
 | ------------------------- | --------------------------------------------------------- |
 | `npm run dev`             | Watch & rebuild the library (for local consumers, not Storybook) |
-| `npm run build:esheet`    | Build eSheet submodule packages for first-time setup (skips when already built) |
-| `npm run rebuild:esheet`  | Force a full eSheet rebuild after `packages/esheet` changes |
+| `npm run build:esheet`    | Build eSheet submodule packages (auto-run by `prestorybook`/`prebuild`; skips when already built) |
 | `npm run build`           | Build the library for production                          |
 | `npm run storybook`       | Start Storybook development server                        |
 | `npm run build-storybook` | Build Storybook for static hosting                        |

--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -654,7 +654,7 @@ Want to develop components, browse the full library on your machine, or contribu
 ### Setup
 
 ```bash
-# 1. Clone with submodules (eSheet and YChart are git submodules)
+# 1. Clone with submodules (esheet, ychart, and datavis are git submodules)
 git clone --recurse-submodules https://github.com/mieweb/ui.git
 cd ui
 
@@ -696,11 +696,11 @@ That's the whole flow — `pnpm install && pnpm storybook`. A `prestorybook` hoo
 
 `@mieweb/ui`'s Storybook integrates three sibling MIE projects, each sourced differently:
 
-- **DataVis NITRO** — npm package `@mieweb/datavis`. _No build step:_ consumed as a published package (no submodule build needed). Powers the DataVis NITRO data-grid stories.
+- **DataVis NITRO** — npm package `@mieweb/datavis`. _No build step:_ consumed as a published package (no submodule build needed). Powers the DataVis NITRO data-grid stories. (A legacy `packages/datavis` submodule is still declared in `.gitmodules` and gets cloned, but the build no longer uses it.)
 - **eSheet** — git submodule `packages/esheet`. _Built automatically_ by the `prestorybook` hook (nx) before Storybook starts; rebuilds only when its artifacts are missing. The form builder/renderer toolkit.
-- **YChart** — git submodule `packages/ychart`. _No build step:_ linked from source and aliased into Storybook's Vite config. Org-chart / visualization toolkit.
+- **YChart** — git submodule `packages/ychart`. _No build step:_ the story imports it directly from source via a relative dynamic import; Storybook's Vite config supplies a `virtual:git-info` plugin, a `__YCHART_VERSION__` define, and dependency pre-bundling (`optimizeDeps`). Org-chart / visualization toolkit.
 
-> **Heads up:** DataVis NITRO was recently moved from a git submodule to the published `@mieweb/datavis` npm package — a fresh clone no longer builds DataVis from source.
+> **Heads up:** DataVis NITRO is now consumed from the published `@mieweb/datavis` npm package rather than built from source — a fresh clone no longer builds DataVis. The `packages/datavis` submodule still exists for now, but it's no longer required by the build.
 
 ### Common Commands
 

--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -641,6 +641,79 @@ For advanced usage — custom field types, conditional logic, standalone/Blaze r
 
 ---
 
+## 🛠️ Running Storybook Locally
+
+Want to develop components, browse the full library on your machine, or contribute? Getting this Storybook running locally is a two-command flow.
+
+### Prerequisites
+
+- **Node.js** ≥ 20
+- **pnpm** 10.29.1 — pinned via the repo's `packageManager` field. Enable it with `corepack enable`.
+- **Git** with submodule support
+
+### Setup
+
+```bash
+# 1. Clone with submodules (eSheet and YChart are git submodules)
+git clone --recurse-submodules https://github.com/mieweb/ui.git
+cd ui
+
+# 2. Install dependencies
+#    A preinstall hook auto-inits/updates submodules — so even if you
+#    forgot --recurse-submodules above, this step pulls them in.
+pnpm install
+
+# 3. Start Storybook on http://localhost:6006
+pnpm storybook
+```
+
+That's the whole flow — `pnpm install && pnpm storybook`. A `prestorybook` hook builds the eSheet packages automatically on first run, so the eSheet stories work out of the box with no manual build step (it's a near-instant no-op on later runs once the artifacts exist).
+
+<div
+  style={{
+    marginTop: '16px',
+    padding: '12px 16px',
+    borderRadius: '8px',
+    border: '1px solid var(--mieweb-border, #e5e7eb)',
+    backgroundColor: 'var(--mieweb-muted, #f5f5f5)',
+  }}
+>
+  <strong>Already cloned without submodules?</strong>
+  <span
+    style={{
+      fontSize: '14px',
+      color: 'var(--mieweb-muted-foreground, #737373)',
+      display: 'block',
+      marginTop: '4px',
+    }}
+  >
+    Run <code>git submodule update --init --recursive</code> — or just{' '}
+    <code>pnpm install</code>, which does it for you.
+  </span>
+</div>
+
+### How the Sub-Packages Are Wired
+
+`@mieweb/ui`'s Storybook integrates three sibling MIE projects, each sourced differently:
+
+- **DataVis NITRO** — npm package `@mieweb/datavis`. _No build step:_ consumed as a published package (no submodule build needed). Powers the DataVis NITRO data-grid stories.
+- **eSheet** — git submodule `packages/esheet`. _Built automatically_ by the `prestorybook` hook (nx) before Storybook starts; rebuilds only when its artifacts are missing. The form builder/renderer toolkit.
+- **YChart** — git submodule `packages/ychart`. _No build step:_ linked from source and aliased into Storybook's Vite config. Org-chart / visualization toolkit.
+
+> **Heads up:** DataVis NITRO was recently moved from a git submodule to the published `@mieweb/datavis` npm package — a fresh clone no longer builds DataVis from source.
+
+### Common Commands
+
+- `pnpm storybook` — Run Storybook in dev mode on port 6006
+- `pnpm build-storybook` — Build the static Storybook site
+- `pnpm build` — Build the publishable `@mieweb/ui` library
+- `pnpm test` — Run the unit test suite (Vitest)
+- `pnpm test:visual` — Run Playwright visual regression tests
+- `pnpm typecheck` — Type-check without emitting
+- `pnpm lint` — Lint `src/**`
+
+---
+
 ## 🔗 Resources
 
 - [GitHub Repository](https://github.com/mieweb/ui) — Source code and issue tracker


### PR DESCRIPTION
Introduction.mdx:
- Add '🛠️ Running Storybook Locally' section documenting the full clone → install → run flow (prerequisites, setup, common commands).
- Explain how the three sibling MIE projects are wired: DataVis NITRO (published @mieweb/datavis npm package, no build), eSheet (git submodule, auto-built by the prestorybook hook), YChart (git submodule, source-linked via Vite alias).
- Convert tables that did not render under MDX/remark-gfm to bullet lists and repair two corrupted heading emoji.

README.md:
- Drop DataVis from the 'submodules required for stories' note now that it ships as the @mieweb/datavis npm package.
- Reframe eSheet build as automatic via the prestorybook hook and replace the non-existent 'rebuild:esheet' script with an accurate force-rebuild command.
- Add a 'How the Sub-Packages Are Wired' subsection and fix the Available Scripts table.

Verified end to end with a fresh --recurse-submodules clone following only the Introduction instructions: pnpm install + pnpm storybook boots cleanly and DataVis NITRO, eSheet, and YChart stories all render.