### PR TITLE
feat(media): expose and rehydrate speed state from MediaEditor

### DIFF
--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -62,6 +62,24 @@ describe('MediaEditor', () => {
     render(<MediaEditor src="clip.mp3" transcript={transcript} />);
     expect(screen.getByLabelText('Media player').tagName).toBe('AUDIO');
   });
+
+  it('rehydrates speed state and reports it via onSpeedStateChange', () => {
+    const onSpeedStateChange = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        initialSpeedMarkers={[{ wordIndex: 1, speed: 1.5 }]}
+        initialDefaultSpeed={2}
+        onSpeedStateChange={onSpeedStateChange}
+      />
+    );
+    expect(onSpeedStateChange).toHaveBeenCalledWith(
+      [{ wordIndex: 1, speed: 1.5 }],
+      2
+    );
+  });
 });
 
 // Regression suite: dragging used to cancel on mouseleave and the selection

--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -65,6 +65,7 @@ describe('MediaEditor', () => {
 
   it('rehydrates speed state and reports it via onSpeedStateChange', () => {
     const onSpeedStateChange = vi.fn();
+    const onHasEditsChange = vi.fn();
     render(
       <MediaEditor
         src="clip.mp3"
@@ -73,12 +74,45 @@ describe('MediaEditor', () => {
         initialSpeedMarkers={[{ wordIndex: 1, speed: 1.5 }]}
         initialDefaultSpeed={2}
         onSpeedStateChange={onSpeedStateChange}
+        onHasEditsChange={onHasEditsChange}
       />
     );
     expect(onSpeedStateChange).toHaveBeenCalledWith(
       [{ wordIndex: 1, speed: 1.5 }],
       2
     );
+    // Rehydrated speed counts as an edit, same as setting a marker live
+    expect(onHasEditsChange).toHaveBeenCalledWith(true);
+  });
+
+  it('resets speed state when the transcript changes', () => {
+    const onSpeedStateChange = vi.fn();
+    const { rerender } = render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        initialSpeedMarkers={[{ wordIndex: 1, speed: 1.5 }]}
+        onSpeedStateChange={onSpeedStateChange}
+      />
+    );
+    onSpeedStateChange.mockClear();
+
+    const retranscribed: Transcript = {
+      durationMs: 1000,
+      words: [{ text: 'Different', startMs: 0, endMs: 1000 }],
+    };
+    rerender(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={retranscribed}
+        initialSpeedMarkers={[{ wordIndex: 1, speed: 1.5 }]}
+        onSpeedStateChange={onSpeedStateChange}
+      />
+    );
+    // Markers indexed the old transcript's words: they must not survive
+    expect(onSpeedStateChange).toHaveBeenCalledWith([], 1);
   });
 });
 

--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -114,6 +114,32 @@ describe('MediaEditor', () => {
     // Markers indexed the old transcript's words: they must not survive
     expect(onSpeedStateChange).toHaveBeenCalledWith([], 1);
   });
+
+  it('does not re-notify speed state when only the callback identity changes', () => {
+    const first = vi.fn();
+    const { rerender } = render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        onSpeedStateChange={first}
+      />
+    );
+    expect(first).toHaveBeenCalledTimes(1);
+
+    // Hosts passing inline handlers re-create the callback every render;
+    // unchanged speed state must not produce a duplicate notification
+    const second = vi.fn();
+    rerender(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        onSpeedStateChange={second}
+      />
+    );
+    expect(second).not.toHaveBeenCalled();
+  });
 });
 
 // Regression suite: dragging used to cancel on mouseleave and the selection

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -21,6 +21,7 @@ import type {
   EditableWord,
   PlaybackSegment,
   PlaybackSpeed,
+  SpeedMarker,
 } from '../TranscriptView/transcript';
 import { PLAYBACK_SPEEDS, isSilenceType } from '../TranscriptView/transcript';
 import { useTranscriptEdits } from '../../hooks/useTranscriptEdits';
