### PR TITLE
fix(storybook): correct IconButton import path — manager build broken on main

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addons, types } from 'storybook/manager-api';
 import { create } from 'storybook/theming/create';
-import { IconButton } from 'storybook/components';
+import { IconButton } from 'storybook/internal/components';
 import { ShareAltIcon } from '@storybook/icons';
 
 // Brand theme configurations for the Storybook manager UI


### PR DESCRIPTION
## Problem

#337 imported `IconButton` from `storybook/components`, which is **not an export** of the `storybook` package — v10 exposes it at `storybook/internal/components`. The manager build fails, so **every PR's CI has been failing** on its merge commit since (e.g. #336's run: https://github.com/mieweb/ui/actions/runs/30071361166).

## Fix

One-line import path correction. `storybook build` verified locally (manager + preview compile clean).

Unblocks #336 and any other open PRs once merged.