### PR TITLE
Add composer model selector

### DIFF
--- a/src/components/AI/ComposerModelSelector.stories.tsx
+++ b/src/components/AI/ComposerModelSelector.stories.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  ComposerModelSelector,
+  type ProviderModelOption,
+  type ProviderModelValue,
+} from './ComposerModelSelector';
+
+const oneProviderModels: ProviderModelOption[] = [
+  { provider: 'openai', providerLabel: 'OpenAI', model: 'gpt-5-mini' },
+  { provider: 'openai', providerLabel: 'OpenAI', model: 'gpt-5' },
+  {
+    provider: 'openai',
+    providerLabel: 'OpenAI',
+    model: 'gpt-5-chat-latest',
+  },
+];
+
+const multiProviderModels: ProviderModelOption[] = [
+  { provider: 'openai', providerLabel: 'OpenAI', model: 'gpt-5-mini' },
+  { provider: 'openai', providerLabel: 'OpenAI', model: 'gpt-5' },
+  {
+    provider: 'anthropic',
+    providerLabel: 'Anthropic',
+    model: 'claude-sonnet-4-5',
+  },
+  {
+    provider: 'anthropic',
+    providerLabel: 'Anthropic',
+    model: 'claude-opus-4-1',
+  },
+  { provider: 'ollama', providerLabel: 'Ollama', model: 'llama3.1:8b' },
+  {
+    provider: 'ollama',
+    providerLabel: 'Ollama',
+    model: 'qwen2.5-coder:14b',
+  },
+];
+
+const longNameModels: ProviderModelOption[] = [
+  {
+    provider: 'openai',
+    providerLabel: 'OpenAI',
+    model: 'gpt-5-very-long-internal-routing-name-for-widget-overflow-testing',
+    label: 'GPT-5 very long internal routing name for widget overflow testing',
+  },
+  {
+    provider: 'anthropic',
+    providerLabel: 'Anthropic',
+    model: 'claude-sonnet-4-5-20260720-extra-long-stable-alias',
+    label: 'Claude Sonnet 4.5 20260720 extra long stable alias',
+  },
+  {
+    provider: 'ollama',
+    providerLabel: 'Ollama',
+    model: 'local-qwen2.5-coder-with-a-very-long-quantized-model-suffix:14b-q6',
+  },
+];
+
+function SelectorDemo({
+  models,
+  boundaryRef,
+}: {
+  models: ProviderModelOption[];
+  boundaryRef?: React.RefObject<HTMLDivElement | null>;
+}) {
+  const [value, setValue] = React.useState<ProviderModelValue | null>(
+    models[0] ?? null
+  );
+  const [providerFilter, setProviderFilter] = React.useState<string | 'any'>(
+    'any'
+  );
+
+  return (
+    <ComposerModelSelector
+      models={models}
+      value={value}
+      providerFilter={providerFilter}
+      onProviderFilterChange={setProviderFilter}
+      onChange={setValue}
+      boundaryRef={boundaryRef}
+    />
+  );
+}
+
+function ConstrainedContainerDemo() {
+  const boundaryRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <div
+      ref={boundaryRef}
+      className="border-border bg-background flex h-64 w-80 flex-col justify-end overflow-hidden rounded-lg border p-3 shadow-sm"
+    >
+      <div className="border-border bg-card rounded-lg border p-2">
+        <SelectorDemo models={multiProviderModels} boundaryRef={boundaryRef} />
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Product/Feature Modules/AI/ComposerModelSelector',
+  component: ComposerModelSelector,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ComposerModelSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OneProvider: Story = {
+  render: () => <SelectorDemo models={oneProviderModels} />,
+};
+
+export const MultipleProviders: Story = {
+  render: () => <SelectorDemo models={multiProviderModels} />,
+};
+
+export const LongOverflowNames: Story = {
+  render: () => (
+    <div className="w-72">
+      <SelectorDemo models={longNameModels} />
+    </div>
+  ),
+};
+
+export const ConstrainedContainer: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => <ConstrainedContainerDemo />,
+};

--- a/src/components/AI/ComposerModelSelector.stories.tsx
+++ b/src/components/AI/ComposerModelSelector.stories.tsx
@@ -68,6 +68,9 @@ type ModelsKey = keyof typeof modelSets;
 type ComposerModelSelectorStoryArgs = {
   modelsKey: ModelsKey;
   placeholder?: string;
+  anyLabel?: string;
+  emptyLabel?: string;
+  ariaLabel?: string;
   disabled?: boolean;
   className?: string;
 };
