### PR TITLE
ci(a11y): enforce axe checks in Storybook test-runner

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,0 +1,32 @@
+import type { TestRunnerConfig } from '@storybook/test-runner';
+import { getStoryContext } from '@storybook/test-runner';
+import { injectAxe, checkA11y, configureAxe } from 'axe-playwright';
+
+/**
+ * Runs axe-core against every story after it renders (and after its play
+ * function completes), failing CI on violations. Honors the same `a11y`
+ * story/preview parameters as the addon-a11y panel:
+ *
+ * - `a11y: { disable: true }` or `a11y: { test: 'off' }` skips the story
+ * - `a11y.config.rules` (e.g. the global rule exclusions in preview.tsx)
+ *   are applied to the axe run
+ */
+const config: TestRunnerConfig = {
+  async preVisit(page) {
+    await injectAxe(page);
+  },
+  async postVisit(page, context) {
+    const storyContext = await getStoryContext(page, context);
+    const a11y = storyContext.parameters?.a11y;
+    if (a11y?.disable || a11y?.test === 'off') return;
+
+    await configureAxe(page, { rules: a11y?.config?.rules ?? [] });
+    await checkA11y(page, '#storybook-root', {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+      axeOptions: a11y?.options,
+    });
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
     "ag-grid-community": "^35.1.0",
     "ag-grid-react": "^35.1.0",
     "autoprefixer": "^10.4.24",
+    "axe-playwright": "^2.2.2",
     "bootstrap": "^5.3.8",
     "codemirror": "^6.0.2",
     "d3": "^7.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.24
         version: 10.4.24(postcss@8.5.15)
+      axe-playwright:
+        specifier: ^2.2.2
+        version: 2.2.2(playwright@1.58.2)
       bootstrap:
         specifier: ^5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -1944,6 +1947,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/junit-report-builder@3.0.2':
+    resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
+
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
@@ -2377,6 +2383,17 @@ packages:
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
+
+  axe-html-reporter@2.2.11:
+    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
+    engines: {node: '>=8.9.0'}
+    peerDependencies:
+      axe-core: '>=3'
+
+  axe-playwright@2.2.2:
+    resolution: {integrity: sha512-h350/grzDCPgpuWV7eEOqr/f61Xn07Gi9f9B3Ew4rW6/nFtpdEJYW6jgRATorgAGXjEAYFTnaY3sEys39wDw4A==}
+    peerDependencies:
+      playwright: '>1.0.0'
 
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
@@ -4071,6 +4088,10 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  junit-report-builder@5.1.2:
+    resolution: {integrity: sha512-HzvLbEQcoqN2LmGnloShxu2hLadi/rkOTU3zt61UeMICLS0wGDvbf8neIi6+bGkxMnAePIcFMFnbqV+r6YvwxA==}
+    engines: {node: '>=16'}
+
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -4513,6 +4534,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -5884,6 +5909,10 @@ packages:
 
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -7770,6 +7799,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/junit-report-builder@3.0.2': {}
+
   '@types/katex@0.16.8': {}
 
   '@types/luxon@3.7.1': {}
@@ -8233,6 +8264,20 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.1: {}
+
+  axe-html-reporter@2.2.11(axe-core@4.11.1):
+    dependencies:
+      axe-core: 4.11.1
+      mustache: 4.2.0
+
+  axe-playwright@2.2.2(playwright@1.58.2):
+    dependencies:
+      '@types/junit-report-builder': 3.0.2
+      axe-core: 4.11.1
+      axe-html-reporter: 2.2.11(axe-core@4.11.1)
+      junit-report-builder: 5.1.2
+      picocolors: 1.1.1
+      playwright: 1.58.2
 
   axios@1.16.0:
     dependencies:
@@ -10365,6 +10410,12 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  junit-report-builder@5.1.2:
+    dependencies:
+      lodash: 4.18.1
+      make-dir: 3.1.0
+      xmlbuilder: 15.1.1
+
   katex@0.16.47:
     dependencies:
       commander: 8.3.0
@@ -10990,6 +11041,8 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -12603,6 +12656,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xml@1.0.1: {}
+
+  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 

--- a/src/components/ESheet/EsheetBuilder.stories.tsx
+++ b/src/components/ESheet/EsheetBuilder.stories.tsx
@@ -67,6 +67,17 @@ const builderMeta: Meta<typeof EsheetBuilder> = {
   component: EsheetBuilder,
   parameters: {
     layout: 'fullscreen',
+    a11y: {
+      config: {
+        rules: [
+          // TODO(esheet): the active mode tab (`.ms:bg-msprimary-active` +
+          // white label) fails WCAG AA contrast. The fix belongs in the
+          // esheet submodule (BuilderHeader.tsx / msprimary tokens) — a
+          // separate repo/PR. Re-enable once that lands.
+          { id: 'color-contrast', enabled: false },
+        ],
+      },
+    },
     docs: {
       description: {
         component: `

--- a/src/components/Markdown/CodeBlock.tsx
+++ b/src/components/Markdown/CodeBlock.tsx
@@ -21,7 +21,15 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ code, language }) => {
 
   return (
     <FenceBlock code={code} language={language}>
-      <pre className="m-0 overflow-x-auto !bg-transparent p-3 text-sm">
+      {/* Focusable so keyboard users can horizontally scroll long lines
+          (axe: scrollable-region-focusable). */}
+      <pre
+        className="m-0 overflow-x-auto !bg-transparent p-3 text-sm"
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable code needs keyboard focus
+        tabIndex={0}
+        role="region"
+        aria-label={language ? `${language} code` : 'Code'}
+      >
         <code
           className="hljs bg-transparent p-0"
           dangerouslySetInnerHTML={{ __html: html }}

--- a/src/components/Markdown/FenceBlock.tsx
+++ b/src/components/Markdown/FenceBlock.tsx
@@ -118,7 +118,13 @@ export const FenceBlock: React.FC<FenceBlockProps> = ({
           </pre>
         </div>
       ) : showRaw ? (
-        <pre className="overflow-x-auto p-3 text-sm">
+        <pre
+          className="overflow-x-auto p-3 text-sm"
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable code needs keyboard focus (axe: scrollable-region-focusable)
+          tabIndex={0}
+          role="region"
+          aria-label="Raw code"
+        >
           <code>{code}</code>
         </pre>
       ) : (

--- a/src/components/Markdown/styles.css
+++ b/src/components/Markdown/styles.css
@@ -11,7 +11,10 @@
 /* Layout (theme-agnostic) */
 pre code.hljs {
   display: block;
-  overflow-x: auto;
+  /* No own scrollbar — the parent <pre> (focusable, tabIndex=0) is the single
+   * scroll container. A scrollable but unfocusable <code> fails axe's
+   * scrollable-region-focusable rule. */
+  overflow-x: visible;
   padding: 1em;
   /* Transparent so the parent container's background is the single source of truth */
   background: transparent;

--- a/src/components/MediaPlayer/MediaPlayer.tsx
+++ b/src/components/MediaPlayer/MediaPlayer.tsx
@@ -195,8 +195,19 @@ export const MediaPlayer = React.forwardRef<MediaPlayerRef, MediaPlayerProps>(
             role="alert"
             className="border-destructive/30 bg-destructive/10 flex min-h-36 flex-col items-center justify-center gap-3 rounded-lg border p-8 text-center"
           >
-            <p className="text-destructive m-0 text-sm">{error}</p>
-            <Button variant="outline" size="sm" onClick={handleRetry}>
+            {/* destructive-700/300 instead of the base token: #dc2626 on the
+                destructive/10 tint is 4.14:1 — below WCAG AA (axe: color-contrast). */}
+            <p className="text-destructive-700 dark:text-destructive-300 m-0 text-sm">
+              {error}
+            </p>
+            {/* bg-background: the outline button is transparent, and its text on
+                the destructive/10 tint sits exactly at the 4.5:1 AA boundary. */}
+            <Button
+              variant="outline"
+              size="sm"
+              className="bg-background"
+              onClick={handleRetry}
+            >
               Retry
             </Button>
           </div>

--- a/src/components/SuperChat/plugins/mermaid.tsx
+++ b/src/components/SuperChat/plugins/mermaid.tsx
@@ -286,6 +286,12 @@ function MermaidDiagram({ code }: { code: string }) {
     <div
       data-slot="superchat-mermaid"
       className="my-2 overflow-x-auto [&_svg]:h-auto [&_svg]:max-w-none"
+      // Wide diagrams scroll horizontally; keyboard users need focus to scroll
+      // (axe: scrollable-region-focusable).
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={0}
+      role="region"
+      aria-label="Diagram"
       // mermaid renders with securityLevel: 'strict' (labels sanitized, scripts
       // stripped), so the SVG is safe to inject directly.
       dangerouslySetInnerHTML={{ __html: svg }}


### PR DESCRIPTION
The "Accessibility Tests" CI job ran the test-runner without axe hooks, so stories only smoke-rendered and violations passed silently. Add .storybook/test-runner.ts with injectAxe/checkA11y honoring existing a11y story parameters, and fix the violations this surfaced:

- Markdown/styles.css: hljs gave the inner <code> its own overflow-x, creating an unfocusable second scroll region inside the focusable <pre> (scrollable-region-focusable)
- SuperChat mermaid wrapper: scrollable diagram now keyboard-focusable with role=region + label (scrollable-region-focusable)
- MediaPlayer error state: destructive text on the destructive/10 tint measured 4.14:1; use destructive-700/dark:300 and give the outline Retry button a solid background (color-contrast)
- EsheetBuilder stories: color-contrast excluded with a TODO — the failing Build tab lives in the esheet submodule (separate repo)