### PR TITLE
feat(storybook): restore one-click "Open canvas in new tab" toolbar button

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,5 +1,8 @@
-import { addons } from 'storybook/manager-api';
+import React from 'react';
+import { addons, types } from 'storybook/manager-api';
 import { create } from 'storybook/theming/create';
+import { IconButton } from 'storybook/internal/components';
+import { ShareAltIcon } from '@storybook/icons';
 
 // Brand theme configurations for the Storybook manager UI
 const brandThemes = {
@@ -473,4 +476,47 @@ addons.register('mieweb-404-redirect', (api) => {
       selectFallbackIfAvailable();
     }
   }, POLL_INTERVAL_MS);
+});
+
+// Storybook 10 moved "Open canvas in new tab" into the Share menu; restore a
+// one-click toolbar button that opens the bare story iframe (current globals
+// preserved) in a new tab.
+addons.register('mieweb-open-in-new-tab', (api) => {
+  addons.add('mieweb-open-in-new-tab/tool', {
+    type: types.TOOLEXTRA,
+    title: 'Open canvas in new tab',
+    match: ({ viewMode, tabId }) => viewMode === 'story' && !tabId,
+    render: () =>
+      React.createElement(
+        IconButton,
+        {
+          key: 'mieweb-open-in-new-tab',
+          title: 'Open canvas in new tab',
+          'aria-label': 'Open canvas in new tab',
+          onClick: () => {
+            const { storyId } = api.getUrlState();
+            if (!storyId) return;
+            const url = new URL('iframe.html', window.location.href);
+            url.searchParams.set('id', storyId);
+            url.searchParams.set('viewMode', 'story');
+            // Canvas-inspection tools (measure/outline) shouldn't follow the
+            // story into the popped-out tab; object-valued globals (viewport,
+            // backgrounds, …) don't survive `key:value` URL encoding, so only
+            // primitive globals are forwarded.
+            const EXCLUDED_GLOBALS = new Set(['measureEnabled', 'outline']);
+            const globalsParam = Object.entries(api.getGlobals() ?? {})
+              .filter(
+                ([key, value]) =>
+                  !EXCLUDED_GLOBALS.has(key) &&
+                  ['string', 'number', 'boolean'].includes(typeof value)
+              )
+              .map(([key, value]) => `${key}:${value}`)
+              .join(';');
+            if (globalsParam) url.searchParams.set('globals', globalsParam);
+            window.open(url.toString(), '_blank', 'noopener,noreferrer');
+          },
+        },
+        React.createElement(ShareAltIcon)
+      ),
+  });
 });

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -510,8 +510,15 @@ addons.register('mieweb-open-in-new-tab', (api) => {
               'locale',
             ]);
             const globalsParam = Object.entries(api.getGlobals() ?? {})
-              .filter(([key]) => FORWARDED_GLOBALS.has(key))
-              .map(([key, value]) => `${key}:${value}`)
+              .filter(([key, value]) => {
+                if (!FORWARDED_GLOBALS.has(key)) return false;
+                return (
+                  typeof value === 'string' ||
+                  typeof value === 'number' ||
+                  typeof value === 'boolean'
+                );
+              })
+              .map(([key, value]) => `${key}:${String(value)}`)
               .join(';');
             if (globalsParam) url.searchParams.set('globals', globalsParam);
             window.open(url.toString(), '_blank', 'noopener,noreferrer');

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addons, types } from 'storybook/manager-api';
 import { create } from 'storybook/theming/create';
-import { IconButton } from 'storybook/internal/components';
+import { IconButton } from 'storybook/components';
 import { ShareAltIcon } from '@storybook/icons';
 
 // Brand theme configurations for the Storybook manager UI

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -499,17 +499,18 @@ addons.register('mieweb-open-in-new-tab', (api) => {
             const url = new URL('iframe.html', window.location.href);
             url.searchParams.set('id', storyId);
             url.searchParams.set('viewMode', 'story');
-            // Canvas-inspection tools (measure/outline) shouldn't follow the
-            // story into the popped-out tab; object-valued globals (viewport,
-            // backgrounds, …) don't survive `key:value` URL encoding, so only
-            // primitive globals are forwarded.
-            const EXCLUDED_GLOBALS = new Set(['measureEnabled', 'outline']);
+            // Only forward this project's toolbar globals (see preview.tsx
+            // globalTypes); tool globals (measure/outline) and object-valued
+            // globals (viewport, backgrounds, a11y) must not follow the story
+            // into the popped-out tab.
+            const FORWARDED_GLOBALS = new Set([
+              'brand',
+              'theme',
+              'density',
+              'locale',
+            ]);
             const globalsParam = Object.entries(api.getGlobals() ?? {})
-              .filter(
-                ([key, value]) =>
-                  !EXCLUDED_GLOBALS.has(key) &&
-                  ['string', 'number', 'boolean'].includes(typeof value)
-              )
+              .filter(([key]) => FORWARDED_GLOBALS.has(key))
               .map(([key, value]) => `${key}:${value}`)
               .join(';');
             if (globalsParam) url.searchParams.set('globals', globalsParam);

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -347,7 +347,9 @@ const preview: Preview = {
     },
     // Show the story source in a "Code" panel tab (next to Controls). Note: for stories with a custom
     // `render`, Storybook shows the render snippet/args, not the full component source.
-    docs: { codePanel: true },
+    // `canvas.withToolbar` gives every docs canvas (not just the primary story) the
+    // zoom / "Open canvas in new tab" toolbar.
+    docs: { codePanel: true, canvas: { withToolbar: true } },
     layout: 'padded',
     options: {
       storySort: {


### PR DESCRIPTION
Storybook 10 moved "Open canvas in new tab" into the Share menu, making a common workflow two clicks. This restores a one-click toolbar button.

## Changes
- **.storybook/manager.ts**: new `mieweb-open-in-new-tab` manager addon — a toolbar button (after Share) that opens the bare story `iframe.html` in a new tab.
  - Forwards only primitive globals (`brand`, `theme`, `density`, `locale`), so the pop-out keeps its brand/theme context.
  - Excludes canvas-inspection globals (`measureEnabled`, `outline`) so measure/outline overlays do not follow the story into the new tab.
  - Skips object-valued globals (`viewport`, `backgrounds`, `a11y`), which cannot survive `key:value` URL encoding (previously serialized as `[object Object]`).
- **.storybook/preview.tsx**: enable `docs.canvas.withToolbar` so docs canvases get the same zoom/pop-out toolbar.

## Testing
- Verified in the running Storybook: with the Measure tool active, the pop-out URL is `iframe.html?id=…&viewMode=story&globals=brand:bluehive;theme:light;density:standard;locale:en` — no measure overlay, no `[object Object]` params.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:fix` all pass.