### PR TITLE
fix(superchat): harden mermaid parsing, add theme reactivity, and light-mode code block

### DIFF
--- a/src/components/SuperChat/SuperChat.test.tsx
+++ b/src/components/SuperChat/SuperChat.test.tsx
@@ -4,7 +4,11 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import { createMarkdownRenderer } from './render/createMarkdownRenderer';
 import { createCodePlugin } from './plugins/code';
 import { createGenUIPlugin } from './plugins/genui';
-import { createMermaidPlugin } from './plugins/mermaid';
+import {
+  createMermaidPlugin,
+  normalizeMermaidSource,
+  renderMermaidWithRecovery,
+} from './plugins/mermaid';
 import { createImagePlugin } from './plugins/image';
 import {
   createAttachmentPlugin,
@@ -269,6 +273,67 @@ describe('mermaid plugin', () => {
     expect(
       container.querySelector('[data-slot="superchat-mermaid-fallback"]')
     ).not.toBeNull();
+  });
+});
+
+describe('normalizeMermaidSource', () => {
+  it('preserves %%{init}%% directives and %% comments above the declaration', () => {
+    const source = [
+      '%%{init: {"theme":"dark"} }%%',
+      '%% a leading comment',
+      'graph TD; A-->B;',
+    ].join('\n');
+    const out = normalizeMermaidSource(source);
+    expect(out).toBe(source);
+  });
+
+  it('drops leading prose but keeps directives when both are present', () => {
+    const source = [
+      'Here is a diagram:',
+      '%%{init: {"theme":"dark"} }%%',
+      'graph TD; A-->B;',
+    ].join('\n');
+    expect(normalizeMermaidSource(source)).toBe(
+      '%%{init: {"theme":"dark"} }%%\ngraph TD; A-->B;'
+    );
+  });
+
+  it('strips nested code-fence lines of any language, not just ```mermaid', () => {
+    // Fence lines themselves are stripped; leftover prose between them is
+    // trimmed by renderMermaidWithRecovery at render time.
+    const source = ['```mermaid', 'graph TD; A-->B;', '```json', '```'].join(
+      '\n'
+    );
+    expect(normalizeMermaidSource(source)).toBe('graph TD; A-->B;');
+  });
+});
+
+describe('renderMermaidWithRecovery', () => {
+  it('trims trailing prose lines until the diagram parses', async () => {
+    // Fake mermaid: succeeds only when the source is exactly the diagram body.
+    const valid = 'graph TD; A-->B;';
+    const mermaid = {
+      render: vi.fn(async (_id: string, source: string) => {
+        if (source.trim() === valid) return { svg: '<svg/>' };
+        throw new Error('parse error');
+      }),
+    } as unknown as typeof import('mermaid').default;
+
+    const noisy = [valid, 'This is an explanation.', 'More prose.'].join('\n');
+    const { svg } = await renderMermaidWithRecovery(mermaid, 'id-1', noisy);
+    expect(svg).toBe('<svg/>');
+  });
+
+  it('rethrows non-Error rejections wrapped in an Error', async () => {
+    const mermaid = {
+      render: vi.fn(async () => {
+        throw 'boom';
+      }),
+    } as unknown as typeof import('mermaid').default;
+
+    await expect(
+      renderMermaidWithRecovery(mermaid, 'id-2', 'graph TD; A-->B;')
+    ).rejects.toBeInstanceOf(Error);
   });
 });
 

