### PR TITLE
fix(release): restore npm@latest upgrade for tokenless OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # Node 22 (Maintenance LTS as of 2026). Node 20 is deprecated on
-          # GitHub runners, so we run on a current supported LTS and use its
-          # bundled npm (already supports --provenance / OIDC publishing).
-          # 22 over 24 (Active LTS) as a conservative, supported floor.
+          # GitHub runners; npm@latest (>=12, installed below) also requires
+          # Node >=22. 22 over 24 (Active LTS) as a conservative floor.
           node-version: '22'
           check-latest: true
           cache: 'pnpm'
@@ -46,6 +45,15 @@ jobs:
           node -v
           npm -v
           pnpm -v
+
+      # npm's bundled version on Node 22 (10.x) cannot do tokenless OIDC
+      # Trusted Publishing; that needs npm >=11.5.1. Upgrade to npm@latest
+      # so the tokenless `npm publish --provenance` step below can authenticate.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Show npm version after upgrade
+        run: npm -v
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

Follow-up to #304. That PR fixed the **install-time** failure (npm 12 won't install on Node 20 → bumped to Node 22) but I also removed the `Upgrade npm` step, assuming it was dead weight. It wasn't.

Release run **#162** (first run on the Node 22 config) got all the way to **`Publish to npm`** and failed there. `@next` is still stuck at `0.6.1-dev.159`.

Root cause:
- The publish step has **no `NODE_AUTH_TOKEN`** and the job sets `id-token: write`, so it publishes via **tokenless npm OIDC Trusted Publishing**.
- Tokenless trusted publishing requires **npm >= 11.5.1**.
- Node 22 ships **npm 10.9**, which supports `--provenance` but **not** tokenless trusted publishing → auth failure.
- Run #159 only succeeded because its (now-removed) `Upgrade npm` step pulled npm 11.x.

## Fix

Re-add the `Upgrade npm` step. The correct config needs **both** changes together:

| | Node | npm | Installs? | Tokenless OIDC publish? |
|---|---|---|---|---|
| Original (#160/#161) | 20 | upgrade→12 | ❌ npm 12 needs Node ≥22 | — |
| #304 (run #162) | 22 | bundled 10.9 | ✅ | ❌ needs npm ≥11.5.1 |
| **This PR** | 22 | upgrade→12 | ✅ | ✅ |

npm 12 installs cleanly on Node 22 and restores OIDC auth; Node 22 is still required because npm 12 dropped Node 20.

## Scope / risk

- **CI-only** — one file, `.github/workflows/release.yml`. No `src/`, deps, build config, or exports. Cannot regress any consuming app.

## After merge

Merging to `main` triggers the Release workflow; the publish step should now authenticate via OIDC and push `0.6.1-dev.163`+ to `@next`.