### PR TITLE
fix(ThemeToggle): three-way icon previews the next theme, matching the tooltip

### DIFF
--- a/src/components/ThemeProvider/ThemeToggle.tsx
+++ b/src/components/ThemeProvider/ThemeToggle.tsx
@@ -228,14 +228,34 @@ const ThemeToggle = React.forwardRef<HTMLButtonElement, ThemeToggleProps>(
     };
 
     const getCurrentIcon = () => {
-      if (mode === 'three-way' && theme === 'system') {
+      if (mode === 'three-way') {
+        // Preview the NEXT theme in the cycle, matching the tooltip — the icon
+        // always shows what a click gives you (light → dark → system → light).
+        // Previously dark showed a sun (implying light) while the click gave
+        // system, and system showed the current state instead of the next.
+        if (theme === 'light') {
+          return (
+            lightIcon || (
+              <MoonIcon className={themeToggleIconVariants({ size })} />
+            )
+          );
+        }
+        if (theme === 'dark') {
+          return (
+            darkIcon || (
+              <SystemIcon className={themeToggleIconVariants({ size })} />
+            )
+          );
+        }
         return (
           systemIcon || (
-            <SystemIcon className={themeToggleIconVariants({ size })} />
+            <SunIcon className={themeToggleIconVariants({ size })} />
           )
         );
       }
 
+      // Two-way keeps the classic convention: sun while dark ("click for
+      // light"), moon while light ("click for dark").
       if (resolvedTheme === 'dark') {
         return (
           darkIcon || <SunIcon className={themeToggleIconVariants({ size })} />

--- a/src/components/ThemeProvider/ThemeToggle.tsx
+++ b/src/components/ThemeProvider/ThemeToggle.tsx
@@ -114,6 +114,24 @@ const SystemIcon: React.FC<IconProps> = ({ className }) => (
 );
 
 // ============================================================================
+// Three-way cycle (single source of truth)
+// ============================================================================
+
+/** The three-way cycle order: light → dark → system → light. Click handler,
+ *  tooltip label, and default icon are all derived from this one map. */
+const THREE_WAY_NEXT: Record<Theme, Theme> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+};
+
+const THEME_LABELS: Record<Theme, string> = {
+  light: 'Switch to light mode',
+  dark: 'Switch to dark mode',
+  system: 'Switch to system theme',
+};
+
+// ============================================================================
 // ThemeToggle Component
 // ============================================================================
 
@@ -202,13 +220,7 @@ const ThemeToggle = React.forwardRef<HTMLButtonElement, ThemeToggleProps>(
         // Simple toggle between light and dark
         setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
       } else {
-        // Three-way cycle: light → dark → system
-        const nextTheme: Record<Theme, Theme> = {
-          light: 'dark',
-          dark: 'system',
-          system: 'light',
-        };
-        setTheme(nextTheme[theme]);
+        setTheme(THREE_WAY_NEXT[theme]);
       }
     }, [mode, theme, resolvedTheme, setTheme]);
 
@@ -218,53 +230,39 @@ const ThemeToggle = React.forwardRef<HTMLButtonElement, ThemeToggleProps>(
           ? 'Switch to light mode'
           : 'Switch to dark mode';
       }
-      // Three-way mode - show what the next theme will be
-      const nextThemeLabels: Record<Theme, string> = {
-        light: 'Switch to dark mode',
-        dark: 'Switch to system theme',
-        system: 'Switch to light mode',
-      };
-      return nextThemeLabels[theme];
+      // Three-way mode - name the next stop in the cycle
+      return THEME_LABELS[THREE_WAY_NEXT[theme]];
     };
 
     const getCurrentIcon = () => {
+      const iconClass = themeToggleIconVariants({ size });
       if (mode === 'three-way') {
-        // Preview the NEXT theme in the cycle, matching the tooltip — the icon
-        // always shows what a click gives you (light → dark → system → light).
-        // Previously dark showed a sun (implying light) while the click gave
-        // system, and system showed the current state instead of the next.
-        if (theme === 'light') {
-          return (
-            lightIcon || (
-              <MoonIcon className={themeToggleIconVariants({ size })} />
-            )
-          );
-        }
-        if (theme === 'dark') {
-          return (
-            darkIcon || (
-              <SystemIcon className={themeToggleIconVariants({ size })} />
-            )
-          );
-        }
-        return (
-          systemIcon || (
-            <SunIcon className={themeToggleIconVariants({ size })} />
-          )
-        );
+        // The DEFAULT icon previews the next theme in the cycle, matching the
+        // tooltip (previously dark showed a sun while the click gave system,
+        // and system showed the current state instead of the next). The
+        // lightIcon/darkIcon/systemIcon overrides are keyed by the CURRENT
+        // theme — they replace the icon shown while in that theme.
+        const override = {
+          light: lightIcon,
+          dark: darkIcon,
+          system: systemIcon,
+        }[theme];
+        if (override) return override;
+        const defaultIcons: Record<Theme, React.ReactNode> = {
+          light: <SunIcon className={iconClass} />,
+          dark: <MoonIcon className={iconClass} />,
+          system: <SystemIcon className={iconClass} />,
+        };
+        return defaultIcons[THREE_WAY_NEXT[theme]];
       }
 
       // Two-way keeps the classic convention: sun while dark ("click for
       // light"), moon while light ("click for dark").
       if (resolvedTheme === 'dark') {
-        return (
-          darkIcon || <SunIcon className={themeToggleIconVariants({ size })} />
-        );
+        return darkIcon || <SunIcon className={iconClass} />;
       }
 
-      return (
-        lightIcon || <MoonIcon className={themeToggleIconVariants({ size })} />
-      );
+      return lightIcon || <MoonIcon className={iconClass} />;
     };
 
     const label = getLabel();


### PR DESCRIPTION
In three-way mode the tooltip always names the NEXT stop in the light → dark → system → light cycle, but the icon mixed conventions: in dark it showed a **sun** (implying light) while the click gave **system**, and in system it showed the **monitor** (the current state) while the click gave light. Clicking felt broken because the icon kept promising the wrong thing.

The icon now previews the next theme in all three states, consistent with both the tooltip and the existing two-way convention (sun-in-dark = "click for light"). Two-way behavior is unchanged, and the `lightIcon`/`darkIcon`/`systemIcon` override props keep their keyed-by-current-state semantics.

Verified by driving the toggle through the full cycle in a consuming app: light→moon, dark→monitor, system→sun, and back.