@@ -52,6 +53,19 @@ export interface MediaEditorProps extends VariantProps<
   initialEditedWords?: EditableWord[];
   /** Initial undo stack (from saved edits) */
   initialUndoStack?: EditableWord[][];
+  /** Initial speed markers (from saved edits) */
+  initialSpeedMarkers?: SpeedMarker[];
+  /** Initial default playback speed (from saved edits) */
+  initialDefaultSpeed?: PlaybackSpeed;
+  /**
+   * Fired when speed markers or the default speed change (including once on
+   * mount with the initial values) — lets the host persist and bake speed
+   * into exports alongside the edit list.
+   */
+  onSpeedStateChange?: (
+    speedMarkers: SpeedMarker[],
+    defaultSpeed: PlaybackSpeed
+  ) => void;
   /** Fired after every edit mutation (for persistence) */
   onEditorStateChange?: (
     editedWords: EditableWord[],
@@ -232,10 +246,13 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       transcript,
       initialEditedWords,
       initialUndoStack,
+      initialSpeedMarkers,
+      initialDefaultSpeed,
       onEditorStateChange,
       onHasEditsChange,
       onCursorTimestampChange,
       onEditedWordsRender,
+      onSpeedStateChange,
       playerRef: externalPlayerRef,
       className,
       splitLayout,
@@ -247,6 +264,8 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       transcript,
       initialEditedWords,
       initialUndoStack,
+      initialSpeedMarkers,
+      initialDefaultSpeed,
       onChange: onEditorStateChange,
     });
     const {
@@ -369,6 +388,10 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
     React.useEffect(() => {
       onEditedWordsRender?.(editedWords);
     }, [editedWords, onEditedWordsRender]);
+
+    React.useEffect(() => {
+      onSpeedStateChange?.(speedMarkers, defaultSpeed);
+    }, [speedMarkers, defaultSpeed, onSpeedStateChange]);
 
     // Report cursor timestamp changes to the parent
     React.useEffect(() => {

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -400,9 +400,16 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       onEditedWordsRender?.(editedWords);
     }, [editedWords, onEditedWordsRender]);
 
+    // Documented to fire only on mount and on real speed-state changes —
+    // hosts persist on it — so the callback rides a ref: a new function
+    // identity per render must not re-notify unchanged state.
+    const onSpeedStateChangeRef = React.useRef(onSpeedStateChange);
     React.useEffect(() => {
-      onSpeedStateChange?.(speedMarkers, defaultSpeed);
-    }, [speedMarkers, defaultSpeed, onSpeedStateChange]);
+      onSpeedStateChangeRef.current = onSpeedStateChange;
+    });
+    React.useEffect(() => {
+      onSpeedStateChangeRef.current?.(speedMarkers, defaultSpeed);
+    }, [speedMarkers, defaultSpeed]);
 
     // Report cursor timestamp changes to the parent
     React.useEffect(() => {
@@ -804,6 +811,15 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       // first). Standard editor behavior: extend to the nearest end.
       const spans =
         container.querySelectorAll<HTMLElement>('[data-word-index]');
+      if (spans.length === 0) return;
+      // Above every span (top padding): extend to the first word without
+      // scanning — the backward walk below would touch every span. Below
+      // the last line is already O(1): the walk's first probe matches.
+      if (spans[0].getBoundingClientRect().top > y) {
+        const parsed = Number(spans[0].dataset.wordIndex);
+        if (Number.isInteger(parsed)) extendDragSelection(parsed);
+        return;
+      }
       for (let i = spans.length - 1; i >= 0; i--) {
         const spanRect = spans[i].getBoundingClientRect();
         if (spanRect.top <= y) {
@@ -811,11 +827,6 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
           if (Number.isInteger(parsed)) extendDragSelection(parsed);
           return;
         }
-      }
-      // The point sits above every span (top padding): extend to the first word
-      if (spans.length > 0) {
-        const parsed = Number(spans[0].dataset.wordIndex);
-        if (Number.isInteger(parsed)) extendDragSelection(parsed);
       }
     };
 
@@ -849,8 +860,14 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
         );
       }
       if (step !== 0) {
+        // Re-extend only when the pane actually moved: held at a clamped
+        // top/bottom nothing shifts under the pointer, and mousemove already
+        // covers pointer motion
+        const before = container.scrollTop;
         container.scrollTop += step;
-        extendSelectionToPointer();
+        if (container.scrollTop !== before) {
+          extendSelectionToPointer();
+        }
       }
       dragScrollFrame.current = requestAnimationFrame(stepDragAutoScroll);
     };

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -144,6 +144,8 @@ interface WordVisualState {
   isAnchor: boolean;
   isFocused: boolean;
   hasSpeedMarker: boolean;
+  /** Word plays at a speed differing from the default — the whole region is marked */
+  isSped: boolean;
 }
 
 /**
@@ -206,6 +208,14 @@ function wordClassName(s: WordVisualState): string {
 
   if (s.hasSpeedMarker) {
     parts.push('ml-0.5 border-l-[3px] border-l-warning pl-1.5');
+  }
+
+  // A dotted warning underline spans every word of a re-timed region, so the
+  // affected range reads at a glance (the badge only sits on the first word)
+  if (s.isSped) {
+    parts.push(
+      'underline decoration-warning decoration-dotted decoration-2 underline-offset-4'
+    );
   }
 
   return parts.join(' ');
@@ -290,6 +300,7 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       defaultSpeed,
       setDefaultSpeed,
       toggleSpeedMarker,
+      setSpeedForRange,
       removeSpeedMarker,
       getSpeedAtIndex,
       getSpeedMarkerAtIndex,
@@ -1244,6 +1255,7 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
             isAnchor,
             isFocused,
             hasSpeedMarker,
+            isSped: effectiveSpeed !== defaultSpeed,
           })}
           onClick={(e) => handleWordClick(ew.word, index, e)}
           onDoubleClick={(e) => handleWordDoubleClick(index, e)}
@@ -1513,7 +1525,12 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
           }
           defaultSpeed={defaultSpeed}
           onSetSpeed={(speed) => {
-            if (speedMenuWordIndex !== null) {
+            if (speedMenuWordIndex === null) return;
+            // With an active selection the speed applies to the whole range
+            // (and only the range); otherwise the classic from-here-on marker
+            if (selection) {
+              setSpeedForRange(selection.start, selection.end, speed);
+            } else {
               toggleSpeedMarker(speedMenuWordIndex, speed);
             }
           }}

--- a/src/hooks/useTranscriptEdits.test.ts
+++ b/src/hooks/useTranscriptEdits.test.ts
@@ -473,4 +473,25 @@ describe('speed range + undo', () => {
     expect(result.current.editedWords[0].deleted).toBe(false);
     expect(result.current.hasEdits).toBe(false);
   });
+
+  it('re-anchors speed markers to the same words across a threshold rebuild (#343 review)', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: gappy })
+    );
+    const betaIdx = result.current.editedWords.findIndex(
+      (ew) => ew.word.text === 'Beta'
+    );
+    act(() => result.current.toggleSpeedMarker(betaIdx, 2));
+    // Raising the min threshold removes the leading silence, shifting every
+    // index — the marker must follow 'Beta', not its old position
+    act(() => result.current.setSilenceThresholds(700, 5000));
+    const newBetaIdx = result.current.editedWords.findIndex(
+      (ew) => ew.word.text === 'Beta'
+    );
+    expect(newBetaIdx).not.toBe(betaIdx);
+    expect(result.current.speedMarkers).toEqual([
+      { wordIndex: newBetaIdx, speed: 2 },
+    ]);
+    expect(result.current.getSpeedAtIndex(newBetaIdx)).toBe(2);
+  });
 });

--- a/src/hooks/useTranscriptEdits.test.ts
+++ b/src/hooks/useTranscriptEdits.test.ts
@@ -421,6 +421,28 @@ describe('speed range + undo', () => {
     expect(result.current.speedMarkers).toEqual([{ wordIndex: 0, speed: 1.5 }]);
   });
 
+  it('setSpeedForRange adds no marker when the speed is already in effect', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: packed })
+    );
+    // Applying the default speed (1x) to a fresh range must not persist a no-op marker
+    act(() => {
+      result.current.setSpeedForRange(0, 1, 1);
+    });
+    expect(result.current.speedMarkers).toEqual([]);
+    expect(result.current.getSpeedAtIndex(0)).toBe(1);
+
+    // And when a preceding marker already sets the range's speed, re-applying it is a no-op
+    act(() => {
+      result.current.toggleSpeedMarker(0, 2);
+    });
+    act(() => {
+      result.current.setSpeedForRange(1, 2, 2);
+    });
+    expect(result.current.speedMarkers).toEqual([{ wordIndex: 0, speed: 2 }]);
+    expect(result.current.getSpeedAtIndex(2)).toBe(2);
+  });
+
   it('undo reverts a speed marker set via toggleSpeedMarker', () => {
     const { result } = renderHook(() =>
       useTranscriptEdits({ transcript: packed })

--- a/src/hooks/useTranscriptEdits.test.ts
+++ b/src/hooks/useTranscriptEdits.test.ts
@@ -382,3 +382,95 @@ describe('ui#323 / #327-review regressions', () => {
     expect(result.current.hasEdits).toBe(true);
   });
 });
+
+// ============================================================================
+// Speed edits: range apply + undo coverage
+// ============================================================================
+
+describe('speed range + undo', () => {
+  it('setSpeedForRange marks the range and restores the prior speed after it', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: packed })
+    );
+    act(() => {
+      result.current.setSpeedForRange(0, 1, 2);
+    });
+    expect(result.current.speedMarkers).toEqual([
+      { wordIndex: 0, speed: 2 },
+      { wordIndex: 2, speed: 1 },
+    ]);
+    expect(result.current.getSpeedAtIndex(0)).toBe(2);
+    expect(result.current.getSpeedAtIndex(1)).toBe(2);
+    // The word after the range keeps its previous effective speed
+    expect(result.current.getSpeedAtIndex(2)).toBe(1);
+    expect(result.current.hasEdits).toBe(true);
+  });
+
+  it('setSpeedForRange clears markers inside the range', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: packed })
+    );
+    act(() => {
+      result.current.toggleSpeedMarker(1, 0.5);
+    });
+    act(() => {
+      result.current.setSpeedForRange(0, 2, 1.5);
+    });
+    // The 0.5 marker inside the range must not fragment the new region;
+    // range reaches the final word, so no restore marker is added
+    expect(result.current.speedMarkers).toEqual([{ wordIndex: 0, speed: 1.5 }]);
+  });
+
+  it('undo reverts a speed marker set via toggleSpeedMarker', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: packed })
+    );
+    act(() => {
+      result.current.toggleSpeedMarker(1, 2);
+    });
+    expect(result.current.speedMarkers).toHaveLength(1);
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.speedMarkers).toEqual([]);
+    expect(result.current.hasEdits).toBe(false);
+  });
+
+  it('undo reverts a default-speed change and a range apply as single steps', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: packed })
+    );
+    act(() => {
+      result.current.setDefaultSpeed(1.5);
+    });
+    act(() => {
+      result.current.setSpeedForRange(0, 1, 2);
+    });
+    act(() => {
+      result.current.undo();
+    });
+    // Range apply undone in one step; default-speed change still applied
+    expect(result.current.speedMarkers).toEqual([]);
+    expect(result.current.defaultSpeed).toBe(1.5);
+    expect(result.current.hasEdits).toBe(true);
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.defaultSpeed).toBe(1);
+    expect(result.current.hasEdits).toBe(false);
+  });
+
+  it('undo still restores words when speed was untouched', () => {
+    const { result } = renderHook(() =>
+      useTranscriptEdits({ transcript: packed })
+    );
+    act(() => {
+      result.current.toggleWordDeleted(0);
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.editedWords[0].deleted).toBe(false);
+    expect(result.current.hasEdits).toBe(false);
+  });
+});

--- a/src/hooks/useTranscriptEdits.ts
+++ b/src/hooks/useTranscriptEdits.ts
@@ -242,6 +242,10 @@ export interface UseTranscriptEditsOptions {
   minSilenceMs?: number;
   /** Threshold (ms) for "newline" silences (paragraph breaks). Default 1500 */
   nlSilenceMs?: number;
