### PR TITLE
feat(CodeLookup): search by code — code-shaped queries match code prefixes

### DIFF
--- a/src/components/CodeLookup/engine.test.ts
+++ b/src/components/CodeLookup/engine.test.ts
@@ -369,5 +369,23 @@ describe('searchShards', () => {
       const r = searchShards([shard], 'b12');
       expect(r).toHaveLength(1);
     });
+
+    it('collapse keeps one row per family across label and code hits', () => {
+      const shard = makeShard('condition', [
+        { label: 'Type 2 diabetes mellitus', code: 'E11', codetype: 'ICD10' },
+        {
+          label: 'Type 2 diabetes w/ foot ulcer',
+          code: 'E11.621',
+          codetype: 'ICD10',
+        },
+        { label: 'E11 review encounter', code: 'Z09.1', codetype: 'ICD10' },
+      ]);
+      const r = searchShards([shard], 'e11', 20, true);
+      // one row for the #E11 code family (exact code represents), one for
+      // the label-matched Z09 family
+      expect(r).toHaveLength(2);
+      expect(r[0].fullcode).toBe('E11');
+      expect(r[0].viaCode).toBe(true);
+    });
   });
 });

--- a/src/components/CodeLookup/engine.test.ts
+++ b/src/components/CodeLookup/engine.test.ts
@@ -315,4 +315,59 @@ describe('searchShards', () => {
     expect(r.length).toBeGreaterThan(0);
     expect(r[0].label).toBe('z150drug');
   });
+
+  describe('code search', () => {
+    it('finds an entry by its exact code, punctuation-insensitive', () => {
+      const r = searchShards([conditions], 'I50.9');
+      expect(r.length).toBeGreaterThan(0);
+      expect(r[0].label).toBe('Congestive heart failure');
+      expect(r[0].viaCode).toBe(true);
+      // dot optional
+      expect(searchShards([conditions], 'i509')[0].label).toBe(
+        'Congestive heart failure'
+      );
+    });
+
+    it('matches by code prefix, exact code ranking first', () => {
+      const shard = makeShard('condition', [
+        { label: 'Type 2 diabetes mellitus', code: 'E11', codetype: 'ICD10' },
+        {
+          label: 'Type 2 diabetes w/ foot ulcer',
+          code: 'E11.621',
+          codetype: 'ICD10',
+        },
+      ]);
+      const r = searchShards([shard], 'e11');
+      expect(r).toHaveLength(2);
+      expect(r[0].fullcode).toBe('E11');
+      expect(r[1].fullcode).toBe('E11.621');
+    });
+
+    it('code matches outrank label matches for a code-shaped query', () => {
+      const shard = makeShard('condition', [
+        { label: 'Z94 syndrome variant', code: 'Q99.9', codetype: 'ICD10' },
+        { label: 'Heart transplant status', code: 'Z94.1', codetype: 'ICD10' },
+      ]);
+      const r = searchShards([shard], 'z94');
+      expect(r[0].fullcode).toBe('Z94.1');
+      expect(r[0].viaCode).toBe(true);
+    });
+
+    it('does not code-search queries without digits or with spaces', () => {
+      // "zzz" is no code prefix and no label token — nothing comes back
+      expect(searchShards([conditions], 'zzz')).toHaveLength(0);
+      // multi-word queries keep pure label semantics
+      const r = searchShards([conditions], 'heart failure');
+      expect(r).toHaveLength(1);
+      expect(r[0].viaCode).toBeFalsy();
+    });
+
+    it('dedupes a doc matched by both label and code', () => {
+      const shard = makeShard('condition', [
+        { label: 'B12 deficiency anemia', code: 'D51.9', codetype: 'ICD10' },
+      ]);
+      const r = searchShards([shard], 'b12');
+      expect(r).toHaveLength(1);
+    });
+  });
 });

--- a/src/components/CodeLookup/engine.test.ts
+++ b/src/components/CodeLookup/engine.test.ts
@@ -387,5 +387,30 @@ describe('searchShards', () => {
       expect(r[0].fullcode).toBe('E11');
       expect(r[0].viaCode).toBe(true);
     });
+
+    it('applies boostCodetypes to code matches', () => {
+      const shard = makeShard('condition', [
+        { label: 'Other disorder', code: 'E11.8', codetype: 'SNOMED US' },
+        { label: 'Type 2 diabetes, unspec', code: 'E11.9', codetype: 'ICD10' },
+      ]);
+      const r = searchShards([shard], 'e11', 20, false, {
+        boostCodetypes: ['ICD10'],
+      });
+      // equal key lengths — the boosted ICD-10 code must rank first
+      expect(r[0].fullcode).toBe('E11.9');
+    });
+
+    it('still finds the exact code among many prefix matches (scan cap)', () => {
+      // 1500 codes share the prefix — beyond MAX_CODE_SCAN — but the exact
+      // match sits at the start of the sorted range and is always scanned
+      const docs: TestDoc[] = Array.from({ length: 1500 }, (_, i) => ({
+        label: `filler ${i}`,
+        code: `90.${String(i).padStart(4, '0')}`,
+        codetype: 'ICD10',
+      }));
+      docs.push({ label: 'Exact hit', code: '90', codetype: 'ICD10' });
+      const r = searchShards([makeShard('condition', docs)], '90');
+      expect(r[0].label).toBe('Exact hit');
+    });
   });
 });

