### PR TITLE
feat(Select): add native typeahead keyboard support

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -141,6 +141,23 @@ describe('Select typeahead', () => {
     expect(options[0]).toHaveTextContent('Family Care Clinic');
   });
 
+  it('allows typing spaces in the search input (multi-word queries)', async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <Select aria-label="Location Type" searchable options={LOCATION_TYPES} />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const search = screen.getByRole('textbox', { name: 'Search options' });
+    await user.type(search, 'collection site');
+
+    expect(search).toHaveValue('collection site');
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Collection Site');
+  });
+
   it('never calls native scrollIntoView (which would scroll the whole page)', async () => {
     const user = userEvent.setup();
     // The dropdown is portaled to <body> with position: fixed, so calling

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithTheme } from '../../test/test-utils';
 import { Select, type SelectOption } from './Select';
@@ -62,6 +61,58 @@ describe('Select typeahead', () => {
 
     await user.keyboard('c');
     expect(screen.getByRole('option', { name: 'Clinic' })).toHaveAttribute(
+      'data-highlighted',
+      'true'
+    );
+  });
+
+  it('clears the typeahead buffer after a pause (~600ms)', () => {
+    vi.useFakeTimers();
+
+    try {
+      renderWithTheme(
+        <Select aria-label="Location Type" options={LOCATION_TYPES} />
+      );
+
+      fireEvent.click(screen.getByRole('combobox'));
+
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'c' });
+      expect(
+        screen.getByRole('option', { name: 'Cardiology' })
+      ).toHaveAttribute('data-highlighted', 'true');
+
+      // After the buffer clears, "d" starts a fresh query and matches
+      // "Dermatology"; a stale "cd" buffer would match nothing.
+      vi.advanceTimersByTime(700);
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'd' });
+      expect(
+        screen.getByRole('option', { name: 'Dermatology' })
+      ).toHaveAttribute('data-highlighted', 'true');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the typeahead buffer when the dropdown closes', async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <Select aria-label="Location Type" options={LOCATION_TYPES} />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('c');
+    expect(screen.getByRole('option', { name: 'Cardiology' })).toHaveAttribute(
+      'data-highlighted',
+      'true'
+    );
+
+    // Close and quickly reopen: the buffer must reset, so "c" is a fresh
+    // query landing on the first match instead of cycling to the next one.
+    await user.keyboard('{Escape}');
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('c');
+    expect(screen.getByRole('option', { name: 'Cardiology' })).toHaveAttribute(
       'data-highlighted',
       'true'
     );

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithTheme } from '../../test/test-utils';
+import { Select, type SelectOption } from './Select';
+
+const LOCATION_TYPES: SelectOption[] = [
+  { value: 'cardiology', label: 'Cardiology' },
+  { value: 'chiropractic', label: 'Chiropractic' },
+  { value: 'clinic', label: 'Clinic' },
+  { value: 'collection-site', label: 'Collection Site' },
+  { value: 'corporate', label: 'Corporate Location' },
+  { value: 'dermatology', label: 'Dermatology' },
+  { value: 'family-care', label: 'Family Care Clinic' },
+];
+
+describe('Select typeahead', () => {
+  it('jumps to and selects the option matching the typed characters', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    renderWithTheme(
+      <Select
+        aria-label="Location Type"
+        options={LOCATION_TYPES}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.tab();
+    expect(screen.getByRole('combobox')).toHaveFocus();
+
+    // Typing "der" should highlight "Dermatology"; Enter selects it.
+    await user.keyboard('der');
+    await user.keyboard('{Enter}');
+
+    expect(onValueChange).toHaveBeenCalledWith('dermatology');
+  });
+
+  it('lands on the first match then cycles when the same key repeats', async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <Select aria-label="Location Type" options={LOCATION_TYPES} />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    // Fresh keystroke lands on the first "c" match.
+    await user.keyboard('c');
+    expect(screen.getByRole('option', { name: 'Cardiology' })).toHaveAttribute(
+      'data-highlighted',
+      'true'
+    );
+
+    // Repeating the same key (continuous) cycles to the next matches.
+    await user.keyboard('c');
+    expect(
+      screen.getByRole('option', { name: 'Chiropractic' })
+    ).toHaveAttribute('data-highlighted', 'true');
+
+    await user.keyboard('c');
+    expect(screen.getByRole('option', { name: 'Clinic' })).toHaveAttribute(
+      'data-highlighted',
+      'true'
+    );
+  });
+
+  it('does not hijack typing when searchable (search input handles it)', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    renderWithTheme(
+      <Select
+        aria-label="Location Type"
+        searchable
+        options={LOCATION_TYPES}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const search = screen.getByRole('textbox', { name: 'Search options' });
+    await user.type(search, 'family');
+
+    // The list should be filtered to the single matching option.
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Family Care Clinic');
+  });
+});

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -89,4 +89,30 @@ describe('Select typeahead', () => {
     expect(options).toHaveLength(1);
     expect(options[0]).toHaveTextContent('Family Care Clinic');
   });