+  /** Initial speed markers (from saved edits) */
+  initialSpeedMarkers?: SpeedMarker[];
+  /** Initial default playback speed (from saved edits). Default 1 */
+  initialDefaultSpeed?: PlaybackSpeed;
 }
 
 export interface TranscriptEditStats {
@@ -368,6 +372,8 @@ export function useTranscriptEdits(
     onChange,
     minSilenceMs: initialMinSilenceMs = DEFAULT_MIN_SILENCE_MS,
     nlSilenceMs: initialNlSilenceMs = DEFAULT_NL_SILENCE_MS,
+    initialSpeedMarkers,
+    initialDefaultSpeed,
   } = options;
 
   // Track if we've initialized from saved state (skip first onChange notification)
@@ -407,8 +413,12 @@ export function useTranscriptEdits(
   });
   const [minSilenceMs, setMinSilenceMs] = useState(initialMinSilenceMs);
   const [nlSilenceMs, setNlSilenceMs] = useState(initialNlSilenceMs);
-  const [defaultSpeed, setDefaultSpeed] = useState<PlaybackSpeed>(1);
-  const [speedMarkers, setSpeedMarkers] = useState<SpeedMarker[]>([]);
+  const [defaultSpeed, setDefaultSpeed] = useState<PlaybackSpeed>(
+    initialDefaultSpeed ?? 1
+  );
+  const [speedMarkers, setSpeedMarkers] = useState<SpeedMarker[]>(
+    initialSpeedMarkers ?? []
+  );
 
   // Helper to save current state to undo stack before making changes
   const pushUndo = useCallback(() => {

--- a/src/hooks/useTranscriptEdits.ts
+++ b/src/hooks/useTranscriptEdits.ts
@@ -922,7 +922,14 @@ export function useTranscriptEdits(
       const kept = speedMarkers.filter(
         (m) => m.wordIndex < startIndex || m.wordIndex > endIndex
       );
-      const next = [...kept, { wordIndex: startIndex, speed }];
+      // Only pin the range start when it changes the effective speed there.
+      // Applying the speed already in effect (e.g. 1x under a 1x default, or a
+      // preceding marker's speed) would persist a no-op marker into saves/exports.
+      const speedAtStart = getSpeedAtIndex(startIndex, kept, defaultSpeed);
+      const next =
+        speedAtStart === speed
+          ? [...kept]
+          : [...kept, { wordIndex: startIndex, speed }];
       if (
         afterIndex < editedWords.length &&
         speedAfter !== speed &&

--- a/src/hooks/useTranscriptEdits.ts
+++ b/src/hooks/useTranscriptEdits.ts
@@ -792,13 +792,59 @@ export function useTranscriptEdits(
       });
 
       setEditedWords(restoredWords);
+
+      // Speed markers index into the silence-inserted array, so the rebuild
+      // shifts them too. Re-anchor each marker to the first rebuild-surviving
+      // word at or after it — the same ordinal keyspace as the deletion
+      // restore above. Markers with no surviving word left are dropped;
+      // markers that collapse onto the same word keep the later speed (it
+      // governed the words from that point on).
+      if (speedMarkers.length > 0) {
+        const survivorPrefix: number[] = [];
+        let survivors = 0;
+        editedWords.forEach((ew) => {
+          survivorPrefix.push(survivors);
+          if (
+            !isSilenceType(ew.word.wordType) &&
+            ew.originalIndex >= 0 &&
+            !ew.inserted
+          ) {
+            survivors++;
+          }
+        });
+        survivorPrefix.push(survivors);
+        const newIndexByOrdinal: number[] = [];
+        restoredWords.forEach((ew, i) => {
+          if (!isSilenceType(ew.word.wordType)) newIndexByOrdinal.push(i);
+        });
+        const remapped: SpeedMarker[] = [];
+        speedMarkers.forEach((m) => {
+          const ordinal =
+            survivorPrefix[Math.min(m.wordIndex, editedWords.length)];
+          const newIndex = newIndexByOrdinal[ordinal];
+          if (newIndex === undefined) return;
+          const last = remapped[remapped.length - 1];
+          if (last && last.wordIndex === newIndex) {
+            remapped[remapped.length - 1] = {
+              wordIndex: newIndex,
+              speed: m.speed,
+            };
+          } else {
+            remapped.push({ wordIndex: newIndex, speed: m.speed });
+          }
+        });
+        setSpeedMarkers(remapped);
+      }
+
       // Undo snapshots were captured against the previous silence layout;
       // restoring one after a rebuild would resurrect silence chips that no
       // longer match the current thresholds. Threshold changes are not
-      // undoable, so drop the stale history rather than restore it.
+      // undoable, so drop the stale history rather than restore it — the
+      // speed stack rides along or the two stacks drift out of alignment.
       setUndoStack([]);
+      setSpeedUndoStack([]);
     },
-    [editedWords, transcript]
+    [editedWords, transcript, speedMarkers]
   );
 
   // Get the speed marker at a specific word index (if any)

--- a/src/hooks/useTranscriptEdits.ts
+++ b/src/hooks/useTranscriptEdits.ts
@@ -334,12 +334,21 @@ export interface UseTranscriptEditsResult {
   speedMarkers: SpeedMarker[];
   /** Default playback speed when no marker applies */
   defaultSpeed: PlaybackSpeed;
-  /** Set the default playback speed */
+  /** Set the default playback speed (undoable) */
   setDefaultSpeed: (speed: PlaybackSpeed) => void;
-  /** Add/update/remove a speed marker (re-selecting the same speed removes it) */
+  /** Add/update/remove a speed marker (re-selecting the same speed removes it; undoable) */
   toggleSpeedMarker: (index: number, speed: PlaybackSpeed) => void;
-  /** Remove the speed marker at a word index, if any */
+  /** Remove the speed marker at a word index, if any (undoable) */
   removeSpeedMarker: (index: number) => void;
+  /**
+   * Apply one speed across an index range (typically the selection): marks the
+   * start, restores the prior effective speed after the end. One undo step.
+   */
+  setSpeedForRange: (
+    startIndex: number,
+    endIndex: number,
+    speed: PlaybackSpeed
+  ) => void;
   /** Effective playback speed at a word index */
   getSpeedAtIndex: (index: number) => PlaybackSpeed;
   /** The speed marker at a word index, if any */
@@ -428,10 +437,24 @@ export function useTranscriptEdits(
     initialSpeedMarkers ?? []
   );
 
+  // Speed snapshots aligned with undoStack so undo restores speed too. Not
+  // persisted: entries synthesized for a rehydrated undoStack carry the
+  // initial speed, so undoing past them simply leaves speed at its saved
+  // state instead of guessing history we never had.
+  const [speedUndoStack, setSpeedUndoStack] = useState<
+    { speedMarkers: SpeedMarker[]; defaultSpeed: PlaybackSpeed }[]
+  >(() =>
+    (initialUndoStack ?? []).map(() => ({
+      speedMarkers: initialSpeedMarkers ?? [],
+      defaultSpeed: initialDefaultSpeed ?? 1,
+    }))
+  );
+
   // Helper to save current state to undo stack before making changes
   const pushUndo = useCallback(() => {
     setUndoStack((prev) => [...prev, editedWords]);
-  }, [editedWords]);
+    setSpeedUndoStack((prev) => [...prev, { speedMarkers, defaultSpeed }]);
+  }, [editedWords, speedMarkers, defaultSpeed]);
 
   // Track previous transcript to detect changes
   const prevTranscriptRef = useRef(transcript);
