### PR TITLE
feat(DateInput): enforce min and max date bounds in calendar picker

### DIFF
--- a/src/components/DateInput/DateInput.stories.tsx
+++ b/src/components/DateInput/DateInput.stories.tsx
@@ -36,6 +36,14 @@ const meta: Meta<typeof DateInput> = {
     validateOnBlur: {
       control: 'boolean',
     },
+    minDate: {
+      control: 'text',
+      description: 'Earliest allowed date in MM/DD/YYYY format',
+    },
+    maxDate: {
+      control: 'text',
+      description: 'Latest allowed date in MM/DD/YYYY format',
+    },
   },
   decorators: [
     (Story) => (
@@ -69,6 +77,16 @@ export const WithCalendarPreFilled: Story = {
     showCalendar: true,
     width: 'fixed',
     value: '06/15/2026',
+  },
+};
+
+export const WithDateBounds: Story = {
+  args: {
+    label: 'Service Date',
+    minDate: '07/27/2024',
+    maxDate: '07/27/2028',
+    validateOnBlur: true,
+    showCalendar: true,
   },
 };
 

--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithTheme } from '../../test/test-utils';
+import { DateInput } from './DateInput';
+
+describe('DateInput', () => {
+  it('shows only calendar years within its date bounds', async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <DateInput
+        label="Service date"
+        minDate="07/19/2001"
+        maxDate="07/19/2025"
+        showCalendar
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+
+    const years = Array.from(
+      screen.getByLabelText('Select year').querySelectorAll('option')
+    ).map((option) => option.textContent);
+
+    expect(years).toEqual(
+      Array.from({ length: 25 }, (_, index) => String(2001 + index))
+    );
+  });
+});

