### PR TITLE
fix(security): resolve CodeQL alerts (ReDoS, workflow perms, submodule scope)

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -6,3 +6,8 @@ paths-ignore:
   - node_modules
   - "**/*.min.js"
   - "**/*.bundle.js"
+  - "**/dist"
+  # Git submodules are scanned in their own repositories (mieweb/eSheet,
+  # mieweb/ychart); exclude them here to avoid duplicate/noisy alerts.
+  - packages/esheet
+  - packages/ychart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Least-privilege default for all jobs (override per-job as needed).
+permissions:
+  contents: read
+
 jobs:
   lint-and-type-check:
     name: Lint and Type Check

--- a/src/components/AGGrid/CellRenderers.tsx
+++ b/src/components/AGGrid/CellRenderers.tsx
@@ -53,7 +53,7 @@ function getFaviconUrl(domain: string | null | undefined): string | null {
   if (!domain || typeof domain !== 'string') return null;
   const cleanDomain = domain
     .replace(/^https?:\/\//, '')
-    .replace(/\/.*$/, '')
+    .split('/')[0]
     .trim();
   if (!cleanDomain) return null;
   return `https://www.google.com/s2/favicons?domain=${cleanDomain}&sz=64`;

--- a/src/components/AddContactModal/AddContactModal.tsx
+++ b/src/components/AddContactModal/AddContactModal.tsx
@@ -189,7 +189,7 @@ export function AddContactModal({
     }
     if (!formData.email.trim()) {
       newErrors.email = 'Email is required';
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@.]+$/.test(formData.email)) {
       newErrors.email = 'Please enter a valid email address';
     }
 


### PR DESCRIPTION
## Why
The Dependabot PR (#272) cleared dependency alerts, but **CodeQL code-scanning** still showed 16 open alerts — CodeQL scans source-code patterns, not dependencies, so it was untouched.

## What
| Bucket | Count | Fix |
|---|---|---|
| `js/polynomial-redos` (src) | 2 | ReDoS-safe regexes |
| `actions/missing-workflow-permissions` | 6 | least-privilege `permissions` block |
| esheet/ychart submodule alerts | 8 | excluded from this repo's CodeQL scan |

### ReDoS (source)
- **AddContactModal** email regex: `[^\\s@]+\\.[^\\s@]+$` → `[^\\s@]+\\.[^\\s@.]+$` (TLD class excludes `.`, removing polynomial backtracking). Verified behaviorally equivalent across representative inputs.
- **CellRenderers**: replaced `replace(/\\/.*$/, '')` with `.split('/')[0]` — no backtracking regex.

### Workflow permissions
Added top-level `permissions: contents: read` to `ci.yml`. `upload-artifact`/`codecov` steps need no extra scopes.

### Submodule alerts (8)
`packages/esheet` and `packages/ychart` are **git submodules** (mieweb/eSheet, mieweb/ychart) with their own CI/scanning; the ychart one is a minified `dist` build artifact. Excluded `packages/esheet`, `packages/ychart`, and nested `**/dist` from `codeql-config.yml` to avoid duplicate/noisy alerts. These should be fixed upstream in their own repos.

## Verification
- `pnpm lint` clean
- 196 unit tests pass