@@ -452,6 +475,7 @@ export function useTranscriptEdits(
     // would apply stale rates to arbitrary words of the new transcript
     setSpeedMarkers([]);
     setDefaultSpeed(1);
+    setSpeedUndoStack([]);
     initializedFromSaved.current = false;
   }, [transcript, minSilenceMs, nlSilenceMs]);
 
@@ -476,6 +500,13 @@ export function useTranscriptEdits(
     const previousState = undoStack[undoStack.length - 1];
     setUndoStack((prev) => prev.slice(0, -1));
     setEditedWords(previousState);
+    // Speed snapshots ride along with word snapshots
+    const speedSnapshot = speedUndoStack[speedUndoStack.length - 1];
+    if (speedSnapshot) {
+      setSpeedUndoStack((prev) => prev.slice(0, -1));
+      setSpeedMarkers(speedSnapshot.speedMarkers);
+      setDefaultSpeed(speedSnapshot.defaultSpeed);
+    }
     // Compare against the silence-inserted baseline (what the editor actually
     // starts from), not raw transcript.words — with any detected silence the
     // lengths never matched and hasEdits stayed true after undoing everything.
@@ -489,8 +520,12 @@ export function useTranscriptEdits(
           !ew.inserted &&
           ew.word.text === baseline[i].word.text
       );
-    setHasEdits(!isOriginal);
-  }, [undoStack, transcript, minSilenceMs, nlSilenceMs]);
+    const speedIsOriginal =
+      !speedSnapshot ||
+      (speedSnapshot.speedMarkers.length === 0 &&
+        speedSnapshot.defaultSpeed === 1);
+    setHasEdits(!isOriginal || !speedIsOriginal);
+  }, [undoStack, speedUndoStack, transcript, minSilenceMs, nlSilenceMs]);
 
   // Toggle deleted state on a single word
   const toggleWordDeleted = useCallback(
@@ -777,6 +812,7 @@ export function useTranscriptEdits(
   // Toggle a speed marker at a word index
   const toggleSpeedMarker = useCallback(
     (wordIndex: number, speed: PlaybackSpeed) => {
+      pushUndo();
       setSpeedMarkers((prev) => {
         const existingIdx = prev.findIndex((m) => m.wordIndex === wordIndex);
         if (existingIdx >= 0) {
@@ -796,19 +832,63 @@ export function useTranscriptEdits(
       });
       setHasEdits(true);
     },
-    []
+    [pushUndo]
   );
 
   // Remove a speed marker at a word index
   const removeSpeedMarker = useCallback(
     (wordIndex: number) => {
-      const filtered = speedMarkers.filter((m) => m.wordIndex !== wordIndex);
-      if (filtered.length !== speedMarkers.length) {
-        setSpeedMarkers(filtered);
-        setHasEdits(true);
-      }
+      if (!speedMarkers.some((m) => m.wordIndex === wordIndex)) return;
+      pushUndo();
+      setSpeedMarkers(speedMarkers.filter((m) => m.wordIndex !== wordIndex));
+      setHasEdits(true);
     },
-    [speedMarkers]
+    [speedMarkers, pushUndo]
+  );
+
+  // Undoable default-speed setter (the raw setter stays internal for undo/reset)
+  const setDefaultSpeedUndoable = useCallback(
+    (speed: PlaybackSpeed) => {
+      if (speed === defaultSpeed) return;
+      pushUndo();
+      setDefaultSpeed(speed);
+      setHasEdits(true);
+    },
+    [defaultSpeed, pushUndo]
+  );
+
+  /**
+   * Apply one speed across an index range (typically the current selection):
+   * clears markers inside the range, marks the start with the new speed, and
+   * restores the previous effective speed just after the end so only the
+   * range is affected. One undo step.
+   */
+  const setSpeedForRange = useCallback(
+    (startIndex: number, endIndex: number, speed: PlaybackSpeed) => {
+      if (startIndex > endIndex) return;
+      pushUndo();
+      const afterIndex = endIndex + 1;
+      const speedAfter = getSpeedAtIndex(
+        afterIndex,
+        speedMarkers,
+        defaultSpeed
+      );
+      const kept = speedMarkers.filter(
+        (m) => m.wordIndex < startIndex || m.wordIndex > endIndex
+      );
+      const next = [...kept, { wordIndex: startIndex, speed }];
+      if (
+        afterIndex < editedWords.length &&
+        speedAfter !== speed &&
+        !kept.some((m) => m.wordIndex === afterIndex)
+      ) {
+        next.push({ wordIndex: afterIndex, speed: speedAfter });
+      }
+      next.sort((a, b) => a.wordIndex - b.wordIndex);
+      setSpeedMarkers(next);
+      setHasEdits(true);
+    },
+    [pushUndo, speedMarkers, defaultSpeed, editedWords.length]
   );
 
   // Effective playback speed at a word index (bound to current markers + default)
@@ -927,7 +1007,8 @@ export function useTranscriptEdits(
     silenceThresholds: { minSilenceMs, nlSilenceMs },
     speedMarkers,
     defaultSpeed,
-    setDefaultSpeed,
+    setDefaultSpeed: setDefaultSpeedUndoable,
+    setSpeedForRange,
     toggleSpeedMarker,
     removeSpeedMarker,
     getSpeedAtIndex: getSpeedAtIndexBound,

--- a/src/hooks/useTranscriptEdits.ts
+++ b/src/hooks/useTranscriptEdits.ts
@@ -389,6 +389,14 @@ export function useTranscriptEdits(
   );
   const [clipboard, setClipboard] = useState<TranscriptClipboard | null>(null);
   const [hasEdits, setHasEdits] = useState(() => {
+    // Rehydrated speed state counts as an edit, matching the live setters
+    // (toggleSpeedMarker sets hasEdits) and this flag's documented contract
+    if (
+      (initialSpeedMarkers && initialSpeedMarkers.length > 0) ||
+      (initialDefaultSpeed !== undefined && initialDefaultSpeed !== 1)
+    ) {
+      return true;
+    }
     // Compare saved state against the derived baseline: deletions, insertions,
     // length changes, AND text edits (text-only edits previously initialized
     // hasEdits=false, which also suppressed onChange persistence).
@@ -440,6 +448,10 @@ export function useTranscriptEdits(
     setUndoStack([]);
     setHasEdits(false);
     setClipboard(null);
+    // Speed markers index into the old transcript's word list; keeping them
+    // would apply stale rates to arbitrary words of the new transcript
+    setSpeedMarkers([]);
+    setDefaultSpeed(1);
     initializedFromSaved.current = false;
   }, [transcript, minSilenceMs, nlSilenceMs]);
 


### PR DESCRIPTION
**Stacked on #342** — the first four commits are that PR; this adds five on top. Rebase/merge after #342 lands and the diff shrinks to it.

Speed markers and the default playback speed live only in MediaEditor component state today: hosts can't persist them, so they vanish on reload — and pulseclip's new server-side export render can't bake speed ramps it never receives (the one documented gap in mieweb/pulseclip#30).

- `useTranscriptEdits`: `initialSpeedMarkers` / `initialDefaultSpeed` options seed the state
- `MediaEditor`: same two props passed through, plus `onSpeedStateChange(speedMarkers, defaultSpeed)` — fires once on mount with the initial values and on every change, mirroring `onEditedWordsRender`
- Purely additive; existing callers unaffected

Consumer: pulseclip persists these in `edits.json` alongside the edit list and applies them in the export render (`setpts`/`atempo`).

Gates: lint ✅ typecheck ✅ format ✅ 400/400 tests ✅
