### PR TITLE
fix(docs): theme Introduction CTA banner for dark/light mode

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -59,6 +59,24 @@ html, body {
   color: #ffffff !important;
 }
 
+/* Exception: text/icons inside rendered Buttons must inherit the button's own
+   color (MDX wraps button labels in <p> and icons in <span>, which the broad
+   prose rules above would otherwise force to muted grey). */
+[data-theme="dark"] .sbdocs button p,
+[data-theme="dark"] .sbdocs button span,
+[data-theme="dark"] .sbdocs button label,
+[data-theme="dark"] .sbdocs button li,
+[data-theme="dark"] .sbdocs button svg {
+  color: inherit !important;
+}
+
+/* Exception: CTA banner heading should use full foreground (near-white in dark),
+   not the muted prose color that the broad rules above apply to <p>. */
+[data-theme="dark"] .sbdocs .mie-cta-heading,
+[data-theme="dark"] .sbdocs .mie-cta-heading p {
+  color: var(--mieweb-foreground) !important;
+}
+
 /* Story preview containers */
 [data-theme="dark"] .docs-story,
 [data-theme="dark"] .sb-story,

--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -74,6 +74,7 @@ A **themeable, accessible React component library** built with Tailwind CSS 4. D
   <Button
     variant="primary"
     size="md"
+    type="button"
     rightIcon={<ArrowRight size={16} aria-hidden="true" />}
     onClick={() => {
       (window.top ?? window).location.href =

--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -1,4 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { ArrowRight } from 'lucide-react';
+import { Button } from './components/Button';
 
 <Meta title="Introduction" />
 
@@ -42,14 +44,17 @@ A **themeable, accessible React component library** built with Tailwind CSS 4. D
   style={{
     padding: '24px',
     borderRadius: '12px',
-    background:
-      'linear-gradient(135deg, var(--mieweb-primary-500, #27aae1) 0%, var(--mieweb-primary-700, #1786b3) 100%)',
+    backgroundColor: 'var(--mieweb-muted, #f5f5f5)',
+    border: '1px solid var(--mieweb-border, #e5e7eb)',
     marginTop: '16px',
     marginBottom: '24px',
   }}
 >
-  <div style={{ color: 'white', marginBottom: '12px' }}>
-    <strong style={{ fontSize: '18px', display: 'block', marginBottom: '8px' }}>
+  <div style={{ color: 'var(--mieweb-foreground, #171717)', marginBottom: '12px' }}>
+    <strong
+      className="mie-cta-heading"
+      style={{ fontSize: '18px', display: 'block', marginBottom: '8px' }}
+    >
       🚀 Full Dashboard Example
     </strong>
     <span
@@ -66,21 +71,17 @@ A **themeable, accessible React component library** built with Tailwind CSS 4. D
       Data tables, and more.
     </span>
   </div>
-  <a
-    href="?path=/story/product-feature-modules-dashboard--dashboard"
-    style={{
-      display: 'inline-block',
-      padding: '10px 20px',
-      backgroundColor: 'white',
-      color: 'var(--mieweb-primary-700, #1786b3)',
-      borderRadius: '6px',
-      fontWeight: '600',
-      textDecoration: 'none',
-      fontSize: '14px',
+  <Button
+    variant="primary"
+    size="md"
+    rightIcon={<ArrowRight size={16} aria-hidden="true" />}
+    onClick={() => {
+      (window.top ?? window).location.href =
+        '?path=/story/product-feature-modules-dashboard--dashboard';
     }}
   >
-    View Dashboard Example →
-  </a>
+    View Dashboard Example
+  </Button>
 </div>
 
 ---


### PR DESCRIPTION
## Summary

The "Full Dashboard Example" CTA banner on the Introduction docs page didn't respect dark/light mode — it used a fixed gradient and hardcoded `white` colors, so it looked out of place (a bright light box, grey button text) in dark mode.

This reworks the banner to be fully theme-token driven so it adapts across **all brands** and **both color modes**.

## Changes

**`src/Introduction.mdx`**
- Replace the gradient + hardcoded `white` with mode-aware semantic tokens: `--mieweb-muted` surface, `--mieweb-border`, and `--mieweb-foreground` text (flips light/dark, adapts per brand).
- Swap the raw styled `<a>` for the real MIE **`Button`** component (`primary` variant) with a lucide **`ArrowRight`** icon, navigating to the dashboard story via `onClick`.

**`.storybook/preview.css`**
- The broad dark-mode prose rules (`[data-theme="dark"] .sbdocs p/span/svg`) were force-overriding component colors with muted grey. Added two scoped exceptions so:
  - Button label/icon inherit the button's own color (white on primary).
  - The CTA heading uses full `--mieweb-foreground` (near-white in dark) instead of muted grey.

## Verification

- Light mode: muted surface, near-black heading, muted body, primary button — verified.
- Dark mode: dark muted surface matching surrounding panels, near-white heading, white button label + icon — verified.
- Confirmed computed colors via DOM inspection in both modes.

Docs-only change (MDX + Storybook preview CSS); no library/runtime impact.