--- a/src/components/CodeLookup/engine.ts
+++ b/src/components/CodeLookup/engine.ts
@@ -580,6 +580,19 @@ export function searchShards(
       if (!prev || r.score > prev.score) best.set(r.fullid, r);
     }
     results = [...best.values()];
+    if (collapse) {
+      // label hits were collapsed per family inside searchShard, but code
+      // hits are flat — collapse the merged list so a family never shows
+      // twice. Highest score represents (an exact code beats its family's
+      // label row); members stay reachable through the drill-down.
+      const fams = new Map<string, CodifyResult>();
+      for (const r of results) {
+        const key = familyKey(r.domain, r.label, r.fullcode);
+        const prev = fams.get(key);
+        if (!prev || r.score > prev.score) fams.set(key, r);
+      }
+      results = [...fams.values()];
+    }
   }
   results.sort((a, b) => b.score - a.score);
   return results.slice(0, limit);

--- a/src/components/CodeLookup/engine.ts
+++ b/src/components/CodeLookup/engine.ts
@@ -491,6 +491,12 @@ function codeIndex(s: CodifyShard): { keys: string[]; docs: Uint32Array } {
   return s.codeIndex;
 }
 
+/** Cap on code-index entries scanned per shard per query — a short ambiguous
+ * prefix ("e1", "99") stops early instead of walking thousands of codes. The
+ * scan starts at the exact match, so the skipped tail is only ever the
+ * longest (lowest-scoring) extensions. */
+const MAX_CODE_SCAN = 1000;
+
 function searchShardCodes(
   s: CodifyShard,
   q: string,
@@ -509,10 +515,22 @@ function searchShardCodes(
   }
   const billable =
     opts?.billableOnly && s.domain === 'condition' ? billableMask(s) : null;
-  for (let i = lo; i < keys.length && keys[i].startsWith(q); i++) {
+  // codetype boost — same contract as searchShard (see SearchOptions)
+  let boostIdx: Set<number> | null = null;
+  if (opts?.boostCodetypes) {
+    const idx = opts.boostCodetypes
+      .map((ct) => s.codetypes.indexOf(ct))
+      .filter((i) => i >= 0);
+    if (idx.length > 0) boostIdx = new Set(idx);
+  }
+  const end = Math.min(keys.length, lo + MAX_CODE_SCAN);
+  for (let i = lo; i < end && keys[i].startsWith(q); i++) {
     const d = docs[i];
     if (billable && billable[d] !== 1) continue;
-    const score = CODE_MATCH_BASE * (q.length / keys[i].length);
+    const score =
+      CODE_MATCH_BASE *
+      (q.length / keys[i].length) *
+      (boostIdx && boostIdx.has(s.docCodetype[d]) ? CODETYPE_BOOST : 1);
     pushResult(out, s, d, score, false, false, limit * 3, true);
   }
 }

--- a/src/components/CodeLookup/engine.ts
+++ b/src/components/CodeLookup/engine.ts
@@ -49,6 +49,8 @@ export interface CodifyShard {
   touched: Uint32Array;
   /** Lazy cache: 1 = billable (leaf) ICD-10 code; see billableMask() */
   billable?: Uint8Array;
+  /** Lazy cache: sorted normalized code keys + doc ids; see codeIndex() */
+  codeIndex?: { keys: string[]; docs: Uint32Array };
 }
 
 export interface CodifyResult {
@@ -62,6 +64,8 @@ export interface CodifyResult {
   viaAlias: boolean;
   /** true when the match came (partly) from the edit-distance typo fallback */
   viaFuzzy?: boolean;
+  /** true when the match came from the code itself (query looked like a code) */
+  viaCode?: boolean;
 }
 
 // =============================================================================
@@ -443,6 +447,76 @@ export interface SearchOptions {
  * ICD-10 code outranks a shorter, leading-matched SNOMED synonym. */
 const CODETYPE_BOOST = 3;
 
+// =============================================================================
+// Code search — only label/alias words are tokenized in the shards, so a
+// typed code ("I50.9", "2345-7", "73211009") is matched by prefix against a
+// lazily built sorted index of the shard's codes.
+// =============================================================================
+
+/** Base score for direct code matches — far above any label match, decaying
+ * with the unmatched suffix so exact codes rank above their extensions. */
+const CODE_MATCH_BASE = 1000;
+
+/** Strip a code (or code-shaped query) to lowercase alphanumerics, so
+ * "I50.9" matches "i509" regardless of dot/dash formatting. */
+function codeKey(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/** A query "looks like a code" when it is a single word containing a digit
+ * (e.g. "I50.9", "j45", "2345-7"). Returns the normalized key, else null. */
+function codeQueryKey(query: string): string | null {
+  const trimmed = query.trim();
+  if (trimmed === '' || /\s/.test(trimmed)) return null;
+  const key = codeKey(trimmed);
+  return key.length >= 2 && key.length <= 18 && /\d/.test(key) ? key : null;
+}
+
+/** Lazily built code index: normalized code keys sorted ascending, with
+ * their doc ids in parallel. Cached on the shard like `billable`. */
+function codeIndex(s: CodifyShard): { keys: string[]; docs: Uint32Array } {
+  if (s.codeIndex) return s.codeIndex;
+  const pairs: { key: string; d: number }[] = [];
+  for (let d = 0; d < s.docCount; d++) {
+    const key = codeKey(
+      td.decode(s.codeBlob.subarray(s.codeOffsets[d], s.codeOffsets[d + 1]))
+    );
+    if (key) pairs.push({ key, d });
+  }
+  pairs.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  s.codeIndex = {
+    keys: pairs.map((p) => p.key),
+    docs: new Uint32Array(pairs.map((p) => p.d)),
+  };
+  return s.codeIndex;
+}
+
+function searchShardCodes(
+  s: CodifyShard,
+  q: string,
+  out: CodifyResult[],
+  limit: number,
+  opts?: SearchOptions
+) {
+  const { keys, docs } = codeIndex(s);
+  // first key >= q (binary search)
+  let lo = 0;
+  let hi = keys.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (keys[mid] < q) lo = mid + 1;
+    else hi = mid;
+  }
+  const billable =
+    opts?.billableOnly && s.domain === 'condition' ? billableMask(s) : null;
+  for (let i = lo; i < keys.length && keys[i].startsWith(q); i++) {
+    const d = docs[i];
+    if (billable && billable[d] !== 1) continue;
+    const score = CODE_MATCH_BASE * (q.length / keys[i].length);
+    pushResult(out, s, d, score, false, false, limit * 3, true);
+  }
+}
+
 /**
  * Lazily computed billable mask for a condition shard: an ICD-10 code is
  * treated as billable when no other ICD-10 code extends it (leaf = valid at
@@ -489,11 +563,23 @@ export function searchShards(
     .split(' ')
     .filter(Boolean)
     .slice(0, MAX_QUERY_TOKENS);
-  if (qTokens.length === 0) return [];
-  const results: CodifyResult[] = [];
+  const codeQ = codeQueryKey(query);
+  if (qTokens.length === 0 && !codeQ) return [];
+  let results: CodifyResult[] = [];
 
   for (const s of shards) {
-    searchShard(s, qTokens, results, limit, collapse, opts);
+    if (qTokens.length > 0)
+      searchShard(s, qTokens, results, limit, collapse, opts);
+    if (codeQ) searchShardCodes(s, codeQ, results, limit, opts);
+  }
+  if (codeQ) {
+    // a doc can match by both label and code — keep the higher-scoring hit
+    const best = new Map<string, CodifyResult>();
+    for (const r of results) {
+      const prev = best.get(r.fullid);
+      if (!prev || r.score > prev.score) best.set(r.fullid, r);
+    }
+    results = [...best.values()];
   }
   results.sort((a, b) => b.score - a.score);
   return results.slice(0, limit);
@@ -684,7 +770,8 @@ function pushResult(
   score: number,
   viaAlias: boolean,
   viaFuzzy: boolean,
-  cap: number
+  cap: number,
+  viaCode = false
 ) {
   // keep the array bounded: replace the current minimum once at capacity
   if (out.length >= cap) {
@@ -710,5 +797,6 @@ function pushResult(
     score,
     viaAlias,
     viaFuzzy,
+    viaCode,
   });
 }


### PR DESCRIPTION
## Problem

The codify shards only tokenize **label/alias words** — codes live in `codeBlob` for display only. Typing a code like `I50.9` into CodeLookup (or the ConditionEditor / OrderEditor / MedicationEditor lookups) returned nothing.
<img width="738" height="235" alt="image" src="https://github.com/user-attachments/assets/a44518ab-ae27-4b9e-ab61-5c800228d38c" />

## Fix (runtime — no shard rebuild or format change)

<img width="800" alt="code working" src="https://github.com/user-attachments/assets/038500ee-ddf7-4f11-bbbb-4cad12cf2edb" />

- A **code-shaped query** (single word containing a digit: `I50.9`, `e11`, `2345-7`, `73211009`) additionally runs a code-prefix search via `searchShardCodes`.
- Comparison is punctuation-insensitive (`I50.9` ≡ `i509`), against a lazily built sorted code index cached per shard (same pattern as `billableMask`), binary-searched per keystroke.
- Exact codes rank first, extensions after; code hits score above label hits; `billableOnly` is respected; label/code hits for the same doc dedupe. Results carry a new `viaCode` flag.
- Works with all existing published `.mcdx` shards — indexing codes at build time would pollute the token dictionary (`I50.9` → `i50` + `9`) and skew BM25 idf for label search.

## Validation

- 5 new unit tests in `engine.test.ts` (exact code, prefix ranking, code-vs-label priority, no false trigger on word queries, dedupe) — 23/23 pass.
- Verified live in Storybook: `I50.9` returns *Heart failure, unspecified · ICD10 I50.9* as top result.
- `pnpm typecheck` and `pnpm lint` clean.