### PR TITLE
fix: condensed-view composer mic icon rendering

### DIFF
--- a/src/components/RecordButton/RecordButton.tsx
+++ b/src/components/RecordButton/RecordButton.tsx
@@ -77,11 +77,19 @@ export interface RecordButtonProps extends Omit<
 // Icons
 // ============================================================================
 
-function MicIcon({ className }: { className?: string }) {
+function MicIcon({
+  className,
+  size = 20,
+}: {
+  className?: string;
+  size?: number;
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
+      width={size}
+      height={size}
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
@@ -97,11 +105,19 @@ function MicIcon({ className }: { className?: string }) {
   );
 }
 
-function MicOffIcon({ className }: { className?: string }) {
+function MicOffIcon({
+  className,
+  size = 20,
+}: {
+  className?: string;
+  size?: number;
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
+      width={size}
+      height={size}
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
@@ -120,11 +136,19 @@ function MicOffIcon({ className }: { className?: string }) {
   );
 }
 
-function StopIcon({ className }: { className?: string }) {
+function StopIcon({
+  className,
+  size = 20,
+}: {
+  className?: string;
+  size?: number;
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
+      width={size}
+      height={size}
       fill="currentColor"
       className={className}
       aria-hidden="true"
@@ -134,11 +158,19 @@ function StopIcon({ className }: { className?: string }) {
   );
 }
 
-function CheckIcon({ className }: { className?: string }) {
+function CheckIcon({
+  className,
+  size = 20,
+}: {
+  className?: string;
+  size?: number;
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
+      width={size}
+      height={size}
       fill="none"
       stroke="currentColor"
       strokeWidth="2.5"
@@ -152,11 +184,19 @@ function CheckIcon({ className }: { className?: string }) {
   );
 }
 
-function LoadingSpinner({ className }: { className?: string }) {
+function LoadingSpinner({
+  className,
+  size = 20,
+}: {
+  className?: string;
+  size?: number;
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
+      width={size}
+      height={size}
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
@@ -199,6 +239,9 @@ function PulseRings({ variant }: { variant: RecordButtonVariant }) {
 
 function WaveformBars({ size }: { size: RecordButtonSize }) {
   const barHeight = size === 'sm' ? 'h-2' : size === 'md' ? 'h-3' : 'h-4';
+  // Intrinsic px fallback so bars still render if the consuming app's CSS
+  // build does not include these size utilities.
+  const barHeightPx = size === 'sm' ? 8 : size === 'md' ? 12 : 16;
 
   return (
     <div
@@ -213,6 +256,8 @@ function WaveformBars({ size }: { size: RecordButtonSize }) {
             barHeight
           )}
           style={{
+            width: 2,
+            height: barHeightPx,
             animationDelay: `${i * 0.1}s`,
           }}
         />
@@ -256,6 +301,16 @@ const iconSizes: Record<RecordButtonSize, string> = {
   sm: 'size-4',
   md: 'size-5',
   lg: 'size-6',
+};
+
+// Intrinsic px sizes mirroring `iconSizes`, applied as width/height attributes
+// so the icons render at the correct size even when a consuming app's CSS build
+// does not include the Tailwind size utilities (e.g. it only scans its own
+// source and not node_modules/@mieweb/ui).
+const iconPxSizes: Record<RecordButtonSize, number> = {
+  sm: 16,
+  md: 20,
+  lg: 24,
 };
 
 // ============================================================================
@@ -476,6 +531,7 @@ const RecordButton = React.forwardRef<HTMLButtonElement, RecordButtonProps>(
     }, [disabled, controlledState, transcriptionState]);
 
     const iconSize = iconSizes[size];
+    const iconPx = iconPxSizes[size];
     const isRecording = effectiveState === 'recording';
     const isDisabled =
       effectiveState === 'disabled' || effectiveState === 'processing';
@@ -625,16 +681,16 @@ const RecordButton = React.forwardRef<HTMLButtonElement, RecordButtonProps>(
           if (showWaveform) {
             return <WaveformBars size={size} />;
           }
-          return recordingIcon || <StopIcon className={iconSize} />;
+          return recordingIcon || <StopIcon className={iconSize} size={iconPx} />;
         case 'processing':
-          return <LoadingSpinner className={iconSize} />;
+          return <LoadingSpinner className={iconSize} size={iconPx} />;
         case 'disabled':
         case 'error':
-          return <MicOffIcon className={iconSize} />;
+          return <MicOffIcon className={iconSize} size={iconPx} />;
         case 'success':
-          return <CheckIcon className={iconSize} />;
+          return <CheckIcon className={iconSize} size={iconPx} />;
         default:
-          return idleIcon || <MicIcon className={iconSize} />;
+          return idleIcon || <MicIcon className={iconSize} size={iconPx} />;
       }
     };
 

--- a/src/components/RecordButton/RecordButton.tsx
+++ b/src/components/RecordButton/RecordButton.tsx
@@ -239,9 +239,12 @@ function PulseRings({ variant }: { variant: RecordButtonVariant }) {
 
 function WaveformBars({ size }: { size: RecordButtonSize }) {
   const barHeight = size === 'sm' ? 'h-2' : size === 'md' ? 'h-3' : 'h-4';
-  // Intrinsic px fallback so bars still render if the consuming app's CSS
-  // build does not include these size utilities.
-  const barHeightPx = size === 'sm' ? 8 : size === 'md' ? 12 : 16;
+  // rem fallback (matching the Tailwind utility values: h-2/h-3/h-4) so the
+  // bars still render if the consuming app's CSS build does not include these
+  // size utilities. Using rem (not px) keeps scaling consistent with the
+  // utilities and lets condensed `!important` overrides still win.
+  const barHeightRem =
+    size === 'sm' ? '0.5rem' : size === 'md' ? '0.75rem' : '1rem';
 
   return (
     <div
@@ -256,8 +259,8 @@ function WaveformBars({ size }: { size: RecordButtonSize }) {
             barHeight
           )}
           style={{
-            width: 2,
-            height: barHeightPx,
+            width: '0.125rem',
+            height: barHeightRem,
             animationDelay: `${i * 0.1}s`,
           }}
         />
@@ -681,7 +684,9 @@ const RecordButton = React.forwardRef<HTMLButtonElement, RecordButtonProps>(
           if (showWaveform) {
             return <WaveformBars size={size} />;
           }
-          return recordingIcon || <StopIcon className={iconSize} size={iconPx} />;
+          return (
+            recordingIcon || <StopIcon className={iconSize} size={iconPx} />
+          );
         case 'processing':
           return <LoadingSpinner className={iconSize} size={iconPx} />;
         case 'disabled':

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,8 +1,8 @@
 @import 'tailwindcss';
-@source "../../node_modules/@mieweb/datavis/dist";
 @import './condensed-view.css';
 @import './datavis-dark.css';
 @import './datavis-overrides.css';
+@source "../../node_modules/@mieweb/datavis/dist";
 
 @custom-variant dark (&:where(.dark, [data-theme=dark], .dark *, [data-theme=dark] *));
 

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -5905,12 +5905,13 @@ body.condensed [data-slot='composer-input'] {
 
 /* Trailing slot (e.g. record/mic button) – the standard view hard-codes a
    44px height to match the comfortable textarea. In condensed the input row is
-   shorter, so track the wrapper height instead and keep the icon centered to
-   prevent the mic from drooping below and clipping past the input edge. */
+   shorter, so let top/bottom define the height (clearing the fixed h-[44px]
+   via height:auto) to keep the icon centered and prevent the mic from drooping
+   below and clipping past the input edge. */
 body.condensed [data-slot='composer-input-trailing'] {
-  height: 100% !important;
   top: 0 !important;
   bottom: 0 !important;
+  height: auto !important;
 }
 
 /* Send button – smaller */

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -5903,6 +5903,16 @@ body.condensed [data-slot='composer-input'] {
   border-radius: 1rem !important;
 }
 
+/* Trailing slot (e.g. record/mic button) – the standard view hard-codes a
+   44px height to match the comfortable textarea. In condensed the input row is
+   shorter, so track the wrapper height instead and keep the icon centered to
+   prevent the mic from drooping below and clipping past the input edge. */
+body.condensed [data-slot='composer-input-trailing'] {
+  height: 100% !important;
+  top: 0 !important;
+  bottom: 0 !important;
+}
+
 /* Send button – smaller */
 body.condensed [data-slot='composer-send-button'] {
   padding: 0.25rem !important;


### PR DESCRIPTION
##Condensed view
<img width="835" height="556" alt="image" src="https://github.com/user-attachments/assets/add22ee7-ad1d-4941-8c4a-6472873639ce" />


- base.css: reorder @source below @import lines so Storybook's Vite/ postcss-import pipeline no longer drops the local @import rules (condensed-view, datavis-dark, datavis-overrides were silently absent in Storybook; dist build via @tailwindcss/cli was unaffected).
- condensed-view.css: re-center the composer trailing slot (mic button) in condensed mode; the standard view hard-codes a 44px height that left the mic drooping/clipping in the shorter condensed input row.
- RecordButton.tsx: give icon SVGs intrinsic width/height so they render at the correct size even when a consumer's Tailwind build lacks the size-* utilities.