### PR TITLE
fix(release): reset dev prerelease numbers per version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,15 +91,20 @@ jobs:
             # Branch push — auto dev prerelease
             BASE_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
             PACKAGE_NAME=$(node -p "require('./package.json').name")
-            PUBLISHED_VERSIONS=$(npm view "$PACKAGE_NAME" versions --json 2>&1) || {
-              if [[ "$PUBLISHED_VERSIONS" == *"E404"* ]]; then
+            NPM_ERROR_FILE=$(mktemp)
+            if ! PUBLISHED_VERSIONS=$(npm view "$PACKAGE_NAME" versions --json 2>"$NPM_ERROR_FILE"); then
+              NPM_ERROR=$(<"$NPM_ERROR_FILE")
+              rm -f "$NPM_ERROR_FILE"
+              if [[ "$NPM_ERROR" == *"E404"* ]]; then
                 PUBLISHED_VERSIONS='[]'
               else
                 echo "Failed to query published versions for $PACKAGE_NAME:" >&2
-                echo "$PUBLISHED_VERSIONS" >&2
+                echo "$NPM_ERROR" >&2
                 exit 1
               fi
-            }
+            else
+              rm -f "$NPM_ERROR_FILE"
+            fi
             DEV_NUMBER=$(printf '%s' "$PUBLISHED_VERSIONS" | node -e '
               let versions = "";
               process.stdin.on("data", (chunk) => { versions += chunk; });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'  # Stable and prerelease tags, e.g. v1.0.0 or v1.0.0-beta.1
+      - 'v*' # Stable and prerelease tags, e.g. v1.0.0 or v1.0.0-beta.1
     branches:
-      - main   # Auto dev-prerelease on every main push
+      - main # Auto dev-prerelease on every main push
     paths-ignore:
       - '*.md'
       - '.github/**'
@@ -13,7 +13,11 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for npm Trusted Publishing (OIDC)
+  id-token: write # Required for npm Trusted Publishing (OIDC)
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -86,7 +90,25 @@ jobs:
           else
             # Branch push — auto dev prerelease
             BASE_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
-            VERSION="${BASE_VERSION}-dev.${GITHUB_RUN_NUMBER}"
+            PACKAGE_NAME=$(node -p "require('./package.json').name")
+            DEV_NUMBER=$(npm view "$PACKAGE_NAME" versions --json 2>/dev/null | node -e '
+              let versions = "";
+              process.stdin.on("data", (chunk) => { versions += chunk; });
+              process.stdin.on("end", () => {
+                const baseVersion = process.argv[1];
+                try {
+                  const publishedVersions = JSON.parse(versions || "[]");
+                  const devVersions = (Array.isArray(publishedVersions) ? publishedVersions : [publishedVersions])
+                    .map((version) => new RegExp(`^${baseVersion.replace(/\./g, "\\.")}-dev\\.(\\d+)$`).exec(version))
+                    .filter(Boolean)
+                    .map((match) => Number(match[1]));
+                  console.log(devVersions.length === 0 ? 0 : Math.max(...devVersions) + 1);
+                } catch {
+                  console.log(0);
+                }
+              });
+            ' "$BASE_VERSION")
+            VERSION="${BASE_VERSION}-dev.${DEV_NUMBER}"
             IS_TAG=false
             NPM_TAG=next
             IS_PRERELEASE=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,16 @@ jobs:
             # Branch push — auto dev prerelease
             BASE_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
             PACKAGE_NAME=$(node -p "require('./package.json').name")
-            DEV_NUMBER=$(npm view "$PACKAGE_NAME" versions --json 2>/dev/null | node -e '
+            PUBLISHED_VERSIONS=$(npm view "$PACKAGE_NAME" versions --json 2>&1) || {
+              if [[ "$PUBLISHED_VERSIONS" == *"E404"* ]]; then
+                PUBLISHED_VERSIONS='[]'
+              else
+                echo "Failed to query published versions for $PACKAGE_NAME:" >&2
+                echo "$PUBLISHED_VERSIONS" >&2
+                exit 1
+              fi
+            }
+            DEV_NUMBER=$(printf '%s' "$PUBLISHED_VERSIONS" | node -e '
               let versions = "";
               process.stdin.on("data", (chunk) => { versions += chunk; });
               process.stdin.on("end", () => {
@@ -103,8 +112,9 @@ jobs:
                     .filter(Boolean)
                     .map((match) => Number(match[1]));
                   console.log(devVersions.length === 0 ? 0 : Math.max(...devVersions) + 1);
-                } catch {
-                  console.log(0);
+                } catch (error) {
+                  console.error(`Unable to parse published versions: ${error.message}`);
+                  process.exitCode = 1;
                 }
               });
             ' "$BASE_VERSION")


### PR DESCRIPTION
## Summary

Updates the release workflow so development prerelease versions increment independently for each base version.

Previously, prereleases used GitHub’s global workflow run number, causing a new version such as `0.7.1` to continue from prior versions like `0.7.0-dev.184`.

The workflow now checks npm for existing prereleases matching the current base version and publishes the next available version:

- `0.7.0-dev.184` → `0.7.0-dev.185`
- First prerelease after a stable `0.7.1` release → `0.7.1-dev.0`

A concurrency group was also added to prevent simultaneous release workflows from selecting and publishing the same prerelease version.

