### PR TITLE
fix(preinstall): make submodule init cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "preinstall": "if [ -d .git ]; then git submodule update --init --recursive; fi",
+    "preinstall": "node -e \"try{if(require('fs').existsSync('.git'))require('child_process').execSync('git submodule update --init --recursive',{stdio:'inherit'})}catch(e){console.warn('[@mieweb/ui] submodule update skipped:',e.message)}\"",
     "dev": "tsup --watch",
     "prebuild": "npm run build:esheet",
     "build": "node --max-old-space-size=8192 ./node_modules/tsup/dist/cli-default.js && npm run build:css && npm run copy:brand-css && npm run copy:style-css && npm run copy:markdown-css && npm run copy:kerebron-css",


### PR DESCRIPTION

<img width="1000" height="797" alt="image" src="https://github.com/user-attachments/assets/5e863d75-5ce9-4ca9-9f4f-157b55424f13" />


The bash 'if [ -d .git ]; then ... fi' preinstall script fails under Windows cmd.exe ('-d was unexpected at this time'), aborting a fresh 'npm i' of @mieweb/ui for any Windows consumer. Replace it with a Node one-liner that runs identically on all platforms, is a no-op for registry consumers (no .git in the published tarball), and never fails the install (warns on submodule error).