@@ -82,6 +85,9 @@ function SelectorDemo({
   boundaryRef,
   disabled,
   placeholder,
+  anyLabel,
+  emptyLabel,
+  ariaLabel,
   className,
 }: SelectorDemoProps) {
   const [value, setValue] = React.useState<ProviderModelValue | null>(
@@ -118,6 +124,9 @@ function SelectorDemo({
       boundaryRef={boundaryRef}
       disabled={disabled}
       placeholder={placeholder}
+      anyLabel={anyLabel}
+      emptyLabel={emptyLabel}
+      ariaLabel={ariaLabel}
       className={className}
     />
   );
@@ -127,6 +136,9 @@ function ConstrainedContainerDemo({
   modelsKey,
   disabled,
   placeholder,
+  anyLabel,
+  emptyLabel,
+  ariaLabel,
   className,
 }: ComposerModelSelectorStoryArgs) {
   const boundaryRef = React.useRef<HTMLDivElement>(null);
@@ -143,6 +155,9 @@ function ConstrainedContainerDemo({
           boundaryRef={boundaryRef}
           disabled={disabled}
           placeholder={placeholder}
+          anyLabel={anyLabel}
+          emptyLabel={emptyLabel}
+          ariaLabel={ariaLabel}
           className={className}
         />
       </div>
@@ -154,6 +169,9 @@ function ComposerModelSelectorStoryDemo({
   modelsKey,
   disabled,
   placeholder,
+  anyLabel,
+  emptyLabel,
+  ariaLabel,
   className,
 }: ComposerModelSelectorStoryArgs) {
   return (
@@ -161,6 +179,9 @@ function ComposerModelSelectorStoryDemo({
       models={modelSets[modelsKey]}
       disabled={disabled}
       placeholder={placeholder}
+      anyLabel={anyLabel}
+      emptyLabel={emptyLabel}
+      ariaLabel={ariaLabel}
       className={className}
     />
   );
@@ -192,6 +213,27 @@ const meta = {
       control: 'text',
       description: 'Text shown when no model is selected.',
     },
+    anyLabel: {
+      control: 'text',
+      description: 'Provider filter label for the unfiltered state.',
+      table: {
+        defaultValue: { summary: 'Any' },
+      },
+    },
+    emptyLabel: {
+      control: 'text',
+      description: 'Text shown when the current filter has no models.',
+      table: {
+        defaultValue: { summary: 'No models' },
+      },
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Accessible label for the model listbox.',
+      table: {
+        defaultValue: { summary: 'Model' },
+      },
+    },
     disabled: {
       control: 'boolean',
       description: 'Disable the selector trigger.',
@@ -210,6 +252,9 @@ export const OneProvider: Story = {
   args: {
     modelsKey: 'oneProvider',
     placeholder: 'Model',
+    anyLabel: 'Any',
+    emptyLabel: 'No models',
+    ariaLabel: 'Model',
     disabled: false,
   },
 };
@@ -218,6 +263,9 @@ export const MultipleProviders: Story = {
   args: {
     modelsKey: 'multipleProviders',
     placeholder: 'Model',
+    anyLabel: 'Any',
+    emptyLabel: 'No models',
+    ariaLabel: 'Model',
     disabled: false,
   },
 };
@@ -226,6 +274,9 @@ export const LongOverflowNames: Story = {
   args: {
     modelsKey: 'longNames',
     placeholder: 'Model',
+    anyLabel: 'Any',
+    emptyLabel: 'No models',
+    ariaLabel: 'Model',
     disabled: false,
   },
   render: (args) => (
@@ -239,6 +290,9 @@ export const ConstrainedContainer: Story = {
   args: {
     modelsKey: 'multipleProviders',
     placeholder: 'Model',
+    anyLabel: 'Any',
+    emptyLabel: 'No models',
+    ariaLabel: 'Model',
     disabled: false,
   },
   parameters: {

--- a/src/components/AI/ComposerModelSelector.stories.tsx
+++ b/src/components/AI/ComposerModelSelector.stories.tsx
@@ -57,19 +57,56 @@ const longNameModels: ProviderModelOption[] = [
   },
 ];
 
+const modelSets = {
+  oneProvider: oneProviderModels,
+  multipleProviders: multiProviderModels,
+  longNames: longNameModels,
+};
+
+type ModelsKey = keyof typeof modelSets;
+
+type ComposerModelSelectorStoryArgs = {
+  modelsKey: ModelsKey;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+type SelectorDemoProps = Omit<ComposerModelSelectorStoryArgs, 'modelsKey'> & {
+  models: ProviderModelOption[];
+  boundaryRef?: React.RefObject<HTMLDivElement | null>;
+};
+
 function SelectorDemo({
   models,
   boundaryRef,
-}: {
-  models: ProviderModelOption[];
-  boundaryRef?: React.RefObject<HTMLDivElement | null>;
-}) {
+  disabled,
+  placeholder,
+  className,
+}: SelectorDemoProps) {
   const [value, setValue] = React.useState<ProviderModelValue | null>(
     models[0] ?? null
   );
-  const [providerFilter, setProviderFilter] = React.useState<string | 'any'>(
-    'any'
+  const [providerFilter, setProviderFilter] = React.useState<string | null>(
+    null
   );
+
+  React.useEffect(() => {
+    setValue((currentValue) => {
+      if (
+        currentValue &&
+        models.some(
+          (model) =>
+            model.provider === currentValue.provider &&
+            model.model === currentValue.model
+        )
+      ) {
+        return currentValue;
+      }
+
+      return models[0] ?? null;
+    });
+  }, [models]);
 
   return (
     <ComposerModelSelector
@@ -79,12 +116,21 @@ function SelectorDemo({
       onProviderFilterChange={setProviderFilter}
       onChange={setValue}
       boundaryRef={boundaryRef}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
     />
   );
 }
 
-function ConstrainedContainerDemo() {
+function ConstrainedContainerDemo({
+  modelsKey,
+  disabled,
+  placeholder,
+  className,
+}: ComposerModelSelectorStoryArgs) {
   const boundaryRef = React.useRef<HTMLDivElement>(null);
+  const models = modelSets[modelsKey];
 
   return (
     <div
@@ -92,43 +138,111 @@ function ConstrainedContainerDemo() {
       className="border-border bg-background flex h-64 w-80 flex-col justify-end overflow-hidden rounded-lg border p-3 shadow-sm"
     >
       <div className="border-border bg-card rounded-lg border p-2">
-        <SelectorDemo models={multiProviderModels} boundaryRef={boundaryRef} />
+        <SelectorDemo
+          models={models}
+          boundaryRef={boundaryRef}
+          disabled={disabled}
+          placeholder={placeholder}
+          className={className}
+        />
       </div>
     </div>
   );
 }
 
+function ComposerModelSelectorStoryDemo({
+  modelsKey,
+  disabled,
+  placeholder,
+  className,
+}: ComposerModelSelectorStoryArgs) {
+  return (
+    <SelectorDemo
+      models={modelSets[modelsKey]}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
 const meta = {
   title: 'Product/Feature Modules/AI/ComposerModelSelector',
-  component: ComposerModelSelector,
+  component: ComposerModelSelectorStoryDemo,
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'ComposerModelSelector is a compact provider-aware model picker for composer action rows. The host supplies provider/model rows and owns fetching, labels, and selection state.',
+      },
+    },
   },
-} satisfies Meta<typeof ComposerModelSelector>;
+  argTypes: {
+    modelsKey: {
+      control: 'select',
+      options: ['oneProvider', 'multipleProviders', 'longNames'],
+      description: 'Which sample provider/model dataset to display.',
+      table: {
+        defaultValue: { summary: 'multipleProviders' },
+      },
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Text shown when no model is selected.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disable the selector trigger.',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional classes applied to the selector trigger.',
+    },
+  },
+} satisfies Meta<typeof ComposerModelSelectorStoryDemo>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const OneProvider: Story = {
-  render: () => <SelectorDemo models={oneProviderModels} />,
+  args: {
+    modelsKey: 'oneProvider',
+    placeholder: 'Model',
+    disabled: false,
+  },
 };
 
 export const MultipleProviders: Story = {
-  render: () => <SelectorDemo models={multiProviderModels} />,
+  args: {
+    modelsKey: 'multipleProviders',
+    placeholder: 'Model',
+    disabled: false,
+  },
 };
 
 export const LongOverflowNames: Story = {
-  render: () => (
+  args: {
+    modelsKey: 'longNames',
+    placeholder: 'Model',
+    disabled: false,
+  },
+  render: (args) => (
     <div className="w-72">
-      <SelectorDemo models={longNameModels} />
+      <ComposerModelSelectorStoryDemo {...args} />
     </div>
   ),
 };
 
 export const ConstrainedContainer: Story = {
+  args: {
+    modelsKey: 'multipleProviders',
+    placeholder: 'Model',
+    disabled: false,
+  },
   parameters: {
     layout: 'centered',
   },
-  render: () => <ConstrainedContainerDemo />,
+  render: (args) => <ConstrainedContainerDemo {...args} />,
 };

--- a/src/components/AI/ComposerModelSelector.test.tsx
+++ b/src/components/AI/ComposerModelSelector.test.tsx
@@ -115,4 +115,39 @@ describe('ComposerModelSelector', () => {
       model: 'gpt-5',
     });
   });
+
+  it('highlights the selected model when opened', () => {
+    renderSelector({ value: models[1] });
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5/i }));
+
+    expect(screen.getByRole('listbox', { name: /model/i })).toHaveAttribute(
+      'aria-activedescendant',
+      expect.stringContaining('option-1')
+    );
+  });
+
+  it('allows caller-controlled labels', () => {
+    renderWithTheme(
+      <ComposerModelSelector
+        models={[]}
+        value={null}
+        onChange={vi.fn()}
+        placeholder="Choose model"
+        anyLabel="All providers"
+        emptyLabel="No available models"
+        ariaLabel="Model picker"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /choose model/i }));
+
+    expect(
+      screen.getByRole('listbox', { name: /model picker/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /all providers/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('No available models')).toBeInTheDocument();
+  });
 });

--- a/src/components/AI/ComposerModelSelector.test.tsx
+++ b/src/components/AI/ComposerModelSelector.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import {
+  ComposerModelSelector,
+  type ProviderModelOption,
+  type ProviderModelValue,
+} from './ComposerModelSelector';
+
+const models: ProviderModelOption[] = [
+  {
+    provider: 'openai',
+    providerLabel: 'OpenAI',
+    model: 'gpt-5-mini',
+    label: 'GPT-5 mini',
+  },
+  {
+    provider: 'openai',
+    providerLabel: 'OpenAI',
+    model: 'gpt-5',
+    label: 'GPT-5',
+  },
+  {
+    provider: 'anthropic',
+    providerLabel: 'Anthropic',
+    model: 'claude-sonnet-4-5',
+    label: 'Claude Sonnet 4.5',
+  },
+];
+
+function renderSelector(
+  props: Partial<{
+    value: ProviderModelValue | null;
+    onChange: (value: ProviderModelValue) => void;
+    providerFilter: string | null;
+    onProviderFilterChange: (provider: string | null) => void;
+  }> = {}
+) {
+  const baseProps = {
+    models,
+    value: props.value ?? models[0],
+    onChange: props.onChange ?? vi.fn(),
+  };
+
+  if (props.providerFilter !== undefined) {
+    return renderWithTheme(
+      <ComposerModelSelector
+        {...baseProps}
+        providerFilter={props.providerFilter}
+        onProviderFilterChange={props.onProviderFilterChange ?? vi.fn()}
+      />
+    );
+  }
+
+  return renderWithTheme(
+    <ComposerModelSelector
+      {...baseProps}
+      onProviderFilterChange={props.onProviderFilterChange}
+    />
+  );
+}
+
+describe('ComposerModelSelector', () => {
+  it('opens and closes via click', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5 mini/i }));
+    expect(screen.getByRole('listbox', { name: /model/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5 mini/i }));
+    expect(screen.queryByRole('listbox', { name: /model/i })).toBeNull();
+  });
+
+  it('closes on Escape', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5 mini/i }));
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox', { name: /model/i })).toBeNull();
+  });
+
+  it('closes on outside click', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5 mini/i }));
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByRole('listbox', { name: /model/i })).toBeNull();
+  });
+
+  it('filters visible models by provider', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5 mini/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Anthropic' }));
+
+    expect(
+      screen.getByRole('option', { name: /claude sonnet/i })
+    ).toBeVisible();
+    expect(screen.queryByRole('option', { name: /^gpt-5$/i })).toBeNull();
+  });
+
+  it('selects the highlighted model with arrow keys and Enter', () => {
+    const onChange = vi.fn();
+    renderSelector({ onChange });
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5 mini/i }));
+    const listbox = screen.getByRole('listbox', { name: /model/i });
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    fireEvent.keyDown(listbox, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith({
+      provider: 'openai',
+      model: 'gpt-5',
+    });
+  });
+});

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -59,8 +59,8 @@ function groupByProvider(models: ProviderModelOption[]) {
 
 function getProviderLabel(models: ProviderModelOption[], provider: string) {
   return (
-    models.find((model) => model.provider === provider)?.providerLabel ??
-    provider
+    models.find((model) => model.provider === provider && model.providerLabel)
+      ?.providerLabel ?? provider
   );
 }
 
@@ -146,9 +146,11 @@ export function ComposerModelSelector({
     [onProviderFilterChange, providerFilter]
   );
 
-  const close = React.useCallback(() => {
+  const close = React.useCallback((restoreFocus = true) => {
     setOpen(false);
-    triggerRef.current?.focus({ preventScroll: true });
+    if (restoreFocus) {
+      triggerRef.current?.focus({ preventScroll: true });
+    }
   }, []);
 
   const selectModel = React.useCallback(
@@ -177,8 +179,8 @@ export function ComposerModelSelector({
     const spaceAbove = rect.top - boundary.top - gap;
     const spaceBelow = boundary.bottom - rect.bottom - gap;
     const openAbove = spaceBelow < 260 && spaceAbove > spaceBelow;
-    const availableHeight = Math.max(openAbove ? spaceAbove : spaceBelow, 120);
-    const listMaxHeight = Math.max(Math.min(availableHeight - 49, 272), 72);
+    const availableHeight = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
+    const nextListMaxHeight = Math.max(Math.min(availableHeight - 49, 272), 0);
     const left = Math.min(
       Math.max(rect.left, boundary.left + 8),
       boundary.right - menuWidth - 8
@@ -188,12 +190,13 @@ export function ComposerModelSelector({
       position: 'fixed',
       left,
       width: menuWidth,
+      maxHeight: availableHeight,
       ...(openAbove
         ? { bottom: window.innerHeight - rect.top + gap }
         : { top: rect.bottom + gap }),
       zIndex: 9999,
     });
-    setListMaxHeight(listMaxHeight);
+    setListMaxHeight(nextListMaxHeight);
   }, [boundaryRef]);
 
   React.useEffect(() => {
@@ -221,7 +224,7 @@ export function ComposerModelSelector({
       ) {
         return;
       }
-      close();
+      close(false);
     };
 
     document.addEventListener('mousedown', handlePointerDown);

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -15,17 +15,28 @@ export type ProviderModelOption = ProviderModelValue & {
   id?: string;
 };
 
-export interface ComposerModelSelectorProps {
+type ComposerModelSelectorBaseProps = {
   models: ProviderModelOption[];
   value: ProviderModelValue | null;
-  providerFilter?: string | 'any';
-  onProviderFilterChange?: (provider: string | 'any') => void;
   onChange: (value: ProviderModelValue) => void;
   disabled?: boolean;
   className?: string;
   boundaryRef?: React.RefObject<HTMLElement | null>;
   placeholder?: string;
-}
+};
+
+type ControlledProviderFilterProps = {
+  providerFilter: string | 'any';
+  onProviderFilterChange: (provider: string | 'any') => void;
+};
+
+type UncontrolledProviderFilterProps = {
+  providerFilter?: undefined;
+  onProviderFilterChange?: (provider: string | 'any') => void;
+};
+
+export type ComposerModelSelectorProps = ComposerModelSelectorBaseProps &
+  (ControlledProviderFilterProps | UncontrolledProviderFilterProps);
 
 function optionKey(option: ProviderModelValue) {
   return `${option.provider}\u0000${option.model}`;
@@ -230,6 +241,13 @@ export function ComposerModelSelector({
 
   React.useEffect(() => {
     if (!open) return;
+    setHighlightedIndex((current) =>
+      Math.min(current, Math.max(renderedModels.length - 1, 0))
+    );
+  }, [open, renderedModels.length]);
+
+  React.useEffect(() => {
+    if (!open) return;
     requestAnimationFrame(() =>
       listRef.current?.focus({ preventScroll: true })
     );
@@ -266,7 +284,10 @@ export function ComposerModelSelector({
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      selectModel(renderedModels[highlightedIndex]);
+      const highlightedModel = renderedModels[highlightedIndex];
+      if (highlightedModel) {
+        selectModel(highlightedModel);
+      }
     }
   };
 

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -27,10 +27,6 @@ export interface ComposerModelSelectorProps {
   placeholder?: string;
 }
 
-type MenuStyle = React.CSSProperties & {
-  '--composer-model-list-max-height'?: string;
-};
-
 function optionKey(option: ProviderModelValue) {
   return `${option.provider}\u0000${option.model}`;
 }
@@ -72,12 +68,13 @@ export function ComposerModelSelector({
   const [internalProviderFilter, setInternalProviderFilter] =
     React.useState<string>('any');
   const [highlightedIndex, setHighlightedIndex] = React.useState(0);
-  const [menuStyle, setMenuStyle] = React.useState<MenuStyle>({});
+  const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
 
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
   const menuId = React.useId();
+  const [listMaxHeight, setListMaxHeight] = React.useState(272);
 
   const activeProviderFilter = providerFilter ?? internalProviderFilter;
   const selectedKey = value ? optionKey(value) : null;
@@ -108,6 +105,10 @@ export function ComposerModelSelector({
   const groupedModels = React.useMemo(
     () => groupByProvider(filteredModels),
     [filteredModels]
+  );
+  const renderedModels = React.useMemo(
+    () => groupedModels.flatMap((group) => group.options),
+    [groupedModels]
   );
 
   const setProvider = React.useCallback(
@@ -166,9 +167,9 @@ export function ComposerModelSelector({
       ...(openAbove
         ? { bottom: window.innerHeight - rect.top + gap }
         : { top: rect.bottom + gap }),
-      '--composer-model-list-max-height': `${listMaxHeight}px`,
       zIndex: 9999,
     });
+    setListMaxHeight(listMaxHeight);
   }, [boundaryRef]);
 
   React.useEffect(() => {
@@ -229,17 +230,17 @@ export function ComposerModelSelector({
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent) => {
-    if (filteredModels.length === 0) return;
+    if (renderedModels.length === 0) return;
 
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      setHighlightedIndex((current) => (current + 1) % filteredModels.length);
+      setHighlightedIndex((current) => (current + 1) % renderedModels.length);
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault();
       setHighlightedIndex(
         (current) =>
-          (current - 1 + filteredModels.length) % filteredModels.length
+          (current - 1 + renderedModels.length) % renderedModels.length
       );
     }
     if (event.key === 'Home') {
@@ -248,11 +249,11 @@ export function ComposerModelSelector({
     }
     if (event.key === 'End') {
       event.preventDefault();
-      setHighlightedIndex(filteredModels.length - 1);
+      setHighlightedIndex(renderedModels.length - 1);
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      selectModel(filteredModels[highlightedIndex]);
+      selectModel(renderedModels[highlightedIndex]);
     }
   };
 
@@ -335,7 +336,8 @@ export function ComposerModelSelector({
               aria-label="Model"
               tabIndex={-1}
               onKeyDown={handleMenuKeyDown}
-              className="max-h-[var(--composer-model-list-max-height)] overflow-y-auto p-1"
+              style={{ maxHeight: listMaxHeight }}
+              className="overflow-y-auto p-1"
             >
               {groupedModels.length === 0 ? (
                 <div className="text-muted-foreground px-3 py-4 text-center text-sm">
@@ -354,7 +356,7 @@ export function ComposerModelSelector({
                       {providerLabels.get(group.provider) ?? group.provider}
                     </div>
                     {group.options.map((model) => {
-                      const index = filteredModels.findIndex(
+                      const index = renderedModels.findIndex(
                         (item) => optionKey(item) === optionKey(model)
                       );
                       const selected = optionKey(model) === selectedKey;

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -1,0 +1,401 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { Check, ChevronDown } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
+
+export type ProviderModelValue = {
+  provider: string;
+  model: string;
+};
+
+export type ProviderModelOption = ProviderModelValue & {
+  label?: string;
+  providerLabel?: string;
+  id?: string;
+};
+
+export interface ComposerModelSelectorProps {
+  models: ProviderModelOption[];
+  value: ProviderModelValue | null;
+  providerFilter?: string | 'any';
+  onProviderFilterChange?: (provider: string | 'any') => void;
+  onChange: (value: ProviderModelValue) => void;
+  disabled?: boolean;
+  className?: string;
+  boundaryRef?: React.RefObject<HTMLElement | null>;
+  placeholder?: string;
+}
+
+type MenuStyle = React.CSSProperties & {
+  '--composer-model-list-max-height'?: string;
+};
+
+function optionKey(option: ProviderModelValue) {
+  return `${option.provider}\u0000${option.model}`;
+}
+
+function groupByProvider(models: ProviderModelOption[]) {
+  const groups = new Map<string, ProviderModelOption[]>();
+
+  for (const model of models) {
+    const group = groups.get(model.provider);
+    if (group) {
+      group.push(model);
+    } else {
+      groups.set(model.provider, [model]);
+    }
+  }
+
+  return Array.from(groups, ([provider, options]) => ({ provider, options }));
+}
+
+function getProviderLabel(models: ProviderModelOption[], provider: string) {
+  return (
+    models.find((model) => model.provider === provider)?.providerLabel ??
+    provider
+  );
+}
+
+export function ComposerModelSelector({
+  models,
+  value,
+  providerFilter,
+  onProviderFilterChange,
+  onChange,
+  disabled = false,
+  className,
+  boundaryRef,
+  placeholder = 'Model',
+}: ComposerModelSelectorProps) {
+  const [open, setOpen] = React.useState(false);
+  const [internalProviderFilter, setInternalProviderFilter] =
+    React.useState<string>('any');
+  const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+  const [menuStyle, setMenuStyle] = React.useState<MenuStyle>({});
+
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const menuId = React.useId();
+
+  const activeProviderFilter = providerFilter ?? internalProviderFilter;
+  const selectedKey = value ? optionKey(value) : null;
+  const selectedOption = models.find(
+    (model) => optionKey(model) === selectedKey
+  );
+  const providers = React.useMemo(
+    () => Array.from(new Set(models.map((model) => model.provider))),
+    [models]
+  );
+  const providerLabels = React.useMemo(
+    () =>
+      new Map(
+        providers.map((provider) => [
+          provider,
+          getProviderLabel(models, provider),
+        ])
+      ),
+    [models, providers]
+  );
+  const filteredModels = React.useMemo(
+    () =>
+      activeProviderFilter === 'any'
+        ? models
+        : models.filter((model) => model.provider === activeProviderFilter),
+    [activeProviderFilter, models]
+  );
+  const groupedModels = React.useMemo(
+    () => groupByProvider(filteredModels),
+    [filteredModels]
+  );
+
+  const setProvider = React.useCallback(
+    (provider: string | 'any') => {
+      if (providerFilter === undefined) {
+        setInternalProviderFilter(provider);
+      }
+      onProviderFilterChange?.(provider);
+      setHighlightedIndex(0);
+    },
+    [onProviderFilterChange, providerFilter]
+  );
+
+  const close = React.useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const selectModel = React.useCallback(
+    (model: ProviderModelOption) => {
+      onChange({ provider: model.provider, model: model.model });
+      close();
+    },
+    [close, onChange]
+  );
+
+  const updateMenuPosition = React.useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const rect = trigger.getBoundingClientRect();
+    const boundary = boundaryRef?.current?.getBoundingClientRect() ?? {
+      top: 0,
+      right: window.innerWidth,
+      bottom: window.innerHeight,
+      left: 0,
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+    const gap = 6;
+    const menuWidth = Math.min(320, Math.max(248, boundary.width - 16));
+    const spaceAbove = rect.top - boundary.top - gap;
+    const spaceBelow = boundary.bottom - rect.bottom - gap;
+    const openAbove = spaceBelow < 260 && spaceAbove > spaceBelow;
+    const availableHeight = Math.max(openAbove ? spaceAbove : spaceBelow, 120);
+    const listMaxHeight = Math.max(Math.min(availableHeight - 49, 272), 72);
+    const left = Math.min(
+      Math.max(rect.left, boundary.left + 8),
+      boundary.right - menuWidth - 8
+    );
+
+    setMenuStyle({
+      position: 'fixed',
+      left,
+      width: menuWidth,
+      ...(openAbove
+        ? { bottom: window.innerHeight - rect.top + gap }
+        : { top: rect.bottom + gap }),
+      '--composer-model-list-max-height': `${listMaxHeight}px`,
+      zIndex: 9999,
+    });
+  }, [boundaryRef]);
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    updateMenuPosition();
+    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', updateMenuPosition, true);
+    return () => {
+      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', updateMenuPosition, true);
+    };
+  }, [open, updateMenuPosition]);
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (
+      event: globalThis.MouseEvent | globalThis.TouchEvent
+    ) => {
+      const target = event.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        menuRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [open]);
+
+  useEscapeKey(close, open);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setHighlightedIndex(0);
+  }, [activeProviderFilter, open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() =>
+      listRef.current?.focus({ preventScroll: true })
+    );
+  }, [open]);
+
+  const handleTriggerKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      setOpen(true);
+    }
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (filteredModels.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlightedIndex((current) => (current + 1) % filteredModels.length);
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlightedIndex(
+        (current) =>
+          (current - 1 + filteredModels.length) % filteredModels.length
+      );
+    }
+    if (event.key === 'Home') {
+      event.preventDefault();
+      setHighlightedIndex(0);
+    }
+    if (event.key === 'End') {
+      event.preventDefault();
+      setHighlightedIndex(filteredModels.length - 1);
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      selectModel(filteredModels[highlightedIndex]);
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={handleTriggerKeyDown}
+        data-slot="composer-model-selector-trigger"
+        className={cn(
+          'inline-flex h-8 max-w-full items-center gap-1.5 rounded-full border px-2.5 text-sm font-medium',
+          'border-border bg-background text-foreground shadow-sm',
+          'hover:bg-muted/50',
+          'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+      >
+        <span className="max-w-40 min-w-0 truncate">
+          {selectedOption?.label ?? selectedOption?.model ?? placeholder}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 transition-transform',
+            open && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={menuStyle}
+            data-slot="composer-model-selector-menu"
+            className={cn(
+              'border-border bg-card text-card-foreground rounded-lg border shadow-lg',
+              'animate-in fade-in zoom-in-95 overflow-hidden duration-100'
+            )}
+          >
+            <div
+              data-slot="composer-model-selector-provider-filter"
+              className="border-border flex gap-1 overflow-x-auto border-b p-2"
+            >
+              {['any', ...providers].map((provider) => {
+                const selected = activeProviderFilter === provider;
+                return (
+                  <button
+                    key={provider}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => setProvider(provider)}
+                    className={cn(
+                      'shrink-0 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                      'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+                      selected
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    {provider === 'any'
+                      ? 'Any'
+                      : (providerLabels.get(provider) ?? provider)}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div
+              ref={listRef}
+              id={menuId}
+              role="listbox"
+              aria-label="Model"
+              tabIndex={-1}
+              onKeyDown={handleMenuKeyDown}
+              className="max-h-[var(--composer-model-list-max-height)] overflow-y-auto p-1"
+            >
+              {groupedModels.length === 0 ? (
+                <div className="text-muted-foreground px-3 py-4 text-center text-sm">
+                  No models
+                </div>
+              ) : (
+                groupedModels.map((group) => (
+                  <div
+                    key={group.provider}
+                    role="group"
+                    aria-label={
+                      providerLabels.get(group.provider) ?? group.provider
+                    }
+                  >
+                    <div className="text-muted-foreground px-3 py-1.5 text-xs font-semibold uppercase">
+                      {providerLabels.get(group.provider) ?? group.provider}
+                    </div>
+                    {group.options.map((model) => {
+                      const index = filteredModels.findIndex(
+                        (item) => optionKey(item) === optionKey(model)
+                      );
+                      const selected = optionKey(model) === selectedKey;
+                      const highlighted = index === highlightedIndex;
+
+                      return (
+                        <button
+                          key={model.id ?? optionKey(model)}
+                          type="button"
+                          role="option"
+                          aria-selected={selected}
+                          onClick={() => selectModel(model)}
+                          onMouseEnter={() => setHighlightedIndex(index)}
+                          className={cn(
+                            'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm',
+                            'focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-none',
+                            highlighted && 'bg-muted',
+                            selected && 'bg-primary/10 text-primary'
+                          )}
+                        >
+                          <span className="min-w-0 flex-1 truncate">
+                            {model.label ?? model.model}
+                          </span>
+                          {selected && (
+                            <Check
+                              aria-hidden="true"
+                              className="text-primary h-4 w-4 shrink-0"
+                            />
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
+ComposerModelSelector.displayName = 'ComposerModelSelector';

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -110,6 +110,19 @@ export function ComposerModelSelector({
     () => groupedModels.flatMap((group) => group.options),
     [groupedModels]
   );
+  const renderedModelIndexes = React.useMemo(
+    () =>
+      new Map(renderedModels.map((model, index) => [optionKey(model), index])),
+    [renderedModels]
+  );
+  const getOptionId = React.useCallback(
+    (index: number) => `${menuId}-option-${index}`,
+    [menuId]
+  );
+  const activeOptionId =
+    open && renderedModels[highlightedIndex]
+      ? getOptionId(highlightedIndex)
+      : undefined;
 
   const setProvider = React.useCallback(
     (provider: string | 'any') => {
@@ -149,7 +162,7 @@ export function ComposerModelSelector({
       height: window.innerHeight,
     };
     const gap = 6;
-    const menuWidth = Math.min(320, Math.max(248, boundary.width - 16));
+    const menuWidth = Math.min(320, Math.max(boundary.width - 16, 0));
     const spaceAbove = rect.top - boundary.top - gap;
     const spaceBelow = boundary.bottom - rect.bottom - gap;
     const openAbove = spaceBelow < 260 && spaceAbove > spaceBelow;
@@ -197,7 +210,7 @@ export function ComposerModelSelector({
       ) {
         return;
       }
-      setOpen(false);
+      close();
     };
 
     document.addEventListener('mousedown', handlePointerDown);
@@ -206,7 +219,7 @@ export function ComposerModelSelector({
       document.removeEventListener('mousedown', handlePointerDown);
       document.removeEventListener('touchstart', handlePointerDown);
     };
-  }, [open]);
+  }, [close, open]);
 
   useEscapeKey(close, open);
 
@@ -334,6 +347,7 @@ export function ComposerModelSelector({
               id={menuId}
               role="listbox"
               aria-label="Model"
+              aria-activedescendant={activeOptionId}
               tabIndex={-1}
               onKeyDown={handleMenuKeyDown}
               style={{ maxHeight: listMaxHeight }}
@@ -356,15 +370,16 @@ export function ComposerModelSelector({
                       {providerLabels.get(group.provider) ?? group.provider}
                     </div>
                     {group.options.map((model) => {
-                      const index = renderedModels.findIndex(
-                        (item) => optionKey(item) === optionKey(model)
-                      );
+                      const index = renderedModelIndexes.get(optionKey(model));
+                      if (index === undefined) return null;
+
                       const selected = optionKey(model) === selectedKey;
                       const highlighted = index === highlightedIndex;
 
                       return (
                         <button
                           key={model.id ?? optionKey(model)}
+                          id={getOptionId(index)}
                           type="button"
                           role="option"
                           aria-selected={selected}

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -433,7 +433,7 @@ export function ComposerModelSelector({
                           onClick={() => selectModel(model)}
                           onMouseEnter={() => setHighlightedIndex(index)}
                           className={cn(
-                            'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm',
+                            'flex w-full items-center gap-2 rounded-md px-3 py-2 text-start text-sm',
                             'focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-none',
                             highlighted && 'bg-muted',
                             selected && 'bg-primary/10 text-primary'

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -26,13 +26,13 @@ type ComposerModelSelectorBaseProps = {
 };
 
 type ControlledProviderFilterProps = {
-  providerFilter: string | 'any';
-  onProviderFilterChange: (provider: string | 'any') => void;
+  providerFilter: string | null;
+  onProviderFilterChange: (provider: string | null) => void;
 };
 
 type UncontrolledProviderFilterProps = {
   providerFilter?: undefined;
-  onProviderFilterChange?: (provider: string | 'any') => void;
+  onProviderFilterChange?: (provider: string | null) => void;
 };
 
 export type ComposerModelSelectorProps = ComposerModelSelectorBaseProps &
@@ -41,6 +41,16 @@ export type ComposerModelSelectorProps = ComposerModelSelectorBaseProps &
 function optionKey(option: ProviderModelValue) {
   return `${option.provider}\u0000${option.model}`;
 }
+
+function renderedOptionKey(option: ProviderModelOption, index: number) {
+  return `${option.id ?? optionKey(option)}\u0000${index}`;
+}
+
+type RenderedModelOption = {
+  option: ProviderModelOption;
+  index: number;
+  key: string;
+};
 
 function groupByProvider(models: ProviderModelOption[]) {
   const groups = new Map<string, ProviderModelOption[]>();
@@ -76,8 +86,9 @@ export function ComposerModelSelector({
   placeholder = 'Model',
 }: ComposerModelSelectorProps) {
   const [open, setOpen] = React.useState(false);
-  const [internalProviderFilter, setInternalProviderFilter] =
-    React.useState<string>('any');
+  const [internalProviderFilter, setInternalProviderFilter] = React.useState<
+    string | null
+  >(null);
   const [highlightedIndex, setHighlightedIndex] = React.useState(0);
   const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
 
@@ -87,7 +98,8 @@ export function ComposerModelSelector({
   const menuId = React.useId();
   const [listMaxHeight, setListMaxHeight] = React.useState(272);
 
-  const activeProviderFilter = providerFilter ?? internalProviderFilter;
+  const activeProviderFilter =
+    providerFilter === undefined ? internalProviderFilter : providerFilter;
   const selectedKey = value ? optionKey(value) : null;
   const selectedOption = models.find(
     (model) => optionKey(model) === selectedKey
@@ -108,7 +120,7 @@ export function ComposerModelSelector({
   );
   const filteredModels = React.useMemo(
     () =>
-      activeProviderFilter === 'any'
+      activeProviderFilter === null
         ? models
         : models.filter((model) => model.provider === activeProviderFilter),
     [activeProviderFilter, models]
@@ -117,14 +129,24 @@ export function ComposerModelSelector({
     () => groupByProvider(filteredModels),
     [filteredModels]
   );
+  const groupedRenderedModels = React.useMemo(() => {
+    let index = 0;
+    return groupedModels.map((group) => ({
+      provider: group.provider,
+      options: group.options.map((option) => {
+        const rendered: RenderedModelOption = {
+          option,
+          index,
+          key: renderedOptionKey(option, index),
+        };
+        index += 1;
+        return rendered;
+      }),
+    }));
+  }, [groupedModels]);
   const renderedModels = React.useMemo(
-    () => groupedModels.flatMap((group) => group.options),
-    [groupedModels]
-  );
-  const renderedModelIndexes = React.useMemo(
-    () =>
-      new Map(renderedModels.map((model, index) => [optionKey(model), index])),
-    [renderedModels]
+    () => groupedRenderedModels.flatMap((group) => group.options),
+    [groupedRenderedModels]
   );
   const getOptionId = React.useCallback(
     (index: number) => `${menuId}-option-${index}`,
@@ -136,7 +158,7 @@ export function ComposerModelSelector({
       : undefined;
 
   const setProvider = React.useCallback(
-    (provider: string | 'any') => {
+    (provider: string | null) => {
       if (providerFilter === undefined) {
         setInternalProviderFilter(provider);
       }
@@ -287,7 +309,7 @@ export function ComposerModelSelector({
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      const highlightedModel = renderedModels[highlightedIndex];
+      const highlightedModel = renderedModels[highlightedIndex]?.option;
       if (highlightedModel) {
         selectModel(highlightedModel);
       }
@@ -315,7 +337,7 @@ export function ComposerModelSelector({
           className
         )}
       >
-        <span className="max-w-40 min-w-0 truncate">
+        <span className="min-w-0 truncate" style={{ maxWidth: '10rem' }}>
           {selectedOption?.label ?? selectedOption?.model ?? placeholder}
         </span>
         <ChevronDown
@@ -342,13 +364,14 @@ export function ComposerModelSelector({
               data-slot="composer-model-selector-provider-filter"
               className="border-border flex gap-1 overflow-x-auto border-b p-2"
             >
-              {['any', ...providers].map((provider) => {
+              {[null, ...providers].map((provider) => {
                 const selected = activeProviderFilter === provider;
                 return (
                   <button
-                    key={provider}
+                    key={provider ?? 'all-providers'}
                     type="button"
                     aria-pressed={selected}
+                    onMouseDown={(event) => event.preventDefault()}
                     onClick={() => setProvider(provider)}
                     className={cn(
                       'shrink-0 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
@@ -358,7 +381,7 @@ export function ComposerModelSelector({
                         : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                     )}
                   >
-                    {provider === 'any'
+                    {provider === null
                       ? 'Any'
                       : (providerLabels.get(provider) ?? provider)}
                   </button>
@@ -382,7 +405,7 @@ export function ComposerModelSelector({
                   No models
                 </div>
               ) : (
-                groupedModels.map((group) => (
+                groupedRenderedModels.map((group) => (
                   <div
                     key={group.provider}
                     role="group"
@@ -393,20 +416,20 @@ export function ComposerModelSelector({
                     <div className="text-muted-foreground px-3 py-1.5 text-xs font-semibold uppercase">
                       {providerLabels.get(group.provider) ?? group.provider}
                     </div>
-                    {group.options.map((model) => {
-                      const index = renderedModelIndexes.get(optionKey(model));
-                      if (index === undefined) return null;
+                    {group.options.map((renderedModel) => {
+                      const { index, key, option: model } = renderedModel;
 
                       const selected = optionKey(model) === selectedKey;
                       const highlighted = index === highlightedIndex;
 
                       return (
                         <button
-                          key={model.id ?? optionKey(model)}
+                          key={key}
                           id={getOptionId(index)}
                           type="button"
                           role="option"
                           aria-selected={selected}
+                          onMouseDown={(event) => event.preventDefault()}
                           onClick={() => selectModel(model)}
                           onMouseEnter={() => setHighlightedIndex(index)}
                           className={cn(

--- a/src/components/AI/ComposerModelSelector.tsx
+++ b/src/components/AI/ComposerModelSelector.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import { Check, ChevronDown } from 'lucide-react';
+import { Check, ChevronUp } from 'lucide-react';
 import { cn } from '../../utils/cn';
+import { useAnchoredPosition } from '../../hooks/useAnchoredPosition';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 export type ProviderModelValue = {
@@ -23,6 +25,9 @@ type ComposerModelSelectorBaseProps = {
   className?: string;
   boundaryRef?: React.RefObject<HTMLElement | null>;
   placeholder?: string;
+  anyLabel?: string;
+  emptyLabel?: string;
+  ariaLabel?: string;
 };
 
 type ControlledProviderFilterProps = {
@@ -37,6 +42,9 @@ type UncontrolledProviderFilterProps = {
 
 export type ComposerModelSelectorProps = ComposerModelSelectorBaseProps &
   (ControlledProviderFilterProps | UncontrolledProviderFilterProps);
+
+const MENU_OFFSET_PX = 6;
+const MENU_MAX_HEIGHT_PX = 320;
 
 function optionKey(option: ProviderModelValue) {
   return `${option.provider}\u0000${option.model}`;
@@ -84,19 +92,30 @@ export function ComposerModelSelector({
   className,
   boundaryRef,
   placeholder = 'Model',
+  anyLabel = 'Any',
+  emptyLabel = 'No models',
+  ariaLabel = 'Model',
 }: ComposerModelSelectorProps) {
   const [open, setOpen] = React.useState(false);
   const [internalProviderFilter, setInternalProviderFilter] = React.useState<
     string | null
   >(null);
   const [highlightedIndex, setHighlightedIndex] = React.useState(0);
-  const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
-
-  const triggerRef = React.useRef<HTMLButtonElement>(null);
-  const menuRef = React.useRef<HTMLDivElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
   const menuId = React.useId();
-  const [listMaxHeight, setListMaxHeight] = React.useState(272);
+  const {
+    anchorRef: triggerRef,
+    floatingRef: menuRef,
+    style: menuStyle,
+  } = useAnchoredPosition<HTMLButtonElement, HTMLDivElement>({
+    open,
+    placement: 'top-start',
+    offset: MENU_OFFSET_PX,
+    matchMinWidth: true,
+    maxHeight: MENU_MAX_HEIGHT_PX,
+    allowFlip: false,
+    boundaryRef,
+  });
 
   const activeProviderFilter =
     providerFilter === undefined ? internalProviderFilter : providerFilter;
@@ -156,6 +175,15 @@ export function ComposerModelSelector({
     open && renderedModels[highlightedIndex]
       ? getOptionId(highlightedIndex)
       : undefined;
+  const selectedRenderedIndex = React.useMemo(
+    () =>
+      selectedKey
+        ? renderedModels.findIndex(
+            (renderedModel) => optionKey(renderedModel.option) === selectedKey
+          )
+        : -1,
+    [renderedModels, selectedKey]
+  );
 
   const setProvider = React.useCallback(
     (provider: string | null) => {
@@ -163,17 +191,19 @@ export function ComposerModelSelector({
         setInternalProviderFilter(provider);
       }
       onProviderFilterChange?.(provider);
-      setHighlightedIndex(0);
     },
     [onProviderFilterChange, providerFilter]
   );
 
-  const close = React.useCallback((restoreFocus = true) => {
-    setOpen(false);
-    if (restoreFocus) {
-      triggerRef.current?.focus({ preventScroll: true });
-    }
-  }, []);
+  const close = React.useCallback(
+    (restoreFocus = true) => {
+      setOpen(false);
+      if (restoreFocus) {
+        triggerRef.current?.focus({ preventScroll: true });
+      }
+    },
+    [triggerRef]
+  );
 
   const selectModel = React.useCallback(
     (model: ProviderModelOption) => {
@@ -183,86 +213,19 @@ export function ComposerModelSelector({
     [close, onChange]
   );
 
-  const updateMenuPosition = React.useCallback(() => {
-    const trigger = triggerRef.current;
-    if (!trigger) return;
+  const outsideRefs = React.useMemo(
+    () => [triggerRef, menuRef],
+    [triggerRef, menuRef]
+  );
 
-    const rect = trigger.getBoundingClientRect();
-    const boundary = boundaryRef?.current?.getBoundingClientRect() ?? {
-      top: 0,
-      right: window.innerWidth,
-      bottom: window.innerHeight,
-      left: 0,
-      width: window.innerWidth,
-      height: window.innerHeight,
-    };
-    const gap = 6;
-    const menuWidth = Math.min(320, Math.max(boundary.width - 16, 0));
-    const spaceAbove = rect.top - boundary.top - gap;
-    const spaceBelow = boundary.bottom - rect.bottom - gap;
-    const openAbove = spaceBelow < 260 && spaceAbove > spaceBelow;
-    const availableHeight = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
-    const nextListMaxHeight = Math.max(Math.min(availableHeight - 49, 272), 0);
-    const left = Math.min(
-      Math.max(rect.left, boundary.left + 8),
-      boundary.right - menuWidth - 8
-    );
-
-    setMenuStyle({
-      position: 'fixed',
-      left,
-      width: menuWidth,
-      maxHeight: availableHeight,
-      ...(openAbove
-        ? { bottom: window.innerHeight - rect.top + gap }
-        : { top: rect.bottom + gap }),
-      zIndex: 9999,
-    });
-    setListMaxHeight(nextListMaxHeight);
-  }, [boundaryRef]);
-
-  React.useEffect(() => {
-    if (!open) return;
-
-    updateMenuPosition();
-    window.addEventListener('resize', updateMenuPosition);
-    window.addEventListener('scroll', updateMenuPosition, true);
-    return () => {
-      window.removeEventListener('resize', updateMenuPosition);
-      window.removeEventListener('scroll', updateMenuPosition, true);
-    };
-  }, [open, updateMenuPosition]);
-
-  React.useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (
-      event: globalThis.MouseEvent | globalThis.TouchEvent
-    ) => {
-      const target = event.target as Node;
-      if (
-        triggerRef.current?.contains(target) ||
-        menuRef.current?.contains(target)
-      ) {
-        return;
-      }
-      close(false);
-    };
-
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('touchstart', handlePointerDown);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('touchstart', handlePointerDown);
-    };
-  }, [close, open]);
+  useClickOutside(outsideRefs, () => close(false), open);
 
   useEscapeKey(close, open);
 
   React.useEffect(() => {
     if (!open) return;
-    setHighlightedIndex(0);
-  }, [activeProviderFilter, open]);
+    setHighlightedIndex(selectedRenderedIndex >= 0 ? selectedRenderedIndex : 0);
+  }, [activeProviderFilter, open, selectedRenderedIndex]);
 
   React.useEffect(() => {
     if (!open) return;
@@ -337,16 +300,10 @@ export function ComposerModelSelector({
           className
         )}
       >
-        <span className="min-w-0 truncate" style={{ maxWidth: '10rem' }}>
+        <span className="min-w-0 truncate">
           {selectedOption?.label ?? selectedOption?.model ?? placeholder}
         </span>
-        <ChevronDown
-          aria-hidden="true"
-          className={cn(
-            'h-3.5 w-3.5 shrink-0 transition-transform',
-            open && 'rotate-180'
-          )}
-        />
+        <ChevronUp aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
       </button>
 
       {open &&
@@ -356,13 +313,13 @@ export function ComposerModelSelector({
             style={menuStyle}
             data-slot="composer-model-selector-menu"
             className={cn(
-              'border-border bg-card text-card-foreground rounded-lg border shadow-lg',
-              'animate-in fade-in zoom-in-95 overflow-hidden duration-100'
+              'border-border bg-card text-card-foreground flex w-80 max-w-full flex-col rounded-lg border shadow-lg',
+              'animate-in fade-in overflow-hidden duration-100'
             )}
           >
             <div
               data-slot="composer-model-selector-provider-filter"
-              className="border-border flex gap-1 overflow-x-auto border-b p-2"
+              className="border-border flex min-h-9 items-center gap-1 overflow-x-auto overflow-y-hidden border-b p-2"
             >
               {[null, ...providers].map((provider) => {
                 const selected = activeProviderFilter === provider;
@@ -374,7 +331,7 @@ export function ComposerModelSelector({
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={() => setProvider(provider)}
                     className={cn(
-                      'shrink-0 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                      'inline-flex h-6 shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-medium whitespace-nowrap transition-colors',
                       'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
                       selected
                         ? 'bg-primary text-primary-foreground'
@@ -382,7 +339,7 @@ export function ComposerModelSelector({
                     )}
                   >
                     {provider === null
-                      ? 'Any'
+                      ? anyLabel
                       : (providerLabels.get(provider) ?? provider)}
                   </button>
                 );
@@ -393,16 +350,15 @@ export function ComposerModelSelector({
               ref={listRef}
               id={menuId}
               role="listbox"
-              aria-label="Model"
+              aria-label={ariaLabel}
               aria-activedescendant={activeOptionId}
               tabIndex={-1}
               onKeyDown={handleMenuKeyDown}
-              style={{ maxHeight: listMaxHeight }}
-              className="overflow-y-auto p-1"
+              className="min-h-0 flex-1 overflow-y-auto p-1"
             >
               {groupedModels.length === 0 ? (
                 <div className="text-muted-foreground px-3 py-4 text-center text-sm">
-                  No models
+                  {emptyLabel}
                 </div>
               ) : (
                 groupedRenderedModels.map((group) => (

--- a/src/components/AI/index.ts
+++ b/src/components/AI/index.ts
@@ -192,6 +192,14 @@ export {
   type RollingRecorder,
 } from './HeyOzwell/audio';
 
+// Composer model selector
+export {
+  ComposerModelSelector,
+  type ComposerModelSelectorProps,
+  type ProviderModelOption,
+  type ProviderModelValue,
+} from './ComposerModelSelector';
+
 // AI Chat Modal
 export {
   AIChatModal,

--- a/src/hooks/useAnchoredPosition.ts
+++ b/src/hooks/useAnchoredPosition.ts
@@ -23,6 +23,10 @@ export interface UseAnchoredPositionOptions {
   matchMinWidth?: boolean;
   /** Minimum distance from the viewport edges, in px */
   viewportPadding?: number;
+  /** Flip to the opposite vertical side when the preferred side is cramped */
+  allowFlip?: boolean;
+  /** Optional element whose visible rectangle also constrains the popup */
+  boundaryRef?: React.RefObject<HTMLElement | null>;
   /**
    * Additional cap on the floating element's height, in px. The height is
    * always clamped to the available viewport space; this only lowers that
@@ -67,7 +71,7 @@ const HIDDEN_STYLE: React.CSSProperties = {
  * Render the floating element through `createPortal(..., document.body)`
  * and spread the returned `style` onto it. The hook:
  * - flips vertically when there is not enough space on the preferred side
- * - clamps horizontally to the viewport
+ * - clamps horizontally to the viewport or optional boundary element
  * - constrains `maxHeight` to the available space (add `overflow-auto`)
  * - tracks scroll, resize, and anchor/content size changes while open
  *
@@ -96,6 +100,8 @@ export function useAnchoredPosition<
   matchWidth = false,
   matchMinWidth = false,
   viewportPadding = 8,
+  allowFlip = true,
+  boundaryRef,
   maxHeight,
 }: UseAnchoredPositionOptions): UseAnchoredPositionReturn<TAnchor, TFloating> {
   const anchorRef = React.useRef<TAnchor | null>(null);
@@ -113,6 +119,23 @@ export function useAnchoredPosition<
     const rect = anchor.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
+    const boundaryRect = boundaryRef?.current?.getBoundingClientRect();
+    const bounds = boundaryRect ?? {
+      top: 0,
+      right: viewportWidth,
+      bottom: viewportHeight,
+      left: 0,
+    };
+    const leftLimit = Math.max(bounds.left + viewportPadding, viewportPadding);
+    const rightLimit = Math.min(
+      bounds.right - viewportPadding,
+      viewportWidth - viewportPadding
+    );
+    const topLimit = Math.max(bounds.top + viewportPadding, viewportPadding);
+    const bottomLimit = Math.min(
+      bounds.bottom - viewportPadding,
+      viewportHeight - viewportPadding
+    );
 
     // Natural content size (scrollHeight so a previously applied maxHeight
     // doesn't skew the flip decision).
@@ -125,18 +148,20 @@ export function useAnchoredPosition<
     const floatingWidth = matchWidth
       ? rect.width
       : Math.max(floating.offsetWidth, matchMinWidth ? rect.width : 0);
+    const availableWidth = Math.max(rightLimit - leftLimit, 0);
+    const positionedWidth = Math.min(floatingWidth, availableWidth);
 
     // --- Vertical: preferred side, flip when out of space -------------------
-    const spaceBelow = viewportHeight - rect.bottom - offset - viewportPadding;
-    const spaceAbove = rect.top - offset - viewportPadding;
+    const spaceBelow = bottomLimit - rect.bottom - offset;
+    const spaceAbove = rect.top - topLimit - offset;
     const preferTop = placement.startsWith('top');
-    let side: 'top' | 'bottom';
-    if (preferTop) {
+    let side: 'top' | 'bottom' = preferTop ? 'top' : 'bottom';
+    if (allowFlip && preferTop) {
       side =
         spaceAbove < contentHeight && spaceBelow > spaceAbove
           ? 'bottom'
           : 'top';
-    } else {
+    } else if (allowFlip) {
       side =
         spaceBelow < contentHeight && spaceAbove > spaceBelow
           ? 'top'
@@ -157,11 +182,11 @@ export function useAnchoredPosition<
       align === 'left'
         ? rect.left
         : align === 'right'
-          ? rect.right - floatingWidth
-          : rect.left + rect.width / 2 - floatingWidth / 2;
+          ? rect.right - positionedWidth
+          : rect.left + rect.width / 2 - positionedWidth / 2;
     left = Math.min(
-      Math.max(left, viewportPadding),
-      Math.max(viewportWidth - floatingWidth - viewportPadding, viewportPadding)
+      Math.max(left, leftLimit),
+      Math.max(rightLimit - positionedWidth, leftLimit)
     );
 
     setActualSide(side);
@@ -173,6 +198,7 @@ export function useAnchoredPosition<
         : { top: rect.bottom + offset }),
       ...(matchWidth ? { width: rect.width } : {}),
       ...(matchMinWidth ? { minWidth: rect.width } : {}),
+      maxWidth: availableWidth,
       maxHeight: Math.min(availableHeight, maxHeight ?? Infinity),
       zIndex: 9999,
       transition: 'none',
@@ -184,6 +210,8 @@ export function useAnchoredPosition<
     offset,
     placement,
     viewportPadding,
+    allowFlip,
+    boundaryRef,
   ]);
 
   // Position synchronously before paint when opening / re-rendering open.


### PR DESCRIPTION
Closes #317 
Adds a reusable ComposerModelSelector primitive for compact provider/model selection in composer-style UIs.

What changed:
- Added standalone ComposerModelSelector under AI components
<img width="158" height="80" alt="image" src="https://github.com/user-attachments/assets/787e5066-9a1d-4316-a975-70b35e356b00" />

- Supports provider filtering, grouped model rows, providerLabel display labels, long-name truncation, and constrained boundary positioning

<img width="352" height="276" alt="image" src="https://github.com/user-attachments/assets/1c132fd1-0d79-43de-abd9-31caeea7cf3a" />

- Adds Storybook examples for one provider, multiple providers, long names, and constrained containers

Scope:
- Generic UI primitive only
- No Ozwell widget code, backend calls, agent keys, or model fetching logic

Verification:
- tsc --noEmit
- focused eslint
- Prettier
- git diff --check