--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -1,10 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithTheme } from '../../test/test-utils';
 import { DateInput } from './DateInput';
 
 describe('DateInput', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('shows only calendar years within its date bounds', async () => {
     const user = userEvent.setup();
 
@@ -26,5 +30,53 @@ describe('DateInput', () => {
     expect(years).toEqual(
       Array.from({ length: 25 }, (_, index) => String(2001 + index))
     );
+  });
+
+  it('does not select an out-of-range month', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithTheme(
+      <DateInput
+        label="Service month"
+        inputType="month"
+        value="2025-07"
+        minDate="07/15/2025"
+        maxDate="08/15/2025"
+        onChange={onChange}
+        showCalendar
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    await user.click(screen.getByRole('button', { name: 'Jun' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps Today enabled for a partially valid current month', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 27));
+    const onChange = vi.fn();
+
+    renderWithTheme(
+      <DateInput
+        label="Service month"
+        inputType="month"
+        minDate="07/28/2026"
+        maxDate="08/10/2026"
+        onChange={onChange}
+        showCalendar
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open calendar' }));
+
+    const todayButton = screen.getByRole('button', { name: 'Today' });
+    expect(todayButton).toBeEnabled();
+
+    fireEvent.click(todayButton);
+
+    expect(onChange).toHaveBeenCalledWith('2026-07');
   });
 });

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -372,12 +372,17 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const minimumDate = minDate ? parseDateValue(minDate) : null;
     const maximumDate = maxDate ? parseDateValue(maxDate) : null;
 
-    const isDateInRange = (date: Date) => {
-      return (
-        (!minimumDate || date >= minimumDate) &&
-        (!maximumDate || date <= maximumDate)
-      );
-    };
+const isDateInRange = (date: Date) => {
+  const candidate = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate()
+  );
+  return (
+    (!minimumDate || candidate >= minimumDate) &&
+    (!maximumDate || candidate <= maximumDate)
+  );
+};
 
     const isCalendarDateInRange = (day: number) => {
       return isDateInRange(new Date(calendarYear, calendarMonth, day));

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -458,7 +458,13 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
       setCalendarMonth(closestAllowedDate.getMonth());
       setCalendarYear(closestAllowedDate.getFullYear());
-    }, [calendarMonth, calendarYear, isCalendarMonthInRange, maximumDate, minimumDate]);
+    }, [
+      calendarMonth,
+      calendarYear,
+      isCalendarMonthInRange,
+      maximumDate,
+      minimumDate,
+    ]);
 
     // Close calendar on click outside
     React.useEffect(() => {

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../utils/cn';
 import {
   formatDateValue,
   isValidDate,
+  parseDateValue,
   isDateInPast,
   isDateInFuture,
   calculateAge,
@@ -145,6 +146,10 @@ export interface DateInputProps extends Omit<
   minAge?: number;
   /** Maximum age for DOB validation */
   maxAge?: number;
+  /** Earliest allowed date in MM/DD/YYYY format. */
+  minDate?: string;
+  /** Latest allowed date in MM/DD/YYYY format. */
+  maxDate?: string;
   /** Whether to validate on blur */
   validateOnBlur?: boolean;
   /** Whether to show a calendar picker button */
@@ -157,7 +162,9 @@ function getValidationError(
   value: string,
   mode: DateInputMode,
   minAge?: number,
-  maxAge?: number
+  maxAge?: number,
+  minDate?: string,
+  maxDate?: string
 ): string | undefined {
   if (!value || value.replace(/\D/g, '').length === 0) {
     return undefined;
@@ -165,6 +172,18 @@ function getValidationError(
 
   if (!isValidDate(value)) {
     return 'Please enter a valid date (MM/DD/YYYY)';
+  }
+
+  const selectedDate = parseDateValue(value);
+  const minimumDate = minDate ? parseDateValue(minDate) : null;
+  const maximumDate = maxDate ? parseDateValue(maxDate) : null;
+
+  if (selectedDate && minimumDate && selectedDate < minimumDate) {
+    return `Date must be on or after ${minDate}`;
+  }
+
+  if (selectedDate && maximumDate && selectedDate > maximumDate) {
+    return `Date must be on or before ${maxDate}`;
   }
 
   switch (mode) {
@@ -240,6 +259,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       mode = 'default',
       minAge,
       maxAge,
+      minDate,
+      maxDate,
       validateOnBlur,
       showCalendar = false,
       width = 'full',
@@ -282,7 +303,9 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           displayValue,
           mode,
           minAge,
-          maxAge
+          maxAge,
+          minDate,
+          maxDate
         );
         setLocalError(validationError);
       }
@@ -346,6 +369,53 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         ? value.slice(-5)
         : '00:00'
     );
+    const minimumDate = minDate ? parseDateValue(minDate) : null;
+    const maximumDate = maxDate ? parseDateValue(maxDate) : null;
+
+    const isDateInRange = (date: Date) => {
+      return (
+        (!minimumDate || date >= minimumDate) &&
+        (!maximumDate || date <= maximumDate)
+      );
+    };
+
+    const isCalendarDateInRange = (day: number) => {
+      return isDateInRange(new Date(calendarYear, calendarMonth, day));
+    };
+
+    const isCalendarMonthInRange = (month: number, year: number) => {
+      const firstDay = new Date(year, month, 1);
+      const lastDay = new Date(year, month + 1, 0);
+      return (
+        (!minimumDate || lastDay >= minimumDate) &&
+        (!maximumDate || firstDay <= maximumDate)
+      );
+    };
+
+    const firstCalendarYear = minimumDate
+      ? minimumDate.getFullYear()
+      : new Date().getFullYear() - 100;
+    const lastCalendarYear = maximumDate
+      ? maximumDate.getFullYear()
+      : new Date().getFullYear() + 49;
+    const calendarYears = Array.from(
+      { length: Math.max(0, lastCalendarYear - firstCalendarYear + 1) },
+      (_, index) => firstCalendarYear + index
+    );
+    const previousCalendarMonth = calendarMonth === 0 ? 11 : calendarMonth - 1;
+    const previousCalendarYear =
+      calendarMonth === 0 ? calendarYear - 1 : calendarYear;
+    const nextCalendarMonth = calendarMonth === 11 ? 0 : calendarMonth + 1;
+    const nextCalendarYear =
+      calendarMonth === 11 ? calendarYear + 1 : calendarYear;
+    const canGoToPreviousCalendar =
+      inputType === 'month'
+        ? !minimumDate || calendarYear > minimumDate.getFullYear()
+        : isCalendarMonthInRange(previousCalendarMonth, previousCalendarYear);
+    const canGoToNextCalendar =
+      inputType === 'month'
+        ? !maximumDate || calendarYear < maximumDate.getFullYear()
+        : isCalendarMonthInRange(nextCalendarMonth, nextCalendarYear);
 
     // Update calendar view when value changes
     React.useEffect(() => {
@@ -357,6 +427,16 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         setSelectedTime(displayValue.slice(-5));
       }
     }, [displayValue, inputType]);
+
+    React.useEffect(() => {
+      if (isCalendarMonthInRange(calendarMonth, calendarYear)) return;
+
+      const closestAllowedDate = minimumDate ?? maximumDate;
+      if (!closestAllowedDate) return;
+
+      setCalendarMonth(closestAllowedDate.getMonth());
+      setCalendarYear(closestAllowedDate.getFullYear());
+    }, [calendarMonth, calendarYear, minimumDate, maximumDate]);
 
     // Close calendar on click outside
     React.useEffect(() => {
@@ -394,6 +474,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     }, [isCalendarOpen]);
 
     const handleDateSelect = (day: number) => {
+      if (!isCalendarDateInRange(day)) return;
+
       const month = String(calendarMonth + 1).padStart(2, '0');
       const dayStr = String(day).padStart(2, '0');
       const year = String(calendarYear);
@@ -413,7 +495,9 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           formatted,
           mode,
           minAge,
-          maxAge
+          maxAge,
+          minDate,
+          maxDate
         );
         setLocalError(validationError);
       }
@@ -424,6 +508,18 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       setDisplayValue(formatted);
       onChange?.(formatted);
       setIsCalendarOpen(false);
+    };
+
+    const handleCalendarYearChange = (year: number) => {
+      setCalendarYear(year);
+      if (isCalendarMonthInRange(calendarMonth, year)) return;
+
+      const firstAvailableMonth = MONTH_NAMES.findIndex((_, month) =>
+        isCalendarMonthInRange(month, year)
+      );
+      if (firstAvailableMonth !== -1) {
+        setCalendarMonth(firstAvailableMonth);
+      }
     };
 
     const handleTimeChange = (part: 'hour' | 'minute', nextValue: string) => {
@@ -517,7 +613,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   setCalendarMonth(calendarMonth - 1);
                 }
               }}