+
+  it('never calls native scrollIntoView (which would scroll the whole page)', async () => {
+    const user = userEvent.setup();
+    // The dropdown is portaled to <body> with position: fixed, so calling
+    // Element.scrollIntoView would scroll the window. Guard against it.
+    const proto = Element.prototype as unknown as {
+      scrollIntoView?: () => void;
+    };
+    const original = proto.scrollIntoView;
+    const spy = vi.fn();
+    proto.scrollIntoView = spy;
+
+    try {
+      renderWithTheme(
+        <Select aria-label="Location Type" options={LOCATION_TYPES} />
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{ArrowDown}{ArrowDown}{End}');
+      await user.keyboard('der');
+
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      proto.scrollIntoView = original;
+    }
+  });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -419,13 +419,23 @@ function Select({
     setHighlightedIndex(filteredFlatOptions.length > 0 ? 0 : -1);
   }, [searchQuery, filteredFlatOptions.length]);
 
-  // Keep the highlighted option scrolled into view during keyboard navigation.
+  // Keep the highlighted option visible within the listbox during keyboard
+  // navigation. We adjust only the list's own scrollTop instead of calling the
+  // native scrollIntoView: the dropdown is portaled to <body> with
+  // position: fixed, and scrollIntoView would also scroll ancestor/window,
+  // yanking the whole page.
   React.useEffect(() => {
     if (!isOpen || highlightedIndex < 0) return;
-    const el = listRef.current?.querySelector<HTMLElement>(
-      '[data-highlighted="true"]'
-    );
-    el?.scrollIntoView({ block: 'nearest' });
+    const list = listRef.current;
+    const el = list?.querySelector<HTMLElement>('[data-highlighted="true"]');
+    if (!list || !el) return;
+    const listRect = list.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    if (elRect.top < listRect.top) {
+      list.scrollTop -= listRect.top - elRect.top;
+    } else if (elRect.bottom > listRect.bottom) {
+      list.scrollTop += elRect.bottom - listRect.bottom;
+    }
   }, [highlightedIndex, isOpen]);
 
   // Clear any pending typeahead timer on unmount.

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -323,13 +323,14 @@ function Select({
         if (!isOpen) setIsOpen(true);
 
         const hadPendingQuery = typeaheadRef.current.query !== '';
-        if (typeaheadRef.current.timer) {
+        if (typeaheadRef.current.timer !== null) {
           window.clearTimeout(typeaheadRef.current.timer);
         }
         const query = (typeaheadRef.current.query + e.key).toLowerCase();
         typeaheadRef.current.query = query;
         typeaheadRef.current.timer = window.setTimeout(() => {
           typeaheadRef.current.query = '';
+          typeaheadRef.current.timer = null;
         }, 600);
 
         const len = filteredFlatOptions.length;
@@ -438,15 +439,22 @@ function Select({
     }
   }, [highlightedIndex, isOpen]);
 
-  // Clear any pending typeahead timer on unmount.
-  React.useEffect(
-    () => () => {
-      if (typeaheadRef.current.timer) {
-        window.clearTimeout(typeaheadRef.current.timer);
-      }
-    },
-    []
-  );
+  // Reset the typeahead buffer whenever the dropdown closes (Escape, click
+  // outside, selection) so a stale query doesn't carry over on a quick reopen,
+  // and clear any pending timer on unmount.
+  const resetTypeahead = React.useCallback(() => {
+    if (typeaheadRef.current.timer !== null) {
+      window.clearTimeout(typeaheadRef.current.timer);
+      typeaheadRef.current.timer = null;
+    }
+    typeaheadRef.current.query = '';
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen) resetTypeahead();
+  }, [isOpen, resetTypeahead]);
+
+  React.useEffect(() => resetTypeahead, [resetTypeahead]);
 
   // Build aria-describedby
   const describedByIds = [

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -148,6 +148,10 @@ function Select({
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const listRef = React.useRef<HTMLUListElement>(null);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
+  const typeaheadRef = React.useRef<{ query: string; timer: number | null }>({
+    query: '',
+    timer: null,
+  });
 
   const generatedId = React.useId();
   const selectId = id || generatedId;
@@ -303,6 +307,57 @@ function Select({
   // Handle keyboard navigation
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
+      // Typeahead (native-select style): when not using the dedicated search
+      // input, typing printable characters jumps to the first option whose
+      // label starts with the typed string. Repeating the same key cycles
+      // through matches. The buffer clears after a short pause.
+      if (
+        !searchable &&
+        e.key.length === 1 &&
+        e.key !== ' ' &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        e.preventDefault();
+        if (!isOpen) setIsOpen(true);
+
+        const hadPendingQuery = typeaheadRef.current.query !== '';
+        if (typeaheadRef.current.timer) {
+          window.clearTimeout(typeaheadRef.current.timer);
+        }
+        const query = (typeaheadRef.current.query + e.key).toLowerCase();
+        typeaheadRef.current.query = query;
+        typeaheadRef.current.timer = window.setTimeout(() => {
+          typeaheadRef.current.query = '';
+        }, 600);
+
+        const len = filteredFlatOptions.length;
+        if (len > 0) {
+          const allSameChar = query.split('').every((c) => c === query[0]);
+          const needle = allSameChar ? query[0] : query;
+          const matches = (opt: SelectOption) =>
+            opt.label.toLowerCase().startsWith(needle);
+
+          // A fresh keystroke (or refining a multi-char query) searches from
+          // the current option inclusive so typing "car" stays on "Cardiology";
+          // repeating the same key cycles to the next match.
+          const startInclusive = !hadPendingQuery || !allSameChar;
+          const base = startInclusive
+            ? Math.max(highlightedIndex, 0)
+            : highlightedIndex + 1;
+
+          for (let i = 0; i < len; i++) {
+            const idx = (base + i) % len;
+            if (matches(filteredFlatOptions[idx])) {
+              setHighlightedIndex(idx);
+              break;
+            }
+          }
+        }
+        return;
+      }
+
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
@@ -343,7 +398,13 @@ function Select({
           break;
       }
     },
-    [isOpen, highlightedIndex, filteredFlatOptions, handleValueChange]
+    [
+      isOpen,
+      highlightedIndex,
+      filteredFlatOptions,
+      handleValueChange,
+      searchable,
+    ]
   );
 
   // Focus search input when dropdown opens
@@ -357,6 +418,25 @@ function Select({
   React.useEffect(() => {
     setHighlightedIndex(filteredFlatOptions.length > 0 ? 0 : -1);
   }, [searchQuery, filteredFlatOptions.length]);
+
+  // Keep the highlighted option scrolled into view during keyboard navigation.
+  React.useEffect(() => {
+    if (!isOpen || highlightedIndex < 0) return;
+    const el = listRef.current?.querySelector<HTMLElement>(
+      '[data-highlighted="true"]'
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex, isOpen]);
+
+  // Clear any pending typeahead timer on unmount.
+  React.useEffect(
+    () => () => {
+      if (typeaheadRef.current.timer) {
+        window.clearTimeout(typeaheadRef.current.timer);
+      }
+    },
+    []
+  );
 
   // Build aria-describedby
   const describedByIds = [

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -359,6 +359,12 @@ function Select({
         return;
       }
 
+      // Let Space type normally in the search input (e.g. "new york")
+      // instead of being captured by the open/select handler below.
+      if (e.key === ' ' && e.target === searchInputRef.current) {
+        return;
+      }
+
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();


### PR DESCRIPTION
## Summary

Adds native-`<select>`-style **typeahead** to `Select`. Focus the trigger and type — e.g. `der` — and the control jumps to the first option whose label starts with what you typed (like a native `<select>` or select2), no search box required.

## Motivation

`Select` already supported arrow-key navigation, Enter/Space, Home/End, Esc, and an opt-in `searchable` filter box — but there was **no type-to-jump**. Users expect to be able to start typing to land on an option, especially for long lists (e.g. location types, country pickers). This closes that gap so every consumer gets it out of the box.

## Changes

- **Typeahead** (non-`searchable` selects): typing printable characters jumps to the first matching option.
  - Multi-character queries refine the match (typing `car` stays on **Cardiology**).
  - Repeating the same key cycles through matches (`c`, `c`, `c` → Cardiology → Chiropractic → Clinic).
  - The buffer clears after a short pause (~600 ms), following the ARIA listbox typeahead pattern.
  - `Space` is preserved for open/select and is not captured by typeahead.
- **Scroll-into-view**: the highlighted option now scrolls into view during keyboard navigation (arrows + typeahead) — previously the highlight could move off-screen.
- **No behavior change when `searchable`**: the dedicated search input still owns typing; typeahead is skipped.
- Timer cleaned up on unmount.

## Behavior notes

- Works whether the dropdown is open or closed-but-focused (typing opens it, native-style).
- Purely additive — existing keyboard handlers (Arrow/Enter/Space/Home/End/Esc) and the `searchable` prop are unchanged.

## Testing

- Added `Select.test.tsx` with 3 tests: type-to-select, first-match + repeat-key cycling, and that `searchable` routes typing to the search box (typeahead does not hijack it).
- `vitest run src/components/Select/Select.test.tsx` → **3 passed**.
- ESLint and Prettier clean on both files.

## Release

New feature → suggest a **minor** bump when cutting the next stable release. Consuming apps (e.g. waggleline) pick it up after bumping their `@mieweb/ui` dependency.