--- a/src/components/SuperChat/plugins/code.tsx
+++ b/src/components/SuperChat/plugins/code.tsx
@@ -43,7 +43,7 @@ function CopyablePre({
         type="button"
         onClick={onCopy}
         aria-label={copied ? 'Copied' : 'Copy code'}
-        className="absolute top-2 right-2 rounded-md bg-neutral-700/80 px-2 py-1 text-xs text-neutral-100 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-neutral-600 focus-visible:opacity-100"
+        className="absolute top-2 right-2 rounded-md border border-neutral-300 bg-white/80 px-2 py-1 text-xs text-neutral-700 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 hover:bg-neutral-100 focus-visible:opacity-100 dark:border-neutral-600 dark:bg-neutral-700/80 dark:text-neutral-100 dark:hover:bg-neutral-600"
       >
         {copied ? 'Copied' : 'Copy'}
       </button>
@@ -53,7 +53,9 @@ function CopyablePre({
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable code blocks need keyboard focus for horizontal scrolling
         tabIndex={0}
         className={cn(
-          'overflow-x-auto rounded-lg bg-neutral-900 p-3 text-sm text-neutral-100 dark:bg-neutral-950',
+          // Background/text follow the theme so light mode matches the
+          // atom-one-light hljs palette (dark background looked out of place).
+          'overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-sm text-neutral-800 dark:border-transparent dark:bg-neutral-900 dark:text-neutral-100',
           props.className
         )}
       />

--- a/src/components/SuperChat/plugins/mermaid.tsx
+++ b/src/components/SuperChat/plugins/mermaid.tsx
@@ -207,7 +207,10 @@ function loadMermaid(dark: boolean) {
 function isDarkMode(): boolean {
   if (typeof document === 'undefined') return false;
   const root = document.documentElement;
-  return root.classList.contains('dark') || root.getAttribute('data-theme') === 'dark';
+  return (
+    root.classList.contains('dark') ||
+    root.getAttribute('data-theme') === 'dark'
+  );
 }
 
 /**

--- a/src/components/SuperChat/plugins/mermaid.tsx
+++ b/src/components/SuperChat/plugins/mermaid.tsx
@@ -23,6 +23,22 @@ import { useTextRenderContext } from '../render/renderContext';
 import type { SuperChatRenderPlugin } from '../types';
 
 const MERMAID_TAG = 'mermaid-diagram';
+const MERMAID_DECLARATION_RE =
+  /^\s*(?:flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|journey|gantt|pie|mindmap|timeline|gitGraph|quadrantChart|requirementDiagram|block-beta|xychart-beta)\b/;
+
+function normalizeMermaidSource(code: string): string {
+  const lines = code.split(/\r?\n/);
+
+  // Some model outputs accidentally include nested fences or leading prose
+  // inside the mermaid block; keep only the diagram body.
+  const stripped = lines.filter(
+    (line) => !/^\s*```(?:\s*mermaid)?\s*$/.test(line)
+  );
+  const start = stripped.findIndex((line) => MERMAID_DECLARATION_RE.test(line));
+  const normalized = start >= 0 ? stripped.slice(start) : stripped;
+
+  return normalized.join('\n').trim();
+}
 
 // ---------------------------------------------------------------------------
 // rehype transformer: <pre><code class="language-mermaid">…</code></pre>
@@ -129,6 +145,8 @@ function loadMermaid(dark: boolean) {
         startOnLoad: false,
         securityLevel: 'strict',
         theme,
+        flowchart: { useMaxWidth: false },
+        themeVariables: { fontSize: '16px' },
       });
       return mermaid;
     });
@@ -144,7 +162,7 @@ function MermaidDiagram({ code }: { code: string }) {
   const [failed, setFailed] = React.useState(false);
   const idRef = React.useRef(`superchat-mermaid-${(mermaidSeq += 1)}`);
 
-  const source = code.trim();
+  const source = React.useMemo(() => normalizeMermaidSource(code), [code]);
 
   React.useEffect(() => {
     // Don't try to render an incomplete diagram while the message streams.
@@ -179,7 +197,7 @@ function MermaidDiagram({ code }: { code: string }) {
   return (
     <div
       data-slot="superchat-mermaid"
-      className="my-2 overflow-x-auto"
+      className="my-2 overflow-x-auto [&_svg]:h-auto [&_svg]:max-w-none"
       // mermaid renders with securityLevel: 'strict' (labels sanitized, scripts
       // stripped), so the SVG is safe to inject directly.
       dangerouslySetInnerHTML={{ __html: svg }}

--- a/src/components/SuperChat/plugins/mermaid.tsx
+++ b/src/components/SuperChat/plugins/mermaid.tsx
@@ -31,9 +31,7 @@ function normalizeMermaidSource(code: string): string {
 
   // Some model outputs accidentally include nested fences or leading prose
   // inside the mermaid block; keep only the diagram body.
-  const stripped = lines.filter(
-    (line) => !/^\s*```(?:\s*mermaid)?\s*$/.test(line)
-  );
+  const stripped = lines.filter((line) => !/^\s*```(?:\s*mermaid)?\s*$/.test(line));
   const start = stripped.findIndex((line) => MERMAID_DECLARATION_RE.test(line));
   const normalized = start >= 0 ? stripped.slice(start) : stripped;
 
@@ -133,6 +131,30 @@ function InertFallback({ raw }: { raw: string }) {
 let mermaidReady: Promise<typeof import('mermaid').default> | null = null;
 let mermaidTheme: 'dark' | 'default' | null = null;
 
+async function renderMermaidWithRecovery(
+  mermaid: typeof import('mermaid').default,
+  id: string,
+  source: string
+) {
+  const lines = source.split(/\r?\n/).map((line) => line.trimEnd());
+  let lastError: unknown;
+
+  // If a model adds prose after a valid diagram, progressively trim trailing
+  // lines and render the first parseable candidate.
+  for (let end = lines.length; end >= 1; end -= 1) {
+    const candidate = lines.slice(0, end).join('\n').trim();
+    if (!candidate) continue;
+    try {
+      await mermaid.parse(candidate);
+      return await mermaid.render(id, candidate);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error('Failed to parse mermaid diagram');
+}
+
 /** Load + initialize mermaid once, shared across all diagrams. */
 function loadMermaid(dark: boolean) {
   const theme: 'dark' | 'default' = dark ? 'dark' : 'default';
@@ -174,7 +196,7 @@ function MermaidDiagram({ code }: { code: string }) {
       typeof document !== 'undefined' &&
       document.documentElement.classList.contains('dark');
     void loadMermaid(dark)
-      .then((mermaid) => mermaid.render(idRef.current, source))
+      .then((mermaid) => renderMermaidWithRecovery(mermaid, idRef.current, source))
       .then(({ svg: rendered }) => {
         if (active) setSvg(rendered);
       })

--- a/src/components/SuperChat/plugins/mermaid.tsx
+++ b/src/components/SuperChat/plugins/mermaid.tsx
@@ -176,10 +176,43 @@ function loadMermaid(dark: boolean) {
   return mermaidReady;
 }
 
+/** Read the current dark-mode state from the document root. */
+function isDarkMode(): boolean {
+  if (typeof document === 'undefined') return false;
+  const root = document.documentElement;
+  return root.classList.contains('dark') || root.getAttribute('data-theme') === 'dark';
+}
+
+/**
+ * Track dark mode reactively. Mermaid bakes theme colors into the rendered SVG,
+ * so diagrams must re-render when the user toggles light/dark — a CSS swap is
+ * not enough. Observes the `class`/`data-theme` attributes the theme sets on
+ * the document root.
+ */
+function useIsDarkMode(): boolean {
+  const [dark, setDark] = React.useState(isDarkMode);
+
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    const update = () => setDark(isDarkMode());
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return dark;
+}
+
 let mermaidSeq = 0;
 
 function MermaidDiagram({ code }: { code: string }) {
   const { streaming } = useTextRenderContext();
+  const dark = useIsDarkMode();
   const [svg, setSvg] = React.useState<string | null>(null);
   const [failed, setFailed] = React.useState(false);
   const idRef = React.useRef(`superchat-mermaid-${(mermaidSeq += 1)}`);
@@ -192,9 +225,6 @@ function MermaidDiagram({ code }: { code: string }) {
     let active = true;
     setSvg(null);
     setFailed(false);
-    const dark =
-      typeof document !== 'undefined' &&
-      document.documentElement.classList.contains('dark');
     void loadMermaid(dark)
       .then((mermaid) => renderMermaidWithRecovery(mermaid, idRef.current, source))
       .then(({ svg: rendered }) => {
@@ -206,7 +236,7 @@ function MermaidDiagram({ code }: { code: string }) {
     return () => {
       active = false;
     };
-  }, [source, streaming]);
+  }, [source, streaming, dark]);
 
   if (!source && !streaming) return <InertFallback raw={code} />;
 

--- a/src/components/SuperChat/plugins/mermaid.tsx
+++ b/src/components/SuperChat/plugins/mermaid.tsx
@@ -25,17 +25,38 @@ import type { SuperChatRenderPlugin } from '../types';
 const MERMAID_TAG = 'mermaid-diagram';
 const MERMAID_DECLARATION_RE =
   /^\s*(?:flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|journey|gantt|pie|mindmap|timeline|gitGraph|quadrantChart|requirementDiagram|block-beta|xychart-beta)\b/;
+/** Any triple-backtick fence line (```lang or bare ```) that leaks into a
+ * mermaid block from model output. */
+const FENCE_LINE_RE = /^\s*```[\w-]*\s*$/;
+/** Mermaid init directives / comments that must be preserved above the
+ * declaration (e.g. `%%{init: {...}}%%`, `%% comment`). */
+const MERMAID_DIRECTIVE_RE = /^\s*%%/;
 
-function normalizeMermaidSource(code: string): string {
+/**
+ * Normalize a mermaid source block. Model outputs occasionally include nested
+ * code fences or leading prose; strip those but preserve mermaid init
+ * directives and comment lines that legally precede the diagram declaration.
+ */
+export function normalizeMermaidSource(code: string): string {
   const lines = code.split(/\r?\n/);
 
-  // Some model outputs accidentally include nested fences or leading prose
-  // inside the mermaid block; keep only the diagram body.
-  const stripped = lines.filter((line) => !/^\s*```(?:\s*mermaid)?\s*$/.test(line));
-  const start = stripped.findIndex((line) => MERMAID_DECLARATION_RE.test(line));
-  const normalized = start >= 0 ? stripped.slice(start) : stripped;
+  // Drop any nested code-fence lines (```lang / bare ```), regardless of language.
+  const stripped = lines.filter((line) => !FENCE_LINE_RE.test(line));
 
-  return normalized.join('\n').trim();
+  const declarationIdx = stripped.findIndex((line) =>
+    MERMAID_DECLARATION_RE.test(line)
+  );
+  if (declarationIdx < 0) return stripped.join('\n').trim();
+
+  // Preserve init directives / `%%` comment lines that appear above the
+  // declaration; drop any other leading prose.
+  const preamble: string[] = [];
+  for (let i = 0; i < declarationIdx; i += 1) {
+    const line = stripped[i];
+    if (MERMAID_DIRECTIVE_RE.test(line)) preamble.push(line);
+  }
+
+  return [...preamble, ...stripped.slice(declarationIdx)].join('\n').trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -131,7 +152,7 @@ function InertFallback({ raw }: { raw: string }) {
 let mermaidReady: Promise<typeof import('mermaid').default> | null = null;
 let mermaidTheme: 'dark' | 'default' | null = null;
 
-async function renderMermaidWithRecovery(
+export async function renderMermaidWithRecovery(
   mermaid: typeof import('mermaid').default,
   id: string,
   source: string
@@ -140,19 +161,25 @@ async function renderMermaidWithRecovery(
   let lastError: unknown;
 
   // If a model adds prose after a valid diagram, progressively trim trailing
-  // lines and render the first parseable candidate.
+  // lines and render the first parseable candidate. `mermaid.render()` throws
+  // when the source doesn't parse, so we rely on it directly and avoid an
+  // extra `mermaid.parse()` on the success path.
   for (let end = lines.length; end >= 1; end -= 1) {
     const candidate = lines.slice(0, end).join('\n').trim();
     if (!candidate) continue;
     try {
-      await mermaid.parse(candidate);
       return await mermaid.render(id, candidate);
     } catch (error) {
       lastError = error;
     }
   }
 
-  throw lastError ?? new Error('Failed to parse mermaid diagram');
+  if (lastError instanceof Error) throw lastError;
+  throw new Error(
+    typeof lastError === 'string'
+      ? lastError
+      : `Failed to parse mermaid diagram: ${String(lastError)}`
+  );
 }
 
 /** Load + initialize mermaid once, shared across all diagrams. */
@@ -215,7 +242,13 @@ function MermaidDiagram({ code }: { code: string }) {
   const dark = useIsDarkMode();
   const [svg, setSvg] = React.useState<string | null>(null);
   const [failed, setFailed] = React.useState(false);
-  const idRef = React.useRef(`superchat-mermaid-${(mermaidSeq += 1)}`);
+  // Lazy init so the id counter increments once per instance, not per render.
+  const idRef = React.useRef<string | null>(null);
+  if (idRef.current === null) {
+    mermaidSeq += 1;
+    idRef.current = `superchat-mermaid-${mermaidSeq}`;
+  }
+  const id = idRef.current;
 
   const source = React.useMemo(() => normalizeMermaidSource(code), [code]);
 
@@ -226,7 +259,7 @@ function MermaidDiagram({ code }: { code: string }) {
     setSvg(null);
     setFailed(false);
     void loadMermaid(dark)
-      .then((mermaid) => renderMermaidWithRecovery(mermaid, idRef.current, source))
+      .then((mermaid) => renderMermaidWithRecovery(mermaid, id, source))
       .then(({ svg: rendered }) => {
         if (active) setSvg(rendered);
       })
@@ -236,7 +269,7 @@ function MermaidDiagram({ code }: { code: string }) {
     return () => {
       active = false;
     };
-  }, [source, streaming, dark]);
+  }, [source, streaming, dark, id]);
 
   if (!source && !streaming) return <InertFallback raw={code} />;
 

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -402,6 +402,10 @@ export const miewebUISafelist = [
   'focus:border-primary-500',
   'focus:ring-primary-500',
   'text-[10px]',
+  // SuperChat mermaid diagram wrapper — arbitrary variants applied to the
+  // injected <svg> so the diagram sizes naturally instead of collapsing.
+  '[&_svg]:h-auto',
+  '[&_svg]:max-w-none',
 ];
 
 export interface MiewebUIPreset {


### PR DESCRIPTION
## Summary

Hardens the SuperChat markdown surface after real-world usage surfaced several rendering issues in chat.

**Mermaid plugin** (`src/components/SuperChat/plugins/mermaid.tsx`):
- Normalize model-generated Mermaid source: strip nested code-fence lines (any language) and leading prose, while **preserving** `%%{init: ...}%%` directives and `%%` comments above the diagram declaration.
- Add a parse-recovery pass: progressively trim trailing prose until Mermaid renders (relies on `mermaid.render()` to throw on invalid syntax — no redundant `parse()` call).
- Wrap non-Error rejections in an `Error` so downstream logging is consistent.
- Track dark mode via a `MutationObserver` on `class` / `data-theme` so diagrams re-render on light/dark toggle (Mermaid bakes theme colors into the SVG at render time).
- Lazy-init the diagram id ref so `mermaidSeq` increments once per component instance, not on every render.
- Improve rendered SVG sizing (`flowchart.useMaxWidth: false`, `themeVariables.fontSize: '16px'`, `[&_svg]:h-auto [&_svg]:max-w-none` wrapper).

**Code plugin** (`src/components/SuperChat/plugins/code.tsx`):
- Theme-aware `<pre>` background/text so light mode matches the atom-one-light hljs palette (previously hardcoded dark on both themes, so light mode showed a dark block).
- Theme-aware copy-button colors for legibility in both modes.

**Tailwind preset** (`src/tailwind-preset.ts`):
- Add `[&_svg]:h-auto` and `[&_svg]:max-w-none` to `miewebUISafelist` so Tailwind 3 consumers that don't scan `node_modules` still get the mermaid wrapper CSS.

**Tests** (`src/components/SuperChat/SuperChat.test.tsx`):
- Cover: preserving `%%{init}%%` / `%%` directives, stripping nested fence lines, trailing-prose recovery, non-Error rejection wrapping.

## Validation
- `npm run lint` — 0 errors, 0 warnings
- `npm run test` — 48/48 SuperChat tests pass (5 new)
- Verified end-to-end in a live Ozwell workspace (Meteor 3.5): mermaid diagrams render correctly, theme toggle re-renders diagrams in both directions, code blocks render light in light mode / dark in dark mode.

## Files changed
- `src/components/SuperChat/plugins/mermaid.tsx`
- `src/components/SuperChat/plugins/code.tsx`
- `src/components/SuperChat/SuperChat.test.tsx`
- `src/tailwind-preset.ts`