-              className="hover:bg-muted rounded-md p-1 transition-colors"
+              disabled={!canGoToPreviousCalendar}
+              className="hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               aria-label={
                 inputType === 'month' ? 'Previous year' : 'Previous month'
               }
@@ -532,23 +629,24 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   className="bg-background border-border rounded border px-2 py-1 text-sm"
                   aria-label="Select month"
                 >
-                  {MONTH_NAMES.map((name, i) => (
-                    <option key={name} value={i}>
-                      {name}
-                    </option>
-                  ))}
+                  {MONTH_NAMES.map((name, month) =>
+                    isCalendarMonthInRange(month, calendarYear) ? (
+                      <option key={name} value={month}>
+                        {name}
+                      </option>
+                    ) : null
+                  )}
                 </select>
               )}
               <select
                 value={calendarYear}
-                onChange={(e) => setCalendarYear(Number(e.target.value))}
+                onChange={(e) =>
+                  handleCalendarYearChange(Number(e.target.value))
+                }
                 className="bg-background border-border rounded border px-2 py-1 text-sm"
                 aria-label="Select year"
               >
-                {Array.from(
-                  { length: 150 },
-                  (_, i) => new Date().getFullYear() - 100 + i
-                ).map((year) => (
+                {calendarYears.map((year) => (
                   <option key={year} value={year}>
                     {year}
                   </option>
@@ -567,7 +665,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   setCalendarMonth(calendarMonth + 1);
                 }
               }}
-              className="hover:bg-muted rounded-md p-1 transition-colors"
+              disabled={!canGoToNextCalendar}
+              className="hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               aria-label={inputType === 'month' ? 'Next year' : 'Next month'}
             >
               <ChevronRightIcon />
@@ -611,13 +710,16 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   <button
                     key={index}
                     type="button"
-                    disabled={day === null}
+                    disabled={day === null || !isCalendarDateInRange(day)}
                     onClick={() => day && handleDateSelect(day)}
                     className={cn(
                       'h-8 w-8 rounded-md text-sm transition-colors',
                       'focus:ring-ring focus:ring-2 focus:outline-none',
                       day === null && 'invisible',
                       day !== null && 'hover:bg-muted',
+                      day !== null &&
+                        !isCalendarDateInRange(day) &&
+                        'cursor-not-allowed opacity-50',
                       isSelectedDay(day!) &&
                         'bg-primary-800 hover:bg-primary-900 text-white',
                       isToday(day!) &&
@@ -710,7 +812,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   handleDateSelect(today.getDate());
                 }
               }}
-              className="text-primary-800 flex-1 text-sm hover:underline"
+              disabled={!isDateInRange(new Date())}
+              className="text-primary-800 flex-1 text-sm hover:underline disabled:cursor-not-allowed disabled:opacity-50"
             >
               Today
             </button>

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -369,33 +369,48 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         ? value.slice(-5)
         : '00:00'
     );
-    const minimumDate = minDate ? parseDateValue(minDate) : null;
-    const maximumDate = maxDate ? parseDateValue(maxDate) : null;
+    const minimumDate = React.useMemo(
+      () => (minDate ? parseDateValue(minDate) : null),
+      [minDate]
+    );
+    const maximumDate = React.useMemo(
+      () => (maxDate ? parseDateValue(maxDate) : null),
+      [maxDate]
+    );
 
-const isDateInRange = (date: Date) => {
-  const candidate = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate()
-  );
-  return (
-    (!minimumDate || candidate >= minimumDate) &&
-    (!maximumDate || candidate <= maximumDate)
-  );
-};
+    const isDateInRange = React.useCallback(
+      (date: Date) => {
+        const candidate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate()
+        );
+        return (
+          (!minimumDate || candidate >= minimumDate) &&
+          (!maximumDate || candidate <= maximumDate)
+        );
+      },
+      [maximumDate, minimumDate]
+    );
 
