### PR TITLE
fix(release): use Node 24 bundled npm for OIDC publish, drop global npm upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # Node 22 (Maintenance LTS as of 2026). Node 20 is deprecated on
-          # GitHub runners; npm@latest (>=12, installed below) also requires
-          # Node >=22. 22 over 24 (Active LTS) as a conservative floor.
-          node-version: '22'
+          # Node 24 (Active LTS "Krypton"). Its BUNDLED npm is 11.x (>=11.5.1),
+          # which supports tokenless OIDC Trusted Publishing for the provenance
+          # publish step below. Using the bundled npm (rather than a global
+          # `npm install -g npm@latest`) keeps npm's dependency tree intact —
+          # the global upgrade on the runner produced a broken tree missing
+          # `sigstore`, which broke `npm publish --provenance`.
+          node-version: '24'
           check-latest: true
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
@@ -45,15 +48,6 @@ jobs:
           node -v
           npm -v
           pnpm -v
-
-      # npm's bundled version on Node 22 (10.x) cannot do tokenless OIDC
-      # Trusted Publishing; that needs npm >=11.5.1. Upgrade to npm@latest
-      # so the tokenless `npm publish --provenance` step below can authenticate.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-
-      - name: Show npm version after upgrade
-        run: npm -v
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

Third in the series (#304 → #305 → this). Run **#163** (first on the Node 22 + `npm install -g npm@latest` config from #305) finally reached **`Publish to npm`** and produced a *new* error:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error Require stack:
npm error - .../npm/node_modules/libnpmpublish/lib/provenance.js
```

npm 12 *did* install (the version-check steps passed), but globally upgrading npm on the runner's hostedtoolcache left a **broken dependency tree** — the bundled `sigstore` module (needed by `--provenance`) was missing. This is a known fragility of `npm install -g npm@latest` on top of the preinstalled npm.

## Fix

Stop upgrading npm globally. Instead pick a **Node version whose bundled npm already meets our needs**:

- Switch `node-version` **22 → 24** (Active LTS "Krypton").
- **Remove** the `Upgrade npm` step entirely.

Node 24's bundled npm is **11.x** (24.18.0 → npm 11.16.0; every 24.7.0+ ships npm ≥ 11.5.1), which:
- ✅ supports **tokenless OIDC Trusted Publishing** (needs npm ≥ 11.5.1), and
- ✅ has an **intact dependency tree** (sigstore present) because it's the bundled npm, not a re-installed one.

One change satisfies both constraints that tripped up the previous two attempts.

### Full history

| | Node | npm | Install | OIDC publish | provenance/sigstore |
|---|---|---|---|---|---|
| #160/#161 | 20 | `-g` → 12 | ❌ needs Node ≥22 | — | — |
| #304 (run #162) | 22 | bundled 10.9 | ✅ | ❌ needs ≥11.5.1 | — |
| #305 (run #163) | 22 | `-g` → 12 | ✅ | ✅ | ❌ broken tree, no sigstore |
| **This PR** | 24 | bundled 11.16 | ✅ | ✅ | ✅ |

## Scope / risk

- **CI-only** — one file, `.github/workflows/release.yml` (+7/−13; the fragile global-upgrade step is deleted). No `src/`, deps, or exports touched.

## After merge

Merge to `main` triggers the Release workflow; the publish step should authenticate via OIDC with a healthy npm and land `0.6.1-dev.<run#>` on `@next`.