-    const isCalendarDateInRange = (day: number) => {
-      return isDateInRange(new Date(calendarYear, calendarMonth, day));
-    };
+    const isCalendarDateInRange = React.useCallback(
+      (day: number) => {
+        return isDateInRange(new Date(calendarYear, calendarMonth, day));
+      },
+      [calendarMonth, calendarYear, isDateInRange]
+    );
 
-    const isCalendarMonthInRange = (month: number, year: number) => {
-      const firstDay = new Date(year, month, 1);
-      const lastDay = new Date(year, month + 1, 0);
-      return (
-        (!minimumDate || lastDay >= minimumDate) &&
-        (!maximumDate || firstDay <= maximumDate)
-      );
-    };
+    const isCalendarMonthInRange = React.useCallback(
+      (month: number, year: number) => {
+        const firstDay = new Date(year, month, 1);
+        const lastDay = new Date(year, month + 1, 0);
+        return (
+          (!minimumDate || lastDay >= minimumDate) &&
+          (!maximumDate || firstDay <= maximumDate)
+        );
+      },
+      [maximumDate, minimumDate]
+    );
 
     const firstCalendarYear = minimumDate
       ? minimumDate.getFullYear()
@@ -441,7 +456,7 @@ const isDateInRange = (date: Date) => {
 
       setCalendarMonth(closestAllowedDate.getMonth());
       setCalendarYear(closestAllowedDate.getFullYear());
-    }, [calendarMonth, calendarYear, minimumDate, maximumDate]);
+    }, [calendarMonth, calendarYear, isCalendarMonthInRange, maximumDate, minimumDate]);
 
     // Close calendar on click outside
     React.useEffect(() => {

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -532,6 +532,8 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     };
 
     const handleMonthSelect = (month: number) => {
+      if (!isCalendarMonthInRange(month, calendarYear)) return;
+
       const formatted = `${calendarYear}-${String(month + 1).padStart(2, '0')}`;
       setDisplayValue(formatted);
       onChange?.(formatted);
@@ -840,7 +842,14 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                   handleDateSelect(today.getDate());
                 }
               }}
-              disabled={!isDateInRange(new Date())}
+              disabled={
+                inputType === 'month'
+                  ? !isCalendarMonthInRange(
+                      new Date().getMonth(),
+                      new Date().getFullYear()
+                    )
+                  : !isDateInRange(new Date())
+              }
               className="text-primary-800 flex-1 text-sm hover:underline disabled:cursor-not-allowed disabled:opacity-50"
             >
               Today

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -177,13 +177,15 @@ function getValidationError(
   const selectedDate = parseDateValue(value);
   const minimumDate = minDate ? parseDateValue(minDate) : null;
   const maximumDate = maxDate ? parseDateValue(maxDate) : null;
+  const minimumDateLabel = minDate ? formatDateValue(minDate) : '';
+  const maximumDateLabel = maxDate ? formatDateValue(maxDate) : '';
 
   if (selectedDate && minimumDate && selectedDate < minimumDate) {
-    return `Date must be on or after ${minDate}`;
+    return `Date must be on or after ${minimumDateLabel}`;
   }
 
   if (selectedDate && maximumDate && selectedDate > maximumDate) {
-    return `Date must be on or before ${maxDate}`;
+    return `Date must be on or before ${maximumDateLabel}`;
   }
 
   switch (mode) {

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -634,7 +634,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                 }
               }}
               disabled={!canGoToPreviousCalendar}
-              className="hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="enabled:hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               aria-label={
                 inputType === 'month' ? 'Previous year' : 'Previous month'
               }


### PR DESCRIPTION
## Summary

Enhances `DateInput` with configurable `minDate` and `maxDate` bounds that are enforced consistently in both typed input validation and the calendar picker.

## Changes

- Adds `minDate` and `maxDate` props using the existing `MM/DD/YYYY` format.
- Validates typed dates on blur with clear range-specific errors.
- Prevents calendar selection of dates outside the configured range.
- Limits calendar years and available months to valid values.
- Disables previous/next navigation and the `Today` shortcut when they would move outside the range.
- Keeps the calendar view within valid bounds when values or constraints change.
- Adds Storybook controls and a `WithDateBounds` example.
- Adds a regression test confirming the year selector includes only years within the configured bounds.

## User Impact

Users can no longer select invalid dates through the calendar UI, reducing late validation failures and making date constraints visible before submission. Components without date bounds retain their current behavior.

<img width="1046" height="527" alt="image" src="https://github.com/user-attachments/assets/7c6fb119-3a24-44a6-9e9c-cc3cff94f0d6" />

Unavailable dates are not grayed out. and years that are out of bond does not appear - same with the months
