### PR TITLE
feat(CollabStatus): transport-agnostic live-collaboration status chip

### DIFF
--- a/package.json
+++ b/package.json
@@ -414,7 +414,10 @@
     "vite": "^7.3.2",
     "vitest": "^3.2.6",
     "wavesurfer.js": "^7.12.1",
+    "y-protocols": "^1.0.6",
+    "y-websocket": "^3.0.0",
     "ychart": "file:./packages/ychart",
+    "yjs": "^13.6.30",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,9 +311,18 @@ importers:
       wavesurfer.js:
         specifier: ^7.12.1
         version: 7.12.1
+      y-protocols:
+        specifier: ^1.0.6
+        version: 1.0.6(yjs@13.6.30)
+      y-websocket:
+        specifier: ^3.0.0
+        version: 3.0.0(yjs@13.6.30)
       ychart:
         specifier: file:./packages/ychart
         version: '@mieweb/ychart@file:packages/ychart(@popperjs/core@2.11.8)'
+      yjs:
+        specifier: ^13.6.30
+        version: 13.6.30
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5922,6 +5931,12 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
       yjs: ^13.0.0
+
+  y-websocket@3.0.0:
+    resolution: {integrity: sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.5.6
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -12663,7 +12678,13 @@ snapshots:
 
   y-protocols@1.0.6(yjs@13.6.30):
     dependencies:
-      lib0: 0.2.109
+      lib0: 0.2.117
+      yjs: 13.6.30
+
+  y-websocket@3.0.0(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      y-protocols: 1.0.6(yjs@13.6.30)
       yjs: 13.6.30
 
   y18n@4.0.3: {}

--- a/src/components/CollabStatus/CollabStatus.stories.tsx
+++ b/src/components/CollabStatus/CollabStatus.stories.tsx
@@ -14,7 +14,8 @@ const meta: Meta<typeof CollabStatus> = {
         component: `
 Live-collaboration status chip for a header: connection dot, **Live** /
 **Connecting…** label, who else is editing, and a click-to-open panel with the
-room identity and a rolling log of collaboration events.
+room identity, the room's occupants and a rolling log of collaboration events.
+Pass \`compact\` to shrink the trigger down to the dot alone.
 
 The component itself is transport-agnostic — it renders the presence state you
 hand it.
@@ -80,6 +81,11 @@ story in a second tab to watch presence and the log light up.
       description: 'Set false for a status-only chip with no debug panel.',
       control: 'boolean',
     },
+    compact: {
+      description:
+        'Shrink the trigger to the bare dot; the status text moves into its accessible name.',
+      control: 'boolean',
+    },
     labels: { description: 'Overrides for any user-facing string (i18n).' },
   },
 };
@@ -113,6 +119,20 @@ export const WithPeers: Story = {
 
 export const StatusOnly: Story = {
   args: { connected: true, showLog: false, peers: [{ name: 'Ann Nurse' }] },
+};
+
+/** For headers with no room for a chip: the dot alone still opens the panel. */
+export const Compact: Story = {
+  args: {
+    connected: true,
+    compact: true,
+    room,
+    log: sampleLog,
+    peers: [
+      { name: 'Ann Nurse', color: '#2563eb' },
+      { name: 'Bo Tech', color: '#db2777' },
+    ],
+  },
 };
 
 // =============================================================================

--- a/src/components/CollabStatus/CollabStatus.stories.tsx
+++ b/src/components/CollabStatus/CollabStatus.stories.tsx
@@ -15,7 +15,8 @@ const meta: Meta<typeof CollabStatus> = {
 Live-collaboration status chip for a header: connection dot, **Live** /
 **Connecting…** label, who else is editing, and a click-to-open panel with the
 room identity, the room's occupants and a rolling log of collaboration events.
-Pass \`compact\` to shrink the trigger down to the dot alone.
+Pass \`compact\` to shrink the trigger down to the dot alone, and \`attention\` to
+let an app condition ("Unsaved changes") share that dot.
 
 The component itself is transport-agnostic — it renders the presence state you
 hand it.
@@ -86,6 +87,11 @@ story in a second tab to watch presence and the log light up.
         'Shrink the trigger to the bare dot; the status text moves into its accessible name.',
       control: 'boolean',
     },
+    attention: {
+      description:
+        'App condition that shares the dot (turns it amber) and heads the panel.',
+      control: 'text',
+    },
     labels: { description: 'Overrides for any user-facing string (i18n).' },
   },
 };
@@ -132,6 +138,16 @@ export const Compact: Story = {
       { name: 'Ann Nurse', color: '#2563eb' },
       { name: 'Bo Tech', color: '#db2777' },
     ],
+  },
+};
+
+/** One dot, two meanings: connected, but the app has work not yet saved. */
+export const Attention: Story = {
+  args: {
+    connected: true,
+    room,
+    log: sampleLog,
+    attention: 'Unsaved changes',
   },
 };
 

--- a/src/components/CollabStatus/CollabStatus.stories.tsx
+++ b/src/components/CollabStatus/CollabStatus.stories.tsx
@@ -1,0 +1,338 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { CollabStatus } from './CollabStatus';
+import { useYjsCollabStatus } from './useYjsCollabStatus';
+import { LocalYjsRoom, sampleLog, type LocalYjsMember } from './storyData';
+
+const meta: Meta<typeof CollabStatus> = {
+  title: 'Components/Status Indicators/CollabStatus',
+  component: CollabStatus,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Live-collaboration status chip for a header: connection dot, **Live** /
+**Connecting…** label, who else is editing, and a click-to-open panel with the
+room identity and a rolling log of collaboration events.
+
+The component itself is transport-agnostic — it renders the presence state you
+hand it.
+
+### Binding it to a Yjs server (the short version)
+
+\`@mieweb/ui\` has **no Yjs dependency**: \`useYjsCollabStatus\` types the doc,
+awareness and provider structurally, so a real \`Y.Doc\` / \`WebsocketProvider\`
+satisfies it as-is. Wire it up in three lines:
+
+\`\`\`tsx
+import * as Y from 'yjs';
+import { WebsocketProvider } from 'y-websocket';
+import { CollabStatus, useYjsCollabStatus } from '@mieweb/ui';
+
+function CaseHeader({ caseId, userId }: { caseId: string; userId: string }) {
+  const doc = React.useMemo(() => new Y.Doc(), []);
+  const provider = React.useMemo(
+    () => new WebsocketProvider(WS_BASE, \`case/\${caseId}\`, doc, {
+      params: { userId },              // wcts authorizes the socket on this
+    }),
+    [doc, caseId, userId]
+  );
+  React.useEffect(() => () => { provider.destroy(); doc.destroy(); }, [provider, doc]);
+
+  const status = useYjsCollabStatus({ doc, provider, user: { name: 'Ann' }, userId });
+  return <CollabStatus {...status} />;
+}
+\`\`\`
+
+The provider URL is \`\${WS_BASE}/\${room}\`, so a wcts hub listening on
+\`/sync/:type/:id\` takes \`WS_BASE = 'ws://localhost:39000/sync'\` and room
+\`case/4\`. \`useYjsCollabStatus\` also returns \`publishActivity(fields)\` —
+call it whenever you write to the doc so other windows can attribute the edit —
+and \`lastRemoteEdit\`, which is handy for a toast.
+
+Pass \`doc: null\` / \`provider: null\` to keep the hook inert (e.g. an offline
+or browser-only mode).
+
+### Trying it against a real server
+
+Any \`y-websocket\`-compatible server works:
+
+\`\`\`bash
+npx y-websocket --port 1234     # or: npm run dev in wcts (ws://localhost:39000/sync)
+\`\`\`
+
+then open the **Live Server Room** story, point it at the URL, and open the same
+story in a second tab to watch presence and the log light up.
+`,
+      },
+    },
+  },
+  argTypes: {
+    connected: {
+      description: 'True once the room completed its initial server sync.',
+      control: 'boolean',
+    },
+    peers: { description: 'Other people in the room right now.' },
+    log: { description: 'Recent collaboration events, newest first.' },
+    room: { description: 'Room identity shown at the top of the panel.' },
+    showLog: {
+      description: 'Set false for a status-only chip with no debug panel.',
+      control: 'boolean',
+    },
+    labels: { description: 'Overrides for any user-facing string (i18n).' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CollabStatus>;
+
+const room = {
+  name: 'case/4',
+  url: 'ws://localhost:39000/sync',
+  clientId: 2154903845,
+  userId: '8',
+};
+
+export const Connecting: Story = {
+  args: { connected: false, room, log: [] },
+};
+
+export const Live: Story = {
+  args: { connected: true, room, log: sampleLog },
+};
+
+export const WithPeers: Story = {
+  args: {
+    connected: true,
+    room,
+    log: sampleLog,
+    peers: [{ name: 'Ann Nurse' }, { name: 'Bo Tech' }, { name: 'Bo Tech' }],
+  },
+};
+
+export const StatusOnly: Story = {
+  args: { connected: true, showLog: false, peers: [{ name: 'Ann Nurse' }] },
+};
+
+// =============================================================================
+// Real Yjs room, in-memory transport
+// =============================================================================
+
+function RoomMember({
+  member,
+  name,
+  onLeave,
+}: {
+  member: LocalYjsMember;
+  name: string;
+  onLeave?: () => void;
+}) {
+  const status = useYjsCollabStatus({
+    doc: member.doc,
+    provider: member.provider,
+    user: { name },
+    userId: name,
+  });
+
+  return (
+    <div className="border-border flex items-center gap-3 rounded-lg border p-3">
+      <span className="text-foreground w-24 text-sm font-medium">{name}</span>
+      <CollabStatus {...status} />
+      <div className="ml-auto flex gap-2">
+        <button
+          type="button"
+          className="border-border rounded-md border px-2 py-1 text-xs"
+          onClick={() => {
+            LocalYjsRoom.type(member, `${name} typed. `);
+            status.publishActivity(['Case notes']);
+          }}
+        >
+          Edit notes
+        </button>
+        {onLeave && (
+          <button
+            type="button"
+            className="border-border rounded-md border px-2 py-1 text-xs"
+            onClick={onLeave}
+          >
+            Leave
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SimulatedRoomDemo() {
+  const roomRef = React.useRef<LocalYjsRoom | null>(null);
+  if (!roomRef.current) roomRef.current = new LocalYjsRoom('case/4');
+
+  const [self] = React.useState(() => roomRef.current!.join());
+  const [guests, setGuests] = React.useState<
+    { id: number; name: string; member: LocalYjsMember }[]
+  >([]);
+  const nextId = React.useRef(1);
+
+  React.useEffect(() => () => self.leave(), [self]);
+
+  return (
+    <div className="space-y-3">
+      <RoomMember member={self} name="You" />
+      {guests.map((g) => (
+        <RoomMember
+          key={g.id}
+          member={g.member}
+          name={g.name}
+          onLeave={() => {
+            g.member.leave();
+            setGuests((prev) => prev.filter((x) => x.id !== g.id));
+          }}
+        />
+      ))}
+      <button
+        type="button"
+        className="bg-primary-500 rounded-md px-3 py-1.5 text-sm text-white"
+        onClick={() => {
+          const id = nextId.current++;
+          const name = ['Ann Nurse', 'Bo Tech', 'Cy Admin'][(id - 1) % 3];
+          setGuests((prev) => [
+            ...prev,
+            { id, name, member: roomRef.current!.join() },
+          ]);
+        }}
+      >
+        Add a peer window
+      </button>
+      <p className="text-muted-foreground text-xs">
+        Every row is a separate <code>Y.Doc</code> + <code>Awareness</code>,
+        relayed in memory instead of over a WebSocket. Add a peer, click{' '}
+        <em>Edit notes</em>, then open a chip to watch the log.
+      </p>
+    </div>
+  );
+}
+
+export const SimulatedRoom: StoryObj = {
+  name: 'Simulated Yjs room (no server)',
+  render: () => <SimulatedRoomDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A real Yjs room — real docs, real awareness, real update encoding — ' +
+          'with an in-memory transport, so it runs with no server and in CI.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Real Yjs server
+// =============================================================================
+
+function LiveServerDemo({
+  serverUrl,
+  roomName,
+  userName,
+}: {
+  serverUrl: string;
+  roomName: string;
+  userName: string;
+}) {
+  const [session, setSession] = React.useState<{
+    doc: import('yjs').Doc;
+    provider: import('y-websocket').WebsocketProvider;
+  } | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let disposed = false;
+    let cleanup = () => {};
+
+    // Loaded lazily so the story page still renders if y-websocket is absent.
+    void (async () => {
+      try {
+        const [Y, { WebsocketProvider }] = await Promise.all([
+          import('yjs'),
+          import('y-websocket'),
+        ]);
+        if (disposed) return;
+        const doc = new Y.Doc();
+        const provider = new WebsocketProvider(serverUrl, roomName, doc);
+        setSession({ doc, provider });
+        cleanup = () => {
+          provider.destroy();
+          doc.destroy();
+        };
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      cleanup();
+      setSession(null);
+    };
+  }, [serverUrl, roomName]);
+
+  const status = useYjsCollabStatus({
+    doc: session?.doc ?? null,
+    provider: session?.provider ?? null,
+    user: { name: userName },
+    userId: userName,
+  });
+
+  if (error) {
+    return <p className="text-destructive text-sm">{error}</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="border-border flex items-center gap-3 rounded-lg border p-3">
+        <CollabStatus {...status} />
+        <button
+          type="button"
+          className="border-border ml-auto rounded-md border px-2 py-1 text-xs"
+          onClick={() => {
+            const notes = session?.doc.getText('notes');
+            notes?.insert(notes.length, `${userName} typed. `);
+            status.publishActivity(['Case notes']);
+          }}
+        >
+          Edit notes
+        </button>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        Start a server with <code>npx y-websocket --port 1234</code> (or run
+        wcts and use <code>ws://localhost:39000/sync</code>), then open this
+        story in a second tab with a different <code>userName</code>.
+      </p>
+    </div>
+  );
+}
+
+export const LiveServerRoom: StoryObj<typeof LiveServerDemo> = {
+  name: 'Live server room',
+  args: {
+    serverUrl: 'ws://localhost:1234',
+    roomName: 'case/4',
+    userName: 'Ann Nurse',
+  },
+  argTypes: {
+    serverUrl: { control: 'text' },
+    roomName: { control: 'text' },
+    userName: { control: 'text' },
+  },
+  render: (args) => <LiveServerDemo {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Connects a real `y-websocket` provider to the URL below. Shows ' +
+          '“Connecting…” until a server accepts the room.',
+      },
+    },
+  },
+};

--- a/src/components/CollabStatus/CollabStatus.stories.tsx
+++ b/src/components/CollabStatus/CollabStatus.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
+import { Button } from '../Button/Button';
 import { CollabStatus } from './CollabStatus';
 import { useYjsCollabStatus } from './useYjsCollabStatus';
 import { LocalYjsRoom, sampleLog, type LocalYjsMember } from './storyData';
@@ -226,9 +227,8 @@ function SimulatedRoomDemo() {
           }}
         />
       ))}
-      <button
-        type="button"
-        className="bg-primary-500 rounded-md px-3 py-1.5 text-sm text-white"
+      <Button
+        size="sm"
         onClick={() => {
           const id = nextId.current++;
           const name = ['Ann Nurse', 'Bo Tech', 'Cy Admin'][(id - 1) % 3];
@@ -239,7 +239,7 @@ function SimulatedRoomDemo() {
         }}
       >
         Add a peer window
-      </button>
+      </Button>
       <p className="text-muted-foreground text-xs">
         Every row is a separate <code>Y.Doc</code> + <code>Awareness</code>,
         relayed in memory instead of over a WebSocket. Add a peer, click{' '}

--- a/src/components/CollabStatus/CollabStatus.test.tsx
+++ b/src/components/CollabStatus/CollabStatus.test.tsx
@@ -62,6 +62,64 @@ describe('CollabStatus', () => {
       'You are the only one here.'
     );
   });
+
+  it('shares the dot with an app-level attention state', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <CollabStatus connected compact attention="Unsaved changes" />
+    );
+
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAccessibleName(/Live — Unsaved changes/);
+    expect(
+      container.querySelector('[data-slot="collab-status-dot"]')
+    ).toHaveClass('bg-warning-500');
+
+    await user.click(trigger);
+    expect(await screen.findByRole('dialog')).toHaveTextContent(
+      'Unsaved changes'
+    );
+  });
+
+  it('keeps the full text of clipped values in a hover tooltip', async () => {
+    const user = userEvent.setup();
+    const url = 'ws://localhost:5173/yorm/ws/Patient/p-demo?mode=editor';
+    render(
+      <CollabStatus
+        connected
+        room={{ name: 'Patient/p-demo', url }}
+        log={[{ id: 'e1', at: 0, kind: 'patch', detail: 'edited family' }]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Live-sync status/ }));
+
+    const panel = await screen.findByRole('dialog');
+    expect(panel.querySelector(`[title="${url}"]`)).not.toBeNull();
+    expect(panel.querySelector('[title="edited family"]')).not.toBeNull();
+  });
+
+  it('unclips every value when the wrap toggle is pressed', async () => {
+    const user = userEvent.setup();
+    const url = 'ws://localhost:5173/yorm/ws/Patient/p-demo?mode=editor';
+    render(
+      <CollabStatus
+        connected
+        room={{ name: 'Patient/p-demo', url }}
+        log={[{ id: 'e1', at: 0, kind: 'patch', detail: 'edited family' }]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Live-sync status/ }));
+    const panel = await screen.findByRole('dialog');
+    expect(panel.querySelectorAll('.truncate').length).toBeGreaterThan(0);
+
+    const wrap = screen.getByRole('button', { name: 'Wrap long values' });
+    await user.click(wrap);
+
+    expect(wrap).toHaveAttribute('aria-pressed', 'true');
+    expect(panel.querySelectorAll('.truncate')).toHaveLength(0);
+  });
 });
 
 describe('useYjsCollabStatus', () => {

--- a/src/components/CollabStatus/CollabStatus.test.tsx
+++ b/src/components/CollabStatus/CollabStatus.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { CollabStatus } from './CollabStatus';
+import { useYjsCollabStatus } from './useYjsCollabStatus';
+import { LocalYjsRoom } from './storyData';
+
+describe('CollabStatus', () => {
+  it('renders the connection state and who else is editing', () => {
+    render(
+      <CollabStatus
+        connected
+        peers={[{ name: 'Ann' }, { name: 'Bo' }, { name: 'Bo' }]}
+      />
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Live');
+    // Two windows of the same person collapse into "Bo (2)".
+    expect(screen.getByRole('button')).toHaveTextContent(
+      'Ann, Bo (2) are editing'
+    );
+  });
+
+  it('shows "Connecting…" before the initial sync', () => {
+    render(<CollabStatus connected={false} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Connecting…');
+  });
+});
+
+describe('useYjsCollabStatus', () => {
+  it('reports sync, peers and remote updates from a Yjs room', async () => {
+    const room = new LocalYjsRoom('case/4');
+    const self = room.join(0);
+    const peer = room.join(0);
+
+    const { result } = renderHook(() =>
+      useYjsCollabStatus({
+        doc: self.doc,
+        provider: self.provider,
+        user: { name: 'Me' },
+      })
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    act(() => peer.awareness.setLocalStateField('user', { name: 'Ann' }));
+    await waitFor(() =>
+      expect(result.current.peers).toEqual([{ name: 'Ann', color: undefined }])
+    );
+
+    act(() => LocalYjsRoom.type(peer, 'hello'));
+    await waitFor(() =>
+      expect(
+        result.current.log.some(
+          (e) => e.kind === 'doc' && e.origin === 'remote'
+        )
+      ).toBe(true)
+    );
+
+    expect(result.current.room?.name).toBe('case/4');
+
+    act(() => {
+      self.leave();
+      peer.leave();
+    });
+  });
+
+  it('stays inert without a doc or provider', () => {
+    const { result } = renderHook(() =>
+      useYjsCollabStatus({ doc: null, provider: null })
+    );
+
+    expect(result.current.connected).toBe(false);
+    expect(result.current.room).toBeNull();
+  });
+});

--- a/src/components/CollabStatus/CollabStatus.test.tsx
+++ b/src/components/CollabStatus/CollabStatus.test.tsx
@@ -42,7 +42,9 @@ describe('CollabStatus', () => {
 
   it('lists who is in the room in the panel', async () => {
     const user = userEvent.setup();
-    render(<CollabStatus connected peers={[{ name: 'Ann' }, { name: 'Bo' }]} />);
+    render(
+      <CollabStatus connected peers={[{ name: 'Ann' }, { name: 'Bo' }]} />
+    );
 
     await user.click(screen.getByRole('button', { name: /Live-sync status/ }));
 

--- a/src/components/CollabStatus/CollabStatus.test.tsx
+++ b/src/components/CollabStatus/CollabStatus.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CollabStatus } from './CollabStatus';
 import { useYjsCollabStatus } from './useYjsCollabStatus';
 import { LocalYjsRoom } from './storyData';
@@ -29,6 +30,37 @@ describe('CollabStatus', () => {
   it('shows "Connecting…" before the initial sync', () => {
     render(<CollabStatus connected={false} />);
     expect(screen.getByRole('button')).toHaveTextContent('Connecting…');
+  });
+
+  it('renders a dot-only trigger when compact, keeping the status accessible', () => {
+    render(<CollabStatus connected compact peers={[{ name: 'Ann' }]} />);
+
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveTextContent('');
+    expect(trigger).toHaveAccessibleName(/Live — Ann is editing/);
+  });
+
+  it('lists who is in the room in the panel', async () => {
+    const user = userEvent.setup();
+    render(<CollabStatus connected peers={[{ name: 'Ann' }, { name: 'Bo' }]} />);
+
+    await user.click(screen.getByRole('button', { name: /Live-sync status/ }));
+
+    const panel = await screen.findByRole('dialog');
+    expect(panel).toHaveTextContent('In the room (2)');
+    expect(panel).toHaveTextContent('Ann');
+    expect(panel).toHaveTextContent('Bo');
+  });
+
+  it('says so when nobody else is in the room', async () => {
+    const user = userEvent.setup();
+    render(<CollabStatus connected />);
+
+    await user.click(screen.getByRole('button', { name: /Live-sync status/ }));
+
+    expect(await screen.findByRole('dialog')).toHaveTextContent(
+      'You are the only one here.'
+    );
   });
 });
 

--- a/src/components/CollabStatus/CollabStatus.tsx
+++ b/src/components/CollabStatus/CollabStatus.tsx
@@ -54,6 +54,10 @@ export interface CollabStatusLabels {
   editing: (names: string[]) => string;
   /** Accessible name / tooltip of the trigger button. */
   triggerLabel: string;
+  /** Heading of the room-occupants section. */
+  peersTitle: (count: number) => string;
+  /** Shown in the occupants section when nobody else is in the room. */
+  alone: React.ReactNode;
   /** Heading of the debug panel. */
   logTitle: (count: number) => string;
   /** Accessible name of the panel close button. */
@@ -75,6 +79,8 @@ export const defaultCollabStatusLabels: CollabStatusLabels = {
   editing: (names) =>
     `${names.join(', ')} ${names.length === 1 ? 'is' : 'are'} editing`,
   triggerLabel: 'Live-sync status — open the update log',
+  peersTitle: (count) => `In the room (${count})`,
+  alone: 'You are the only one here.',
   logTitle: (count) => `Update log (${count})`,
   close: 'Close update log',
   empty: 'No updates yet.',
@@ -97,6 +103,11 @@ export interface CollabStatusProps {
   room?: CollabRoomInfo | null;
   /** Set false to render a status-only chip with no debug panel. */
   showLog?: boolean;
+  /**
+   * Render the trigger as the bare connection dot, moving the status text into
+   * its accessible name. For headers with no room for a full chip.
+   */
+  compact?: boolean;
   /** Overrides for any user-facing string. */
   labels?: Partial<CollabStatusLabels>;
   /** Additional className for the trigger wrapper. */
@@ -107,11 +118,24 @@ export interface CollabStatusProps {
 // Helpers
 // =============================================================================
 
+/** One row of the occupants list: a display label and its presence color. */
+interface PeerLabel {
+  label: string;
+  color?: string;
+}
+
 /** Collapse multiple windows of the same person into `Name (N)`. */
-function peerLabels(peers: CollabPeer[]): string[] {
-  const counts = new Map<string, number>();
-  for (const p of peers) counts.set(p.name, (counts.get(p.name) ?? 0) + 1);
-  return [...counts].map(([name, n]) => (n > 1 ? `${name} (${n})` : name));
+function peerLabels(peers: CollabPeer[]): PeerLabel[] {
+  const seen = new Map<string, { count: number; color?: string }>();
+  for (const p of peers) {
+    const entry = seen.get(p.name);
+    if (entry) entry.count += 1;
+    else seen.set(p.name, { count: 1, color: p.color });
+  }
+  return [...seen].map(([name, { count, color }]) => ({
+    label: count > 1 ? `${name} (${count})` : name,
+    color,
+  }));
 }
 
 const PANEL_OFFSET = 6;
@@ -185,7 +209,8 @@ const KIND_TONE: Record<CollabLogKind, string> = {
 /**
  * Live-collaboration status chip: a connection dot, a `Live` / `Connecting…`
  * label, a summary of who else is editing, and a click-to-open panel with the
- * room identity and a rolling log of collaboration events.
+ * room identity, who is in the room, and a rolling log of collaboration
+ * events. Pass `compact` to shrink the trigger down to the dot alone.
  *
  * Transport-agnostic — it renders whatever presence state you hand it. For a
  * Yjs (`y-websocket`) room, {@link useYjsCollabStatus} produces these props
@@ -209,6 +234,7 @@ export function CollabStatus({
   log = [],
   room = null,
   showLog = true,
+  compact = false,
   labels: labelOverrides,
   className,
 }: CollabStatusProps) {
@@ -241,7 +267,16 @@ export function CollabStatus({
     };
   }, [open]);
 
-  const names = peerLabels(peers);
+  const occupants = peerLabels(peers);
+  const names = occupants.map((p) => p.label);
+  const statusText = connected ? labels.live : labels.connecting;
+  // Compact triggers have no visible text, so the status and who is editing
+  // have to reach assistive tech (and the tooltip) through the label.
+  const triggerLabel = compact
+    ? [labels.triggerLabel, statusText, names.length > 0 && labels.editing(names)]
+        .filter(Boolean)
+        .join(' — ')
+    : labels.triggerLabel;
 
   const trigger = (
     <button
@@ -255,9 +290,9 @@ export function CollabStatus({
       )}
       onClick={showLog ? () => setOpen((v) => !v) : undefined}
       disabled={!showLog}
-      title={showLog ? labels.triggerLabel : undefined}
+      title={showLog ? triggerLabel : undefined}
       aria-expanded={showLog ? open : undefined}
-      aria-label={showLog ? labels.triggerLabel : undefined}
+      aria-label={showLog ? triggerLabel : undefined}
       data-slot="collab-status-trigger"
     >
       <span
@@ -268,8 +303,8 @@ export function CollabStatus({
           connected ? 'bg-success-500' : 'bg-warning-500 animate-pulse'
         )}
       />
-      <span>{connected ? labels.live : labels.connecting}</span>
-      {names.length > 0 && (
+      {!compact && <span>{statusText}</span>}
+      {!compact && names.length > 0 && (
         <span className="truncate">{`· ${labels.editing(names)}`}</span>
       )}
     </button>
@@ -341,6 +376,33 @@ export function CollabStatus({
                 )}
               </dl>
             )}
+
+            <section className="border-border mb-2 border-b pb-2">
+              <strong className="text-foreground mb-1 block">
+                {labels.peersTitle(peers.length)}
+              </strong>
+              {peers.length === 0 ? (
+                <p className="text-muted-foreground">{labels.alone}</p>
+              ) : (
+                <ul
+                  className="flex flex-wrap gap-x-3 gap-y-1"
+                  data-slot="collab-status-peers"
+                >
+                  {occupants.map((peer) => (
+                    <li key={peer.label} className="flex items-center gap-1.5">
+                      <span
+                        aria-hidden="true"
+                        className="h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: peer.color ?? 'currentColor' }}
+                      />
+                      <span className="text-foreground truncate">
+                        {peer.label}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
 
             {log.length === 0 ? (
               <p className="text-muted-foreground">{labels.empty}</p>

--- a/src/components/CollabStatus/CollabStatus.tsx
+++ b/src/components/CollabStatus/CollabStatus.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import { X } from 'lucide-react';
+import { WrapText, X } from 'lucide-react';
 import { cn } from '../../utils/cn';
 
 // =============================================================================
@@ -62,6 +62,8 @@ export interface CollabStatusLabels {
   logTitle: (count: number) => string;
   /** Accessible name of the panel close button. */
   close: string;
+  /** Accessible name of the toggle that unclips long values. */
+  wrap: string;
   /** Shown when the log is empty. */
   empty: React.ReactNode;
   roomTerm: string;
@@ -83,6 +85,7 @@ export const defaultCollabStatusLabels: CollabStatusLabels = {
   alone: 'You are the only one here.',
   logTitle: (count) => `Update log (${count})`,
   close: 'Close update log',
+  wrap: 'Wrap long values',
   empty: 'No updates yet.',
   roomTerm: 'Room',
   urlTerm: 'Socket',
@@ -108,6 +111,12 @@ export interface CollabStatusProps {
    * its accessible name. For headers with no room for a full chip.
    */
   compact?: boolean;
+  /**
+   * An app-level condition worth the same glance as the connection state, e.g.
+   * `"Unsaved changes"`. While set, the dot turns amber and the text joins the
+   * trigger's accessible name and heads the panel.
+   */
+  attention?: React.ReactNode;
   /** Overrides for any user-facing string. */
   labels?: Partial<CollabStatusLabels>;
   /** Additional className for the trigger wrapper. */
@@ -210,7 +219,8 @@ const KIND_TONE: Record<CollabLogKind, string> = {
  * Live-collaboration status chip: a connection dot, a `Live` / `Connecting…`
  * label, a summary of who else is editing, and a click-to-open panel with the
  * room identity, who is in the room, and a rolling log of collaboration
- * events. Pass `compact` to shrink the trigger down to the dot alone.
+ * events. Pass `compact` to shrink the trigger down to the dot alone, and
+ * `attention` to let an app condition ("Unsaved changes") share that dot.
  *
  * Transport-agnostic — it renders whatever presence state you hand it. For a
  * Yjs (`y-websocket`) room, {@link useYjsCollabStatus} produces these props
@@ -235,11 +245,13 @@ export function CollabStatus({
   room = null,
   showLog = true,
   compact = false,
+  attention = null,
   labels: labelOverrides,
   className,
 }: CollabStatusProps) {
   const labels = { ...defaultCollabStatusLabels, ...labelOverrides };
   const [open, setOpen] = React.useState(false);
+  const [wrapped, setWrapped] = React.useState(false);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const panelRef = React.useRef<HTMLDivElement>(null);
   const pos = useAnchoredPanel(open && showLog, triggerRef, panelRef);
@@ -269,11 +281,21 @@ export function CollabStatus({
 
   const occupants = peerLabels(peers);
   const names = occupants.map((p) => p.label);
+  // Long values are clipped to one line; the panel's wrap toggle unclips them.
+  const clip = wrapped ? 'break-all whitespace-pre-wrap' : 'truncate';
   const statusText = connected ? labels.live : labels.connecting;
+  const clientLine = `${room?.clientId ?? '—'} · ${
+    connected ? labels.clientSynced : labels.clientConnecting
+  }`;
   // Compact triggers have no visible text, so the status and who is editing
   // have to reach assistive tech (and the tooltip) through the label.
   const triggerLabel = compact
-    ? [labels.triggerLabel, statusText, names.length > 0 && labels.editing(names)]
+    ? [
+        labels.triggerLabel,
+        statusText,
+        attention,
+        names.length > 0 && labels.editing(names),
+      ]
         .filter(Boolean)
         .join(' — ')
     : labels.triggerLabel;
@@ -300,10 +322,17 @@ export function CollabStatus({
         data-slot="collab-status-dot"
         className={cn(
           'h-2 w-2 shrink-0 rounded-full',
-          connected ? 'bg-success-500' : 'bg-warning-500 animate-pulse'
+          !connected && 'bg-warning-500 animate-pulse',
+          connected && attention && 'bg-warning-500',
+          connected && !attention && 'bg-success-500'
         )}
       />
       {!compact && <span>{statusText}</span>}
+      {!compact && attention && (
+        <span className="text-warning-700 truncate dark:text-warning-400">
+          · {attention}
+        </span>
+      )}
       {!compact && names.length > 0 && (
         <span className="truncate">{`· ${labels.editing(names)}`}</span>
       )}
@@ -340,38 +369,69 @@ export function CollabStatus({
               <strong id={titleId} className="text-foreground text-sm">
                 {labels.logTitle(log.length)}
               </strong>
-              <button
-                type="button"
-                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded p-0.5 focus-visible:ring-2 focus-visible:outline-none"
-                onClick={() => {
-                  setOpen(false);
-                  triggerRef.current?.focus();
-                }}
-                aria-label={labels.close}
-              >
-                <X className="h-4 w-4" aria-hidden="true" />
-              </button>
+              <span className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  className={cn(
+                    'hover:text-foreground focus-visible:ring-ring rounded p-0.5 focus-visible:ring-2 focus-visible:outline-none',
+                    wrapped ? 'text-foreground bg-muted' : 'text-muted-foreground'
+                  )}
+                  onClick={() => setWrapped((v) => !v)}
+                  aria-pressed={wrapped}
+                  aria-label={labels.wrap}
+                  title={labels.wrap}
+                  data-slot="collab-status-wrap"
+                >
+                  <WrapText className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded p-0.5 focus-visible:ring-2 focus-visible:outline-none"
+                  onClick={() => {
+                    setOpen(false);
+                    triggerRef.current?.focus();
+                  }}
+                  aria-label={labels.close}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </span>
             </div>
+
+            {attention && (
+              <p
+                data-slot="collab-status-attention"
+                className="text-warning-700 dark:text-warning-400 mb-2"
+              >
+                {attention}
+              </p>
+            )}
 
             {room && (
               <dl className="border-border text-muted-foreground mb-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 border-b pb-2">
                 <dt className="opacity-70">{labels.roomTerm}</dt>
-                <dd className="truncate">{room.name}</dd>
+                {/* The values are clipped, so hovering must reveal the rest. */}
+                <dd className={clip} title={room.name}>
+                  {room.name}
+                </dd>
                 {room.url && (
                   <>
                     <dt className="opacity-70">{labels.urlTerm}</dt>
-                    <dd className="truncate">{room.url}</dd>
+                    <dd className={clip} title={room.url}>
+                      {room.url}
+                    </dd>
                   </>
                 )}
                 <dt className="opacity-70">{labels.clientTerm}</dt>
-                <dd className="truncate">
-                  {room.clientId ?? '—'}
-                  {` · ${connected ? labels.clientSynced : labels.clientConnecting}`}
+                <dd className={clip} title={clientLine}>
+                  {clientLine}
                 </dd>
                 {room.userId && (
                   <>
                     <dt className="opacity-70">{labels.userTerm}</dt>
-                    <dd className="truncate">{room.userId}</dd>
+                    <dd className={clip} title={room.userId}>
+                      {room.userId}
+                    </dd>
                   </>
                 )}
               </dl>
@@ -395,7 +455,7 @@ export function CollabStatus({
                         className="h-2 w-2 shrink-0 rounded-full"
                         style={{ backgroundColor: peer.color ?? 'currentColor' }}
                       />
-                      <span className="text-foreground truncate">
+                      <span className={cn('text-foreground', clip)} title={peer.label}>
                         {peer.label}
                       </span>
                     </li>
@@ -427,7 +487,9 @@ export function CollabStatus({
                       {e.kind}
                       {e.origin ? `/${e.origin}` : ''}
                     </span>
-                    <span className="text-foreground truncate">{e.detail}</span>
+                    <span className={cn('text-foreground', clip)} title={e.detail}>
+                      {e.detail}
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/src/components/CollabStatus/CollabStatus.tsx
+++ b/src/components/CollabStatus/CollabStatus.tsx
@@ -329,7 +329,7 @@ export function CollabStatus({
       />
       {!compact && <span>{statusText}</span>}
       {!compact && attention && (
-        <span className="text-warning-700 truncate dark:text-warning-400">
+        <span className="text-warning-700 dark:text-warning-400 truncate">
           · {attention}
         </span>
       )}
@@ -374,7 +374,9 @@ export function CollabStatus({
                   type="button"
                   className={cn(
                     'hover:text-foreground focus-visible:ring-ring rounded p-0.5 focus-visible:ring-2 focus-visible:outline-none',
-                    wrapped ? 'text-foreground bg-muted' : 'text-muted-foreground'
+                    wrapped
+                      ? 'text-foreground bg-muted'
+                      : 'text-muted-foreground'
                   )}
                   onClick={() => setWrapped((v) => !v)}
                   aria-pressed={wrapped}
@@ -453,9 +455,14 @@ export function CollabStatus({
                       <span
                         aria-hidden="true"
                         className="h-2 w-2 shrink-0 rounded-full"
-                        style={{ backgroundColor: peer.color ?? 'currentColor' }}
+                        style={{
+                          backgroundColor: peer.color ?? 'currentColor',
+                        }}
                       />
-                      <span className={cn('text-foreground', clip)} title={peer.label}>
+                      <span
+                        className={cn('text-foreground', clip)}
+                        title={peer.label}
+                      >
                         {peer.label}
                       </span>
                     </li>
@@ -487,7 +494,10 @@ export function CollabStatus({
                       {e.kind}
                       {e.origin ? `/${e.origin}` : ''}
                     </span>
-                    <span className={cn('text-foreground', clip)} title={e.detail}>
+                    <span
+                      className={cn('text-foreground', clip)}
+                      title={e.detail}
+                    >
                       {e.detail}
                     </span>
                   </li>

--- a/src/components/CollabStatus/CollabStatus.tsx
+++ b/src/components/CollabStatus/CollabStatus.tsx
@@ -1,0 +1,378 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Another participant currently present in the room. */
+export interface CollabPeer {
+  /** Display name published through presence. */
+  name: string;
+  /** Optional presence color (cursor/avatar tint). */
+  color?: string;
+}
+
+/** Static identity of the open collaboration room, shown in the debug panel. */
+export interface CollabRoomInfo {
+  /** Room name on the sync server (e.g. `case/4`). */
+  name: string;
+  /** Transport URL the client connected to. */
+  url?: string;
+  /** This window's client id (stable per document), or null before connect. */
+  clientId?: number | null;
+  /** The acting application user id passed to the sync server. */
+  userId?: string;
+}
+
+/** Category of a collaboration event in the debug log. */
+export type CollabLogKind = 'doc' | 'awareness' | 'sync' | 'patch';
+
+/** A single entry in the collaboration debug log. */
+export interface CollabLogEntry {
+  /** Stable key for rendering. */
+  id: number | string;
+  /** Wall-clock time of the event (epoch ms). */
+  at: number;
+  /** Event category. */
+  kind: CollabLogKind;
+  /** Whether this window or a peer originated it. */
+  origin?: 'local' | 'remote';
+  /** Human-readable detail line. */
+  detail: string;
+}
+
+/** Every user-facing string, so apps can translate the widget. */
+export interface CollabStatusLabels {
+  /** Trigger text once the initial sync completed. */
+  live: string;
+  /** Trigger text before the initial sync completes. */
+  connecting: string;
+  /** Summary of who else is editing, e.g. `Ann, Bo are editing`. */
+  editing: (names: string[]) => string;
+  /** Accessible name / tooltip of the trigger button. */
+  triggerLabel: string;
+  /** Heading of the debug panel. */
+  logTitle: (count: number) => string;
+  /** Accessible name of the panel close button. */
+  close: string;
+  /** Shown when the log is empty. */
+  empty: React.ReactNode;
+  roomTerm: string;
+  urlTerm: string;
+  clientTerm: string;
+  userTerm: string;
+  /** Suffix appended to the client id once synced / while connecting. */
+  clientSynced: string;
+  clientConnecting: string;
+}
+
+export const defaultCollabStatusLabels: CollabStatusLabels = {
+  live: 'Live',
+  connecting: 'Connecting…',
+  editing: (names) =>
+    `${names.join(', ')} ${names.length === 1 ? 'is' : 'are'} editing`,
+  triggerLabel: 'Live-sync status — open the update log',
+  logTitle: (count) => `Update log (${count})`,
+  close: 'Close update log',
+  empty: 'No updates yet.',
+  roomTerm: 'Room',
+  urlTerm: 'Socket',
+  clientTerm: 'Client',
+  userTerm: 'User',
+  clientSynced: 'synced',
+  clientConnecting: 'connecting',
+};
+
+export interface CollabStatusProps {
+  /** True once the room has completed its initial sync with the server. */
+  connected: boolean;
+  /** Other people in the room right now. */
+  peers?: CollabPeer[];
+  /** Recent collaboration events, newest first. */
+  log?: CollabLogEntry[];
+  /** Identity of the open room, shown at the top of the panel. */
+  room?: CollabRoomInfo | null;
+  /** Set false to render a status-only chip with no debug panel. */
+  showLog?: boolean;
+  /** Overrides for any user-facing string. */
+  labels?: Partial<CollabStatusLabels>;
+  /** Additional className for the trigger wrapper. */
+  className?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Collapse multiple windows of the same person into `Name (N)`. */
+function peerLabels(peers: CollabPeer[]): string[] {
+  const counts = new Map<string, number>();
+  for (const p of peers) counts.set(p.name, (counts.get(p.name) ?? 0) + 1);
+  return [...counts].map(([name, n]) => (n > 1 ? `${name} (${n})` : name));
+}
+
+const PANEL_OFFSET = 6;
+const VIEWPORT_PADDING = 8;
+
+/**
+ * Position the panel under the trigger, right-aligned to it but clamped to the
+ * viewport on both axes (it flips above the trigger when it would overflow the
+ * bottom). Returns null until the panel has been measured.
+ */
+function useAnchoredPanel(
+  open: boolean,
+  anchorRef: React.RefObject<HTMLElement | null>,
+  panelRef: React.RefObject<HTMLElement | null>
+) {
+  const [pos, setPos] = React.useState<{ top: number; left: number } | null>(
+    null
+  );
+
+  React.useLayoutEffect(() => {
+    if (!open) {
+      setPos(null);
+      return;
+    }
+    const update = () => {
+      const anchor = anchorRef.current;
+      const panel = panelRef.current;
+      if (!anchor || !panel) return;
+      const a = anchor.getBoundingClientRect();
+      const { offsetWidth: width, offsetHeight: height } = panel;
+
+      const maxLeft = window.innerWidth - width - VIEWPORT_PADDING;
+      const left = Math.max(
+        VIEWPORT_PADDING,
+        Math.min(a.right - width, Math.max(VIEWPORT_PADDING, maxLeft))
+      );
+
+      let top = a.bottom + PANEL_OFFSET;
+      if (top + height > window.innerHeight - VIEWPORT_PADDING) {
+        top = Math.max(VIEWPORT_PADDING, a.top - height - PANEL_OFFSET);
+      }
+
+      setPos({ top, left });
+    };
+
+    // Measured after the (hidden) panel has been laid out.
+    const raf = window.requestAnimationFrame(update);
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [open, anchorRef, panelRef]);
+
+  return pos;
+}
+
+const KIND_TONE: Record<CollabLogKind, string> = {
+  doc: 'text-muted-foreground',
+  awareness: 'text-primary-600 dark:text-primary-400',
+  sync: 'text-success-700 dark:text-success-400',
+  patch: 'text-muted-foreground',
+};
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Live-collaboration status chip: a connection dot, a `Live` / `Connecting…`
+ * label, a summary of who else is editing, and a click-to-open panel with the
+ * room identity and a rolling log of collaboration events.
+ *
+ * Transport-agnostic — it renders whatever presence state you hand it. For a
+ * Yjs (`y-websocket`) room, {@link useYjsCollabStatus} produces these props
+ * directly:
+ *
+ * @example
+ * ```tsx
+ * const doc = React.useMemo(() => new Y.Doc(), []);
+ * const provider = React.useMemo(
+ *   () => new WebsocketProvider('ws://localhost:1234', 'case/4', doc),
+ *   [doc]
+ * );
+ * const status = useYjsCollabStatus({ doc, provider, user: { name: 'Ann' } });
+ *
+ * return <CollabStatus {...status} />;
+ * ```
+ */
+export function CollabStatus({
+  connected,
+  peers = [],
+  log = [],
+  room = null,
+  showLog = true,
+  labels: labelOverrides,
+  className,
+}: CollabStatusProps) {
+  const labels = { ...defaultCollabStatusLabels, ...labelOverrides };
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const pos = useAnchoredPanel(open && showLog, triggerRef, panelRef);
+  const titleId = React.useId();
+
+  // Escape closes and returns focus; a pointer outside dismisses.
+  React.useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    const onPointerDown = (e: Event) => {
+      const target = e.target as Node;
+      if (panelRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('pointerdown', onPointerDown);
+    };
+  }, [open]);
+
+  const names = peerLabels(peers);
+
+  const trigger = (
+    <button
+      type="button"
+      ref={triggerRef}
+      className={cn(
+        'text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-xs',
+        'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none',
+        showLog && 'hover:bg-muted cursor-pointer',
+        className
+      )}
+      onClick={showLog ? () => setOpen((v) => !v) : undefined}
+      disabled={!showLog}
+      title={showLog ? labels.triggerLabel : undefined}
+      aria-expanded={showLog ? open : undefined}
+      aria-label={showLog ? labels.triggerLabel : undefined}
+      data-slot="collab-status-trigger"
+    >
+      <span
+        aria-hidden="true"
+        data-slot="collab-status-dot"
+        className={cn(
+          'h-2 w-2 shrink-0 rounded-full',
+          connected ? 'bg-success-500' : 'bg-warning-500 animate-pulse'
+        )}
+      />
+      <span>{connected ? labels.live : labels.connecting}</span>
+      {names.length > 0 && (
+        <span className="truncate">{`· ${labels.editing(names)}`}</span>
+      )}
+    </button>
+  );
+
+  if (!showLog) return trigger;
+
+  return (
+    <span
+      className="relative inline-flex items-center"
+      data-slot="collab-status"
+    >
+      {trigger}
+      {open &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-labelledby={titleId}
+            data-slot="collab-status-panel"
+            className={cn(
+              'bg-card text-card-foreground border-border fixed z-50 w-[26rem] max-w-[calc(100vw-1rem)]',
+              'rounded-lg border p-3 text-xs shadow-xl'
+            )}
+            style={{
+              top: pos?.top ?? 0,
+              left: pos?.left ?? 0,
+              visibility: pos ? undefined : 'hidden',
+            }}
+          >
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <strong id={titleId} className="text-foreground text-sm">
+                {labels.logTitle(log.length)}
+              </strong>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded p-0.5 focus-visible:ring-2 focus-visible:outline-none"
+                onClick={() => {
+                  setOpen(false);
+                  triggerRef.current?.focus();
+                }}
+                aria-label={labels.close}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+
+            {room && (
+              <dl className="border-border text-muted-foreground mb-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 border-b pb-2">
+                <dt className="opacity-70">{labels.roomTerm}</dt>
+                <dd className="truncate">{room.name}</dd>
+                {room.url && (
+                  <>
+                    <dt className="opacity-70">{labels.urlTerm}</dt>
+                    <dd className="truncate">{room.url}</dd>
+                  </>
+                )}
+                <dt className="opacity-70">{labels.clientTerm}</dt>
+                <dd className="truncate">
+                  {room.clientId ?? '—'}
+                  {` · ${connected ? labels.clientSynced : labels.clientConnecting}`}
+                </dd>
+                {room.userId && (
+                  <>
+                    <dt className="opacity-70">{labels.userTerm}</dt>
+                    <dd className="truncate">{room.userId}</dd>
+                  </>
+                )}
+              </dl>
+            )}
+
+            {log.length === 0 ? (
+              <p className="text-muted-foreground">{labels.empty}</p>
+            ) : (
+              <ul className="max-h-72 space-y-0.5 overflow-y-auto font-mono">
+                {log.map((e) => (
+                  <li
+                    key={e.id}
+                    className="grid grid-cols-[auto_auto_1fr] gap-2"
+                  >
+                    <span className="text-muted-foreground opacity-70">
+                      {new Date(e.at).toLocaleTimeString()}
+                    </span>
+                    <span
+                      className={cn(
+                        'whitespace-nowrap',
+                        e.origin === 'remote'
+                          ? 'text-primary-600 dark:text-primary-400'
+                          : KIND_TONE[e.kind]
+                      )}
+                    >
+                      {e.kind}
+                      {e.origin ? `/${e.origin}` : ''}
+                    </span>
+                    <span className="text-foreground truncate">{e.detail}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>,
+          document.body
+        )}
+    </span>
+  );
+}

--- a/src/components/CollabStatus/index.ts
+++ b/src/components/CollabStatus/index.ts
@@ -1,0 +1,19 @@
+export {
+  CollabStatus,
+  defaultCollabStatusLabels,
+  type CollabStatusProps,
+  type CollabStatusLabels,
+  type CollabPeer,
+  type CollabRoomInfo,
+  type CollabLogEntry,
+  type CollabLogKind,
+} from './CollabStatus';
+export {
+  useYjsCollabStatus,
+  type UseYjsCollabStatusOptions,
+  type YjsCollabStatus,
+  type YjsDocLike,
+  type YjsAwarenessLike,
+  type YjsProviderLike,
+  type CollabRemoteEdit,
+} from './useYjsCollabStatus';

--- a/src/components/CollabStatus/storyData.ts
+++ b/src/components/CollabStatus/storyData.ts
@@ -1,0 +1,181 @@
+import * as Y from 'yjs';
+import {
+  Awareness,
+  applyAwarenessUpdate,
+  encodeAwarenessUpdate,
+} from 'y-protocols/awareness';
+import type { YjsProviderLike } from './useYjsCollabStatus';
+
+/**
+ * Story fixtures for `CollabStatus`.
+ *
+ * `createLocalYjsRoom` is a **real Yjs room** (real `Y.Doc` + `Awareness`, real
+ * update encoding) whose transport is an in-memory hub instead of a WebSocket.
+ * That lets the stories exercise the exact `useYjsCollabStatus` code path —
+ * sync, presence join/leave, remote-edit attribution — with no server running,
+ * so it also works in CI and the Storybook test runner.
+ */
+
+type Handler = (...args: unknown[]) => void;
+
+/** Minimal event emitter with the `on`/`off` surface the hook expects. */
+class Emitter {
+  private handlers = new Map<string, Set<Handler>>();
+
+  on(event: string, handler: Handler) {
+    const set = this.handlers.get(event) ?? new Set<Handler>();
+    set.add(handler);
+    this.handlers.set(event, set);
+  }
+
+  off(event: string, handler: Handler) {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    this.handlers.get(event)?.forEach((h) => h(...args));
+  }
+}
+
+/** A `y-websocket`-shaped provider backed by {@link LocalYjsRoom}. */
+class LocalProvider extends Emitter implements YjsProviderLike {
+  synced = false;
+
+  constructor(
+    readonly roomname: string,
+    readonly url: string,
+    readonly awareness: Awareness
+  ) {
+    super();
+  }
+
+  markSynced(value: boolean) {
+    this.synced = value;
+    this.emit('status', { status: value ? 'connected' : 'disconnected' });
+    this.emit('sync', value);
+  }
+}
+
+export interface LocalYjsMember {
+  doc: Y.Doc;
+  awareness: Awareness;
+  provider: LocalProvider;
+  /** Disconnect this member and clear its presence for everyone else. */
+  leave: () => void;
+}
+
+/**
+ * A real Yjs room whose peers relay updates through memory. Every member gets
+ * its own `Y.Doc` and `Awareness`, exactly as separate browser tabs would.
+ */
+export class LocalYjsRoom {
+  private members = new Set<LocalYjsMember>();
+
+  constructor(
+    readonly name = 'case/4',
+    readonly url = 'memory://storybook'
+  ) {}
+
+  /** Add a member. `syncDelay` simulates the initial server round-trip. */
+  join(syncDelay = 400): LocalYjsMember {
+    const doc = new Y.Doc();
+    const awareness = new Awareness(doc);
+    const provider = new LocalProvider(this.name, this.url, awareness);
+
+    // Catch the newcomer up with the room's current state.
+    for (const peer of this.members) {
+      Y.applyUpdate(doc, Y.encodeStateAsUpdate(peer.doc), provider);
+      const ids = [...peer.awareness.getStates().keys()];
+      applyAwarenessUpdate(
+        awareness,
+        encodeAwarenessUpdate(peer.awareness, ids),
+        provider
+      );
+      break;
+    }
+
+    const onDocUpdate = (update: Uint8Array, origin: unknown) => {
+      if (origin === provider) return; // came from the hub; don't echo it back
+      for (const peer of this.members) {
+        if (peer.provider === provider) continue;
+        Y.applyUpdate(peer.doc, update, peer.provider);
+      }
+    };
+    doc.on('update', onDocUpdate);
+
+    const onAwareness = (
+      changed: { added: number[]; updated: number[]; removed: number[] },
+      origin: unknown
+    ) => {
+      if (origin === provider) return;
+      const ids = [...changed.added, ...changed.updated, ...changed.removed];
+      const update = encodeAwarenessUpdate(awareness, ids);
+      for (const peer of this.members) {
+        if (peer.provider === provider) continue;
+        applyAwarenessUpdate(peer.awareness, update, peer.provider);
+      }
+    };
+    awareness.on('update', onAwareness);
+
+    const member: LocalYjsMember = {
+      doc,
+      awareness,
+      provider,
+      leave: () => {
+        this.members.delete(member);
+        doc.off('update', onDocUpdate);
+        awareness.off('update', onAwareness);
+        // Clear presence, then push that removal so peers log "left the room".
+        awareness.setLocalState(null);
+        const removal = encodeAwarenessUpdate(awareness, [awareness.clientID]);
+        for (const peer of this.members) {
+          applyAwarenessUpdate(peer.awareness, removal, peer.provider);
+        }
+        provider.markSynced(false);
+        awareness.destroy();
+        doc.destroy();
+      },
+    };
+
+    this.members.add(member);
+    window.setTimeout(() => provider.markSynced(true), syncDelay);
+    return member;
+  }
+
+  /** Type into the shared `notes` text as this member, like a real edit. */
+  static type(member: LocalYjsMember, text: string) {
+    const notes = member.doc.getText('notes');
+    member.doc.transact(() => notes.insert(notes.length, text));
+  }
+}
+
+/** Static log fixture for the presentational (transport-free) stories. */
+export const sampleLog = [
+  {
+    id: 4,
+    at: Date.now() - 2_000,
+    kind: 'doc' as const,
+    origin: 'remote' as const,
+    detail: 'doc update · 42 bytes',
+  },
+  {
+    id: 3,
+    at: Date.now() - 9_000,
+    kind: 'awareness' as const,
+    origin: 'remote' as const,
+    detail: 'Ann Nurse edited Case notes',
+  },
+  {
+    id: 2,
+    at: Date.now() - 21_000,
+    kind: 'patch' as const,
+    origin: 'local' as const,
+    detail: 'edited Status',
+  },
+  {
+    id: 1,
+    at: Date.now() - 34_000,
+    kind: 'sync' as const,
+    detail: 'synced with server',
+  },
+];

--- a/src/components/CollabStatus/storyData.ts
+++ b/src/components/CollabStatus/storyData.ts
@@ -122,6 +122,7 @@ export class LocalYjsRoom {
       awareness,
       provider,
       leave: () => {
+        window.clearTimeout(syncTimer);
         this.members.delete(member);
         doc.off('update', onDocUpdate);
         awareness.off('update', onAwareness);
@@ -138,7 +139,10 @@ export class LocalYjsRoom {
     };
 
     this.members.add(member);
-    window.setTimeout(() => provider.markSynced(true), syncDelay);
+    const syncTimer = window.setTimeout(
+      () => provider.markSynced(true),
+      syncDelay
+    );
     return member;
   }
 

--- a/src/components/CollabStatus/useYjsCollabStatus.ts
+++ b/src/components/CollabStatus/useYjsCollabStatus.ts
@@ -1,0 +1,324 @@
+import * as React from 'react';
+import type {
+  CollabLogEntry,
+  CollabPeer,
+  CollabRoomInfo,
+} from './CollabStatus';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// =============================================================================
+// Structural Yjs types
+// =============================================================================
+//
+// Declared structurally (as methods, so parameter bivariance applies) rather
+// than imported from `yjs` / `y-protocols`, so `@mieweb/ui` needs no Yjs
+// dependency at all. A real `Y.Doc`, `Awareness` and `WebsocketProvider`
+// satisfy these as-is.
+
+/** The subset of `Y.Doc` this hook observes. */
+export interface YjsDocLike {
+  clientID: number;
+  on(event: string, handler: (...args: any[]) => void): void;
+  off(event: string, handler: (...args: any[]) => void): void;
+}
+
+/** The subset of `y-protocols/awareness`.`Awareness` this hook uses. */
+export interface YjsAwarenessLike {
+  clientID: number;
+  getStates(): Map<number, Record<string, any>>;
+  setLocalStateField(field: string, value: unknown): void;
+  on(event: string, handler: (...args: any[]) => void): void;
+  off(event: string, handler: (...args: any[]) => void): void;
+}
+
+/** The subset of `y-websocket`.`WebsocketProvider` this hook uses. */
+export interface YjsProviderLike {
+  awareness: YjsAwarenessLike;
+  /** True once the initial sync completed (y-websocket exposes this). */
+  synced?: boolean;
+  /** Room name, used as the default label in the debug panel. */
+  roomname?: string;
+  /** Server URL, used as the default label in the debug panel. */
+  url?: string;
+  on(event: string, handler: (...args: any[]) => void): void;
+  off(event: string, handler: (...args: any[]) => void): void;
+}
+
+/** Awareness payload published whenever this window makes a local edit. */
+interface EditActivity {
+  at: number;
+  fields: string[];
+}
+
+/** A remote collaborator's edit that just changed the open document. */
+export interface CollabRemoteEdit {
+  /** Human-readable labels of the fields that changed. */
+  fields: string[];
+  /** Who made the change, when attributable from presence. */
+  by?: string;
+  /** Timestamp; a new value signals a fresh growl/toast. */
+  at: number;
+}
+
+export interface UseYjsCollabStatusOptions {
+  /** The shared document. Pass null to keep the hook inert. */
+  doc: YjsDocLike | null | undefined;
+  /** The sync provider (e.g. `y-websocket`). Pass null to keep it inert. */
+  provider: YjsProviderLike | null | undefined;
+  /**
+   * Presence identity published for this window. Defaults to
+   * `User <clientID>` so windows are distinguishable without a login.
+   */
+  user?: { name?: string; color?: string };
+  /** Room label for the debug panel. Defaults to `provider.roomname`. */
+  roomName?: string;
+  /** URL label for the debug panel. Defaults to `provider.url`. */
+  url?: string;
+  /** Application user id shown in the debug panel. */
+  userId?: string;
+  /** Maximum log entries kept in memory. Default 100. */
+  logCap?: number;
+}
+
+export interface YjsCollabStatus {
+  /** True once the initial server sync completed. */
+  connected: boolean;
+  /** Other windows currently present in the room. */
+  peers: CollabPeer[];
+  /** Recent collaboration events, newest first. */
+  log: CollabLogEntry[];
+  /** Room identity for the debug panel. */
+  room: CollabRoomInfo | null;
+  /** The most recent remote edit, or null. */
+  lastRemoteEdit: CollabRemoteEdit | null;
+  /**
+   * Announce a local edit and the fields it touched, so other windows can
+   * attribute it. Also records a `patch` log entry.
+   */
+  publishActivity: (fields: string[]) => void;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Bind {@link CollabStatus} to a Yjs room: tracks initial-sync state, publishes
+ * this window's presence, tracks peers joining/leaving, attributes remote edits,
+ * and keeps a capped log of document/awareness/sync events.
+ *
+ * The return value is spreadable straight into the component.
+ *
+ * @example
+ * ```tsx
+ * import * as Y from 'yjs';
+ * import { WebsocketProvider } from 'y-websocket';
+ * import { CollabStatus, useYjsCollabStatus } from '@mieweb/ui';
+ *
+ * function Header({ caseId }: { caseId: string }) {
+ *   const doc = React.useMemo(() => new Y.Doc(), []);
+ *   const provider = React.useMemo(
+ *     () => new WebsocketProvider('ws://localhost:1234', `case/${caseId}`, doc),
+ *     [doc, caseId]
+ *   );
+ *   React.useEffect(() => () => provider.destroy(), [provider]);
+ *
+ *   const status = useYjsCollabStatus({ doc, provider, user: { name: 'Ann' } });
+ *   return <CollabStatus {...status} />;
+ * }
+ * ```
+ */
+export function useYjsCollabStatus({
+  doc,
+  provider,
+  user,
+  roomName,
+  url,
+  userId,
+  logCap = 100,
+}: UseYjsCollabStatusOptions): YjsCollabStatus {
+  const [connected, setConnected] = React.useState(false);
+  const [peers, setPeers] = React.useState<CollabPeer[]>([]);
+  const [lastRemoteEdit, setLastRemoteEdit] =
+    React.useState<CollabRemoteEdit | null>(null);
+  const [log, setLog] = React.useState<CollabLogEntry[]>([]);
+
+  const logIdRef = React.useRef(0);
+  const awarenessRef = React.useRef<YjsAwarenessLike | null>(null);
+  /** Effective display name published to presence. */
+  const selfNameRef = React.useRef('');
+  /** Last activity timestamp seen per remote client, to detect new edits. */
+  const activitySeen = React.useRef(new Map<number, number>());
+  /** Names present, keyed by clientID, to detect join/leave. */
+  const peerNames = React.useRef(new Map<number, string>());
+
+  const pushLog = React.useCallback(
+    (entry: Omit<CollabLogEntry, 'id' | 'at'>) => {
+      const full: CollabLogEntry = {
+        id: ++logIdRef.current,
+        at: Date.now(),
+        ...entry,
+      };
+      setLog((prev) => [full, ...prev].slice(0, logCap));
+    },
+    [logCap]
+  );
+
+  const selfName = user?.name?.trim();
+  const selfColor = user?.color;
+
+  React.useEffect(() => {
+    if (!doc || !provider) {
+      setConnected(false);
+      setPeers([]);
+      setLastRemoteEdit(null);
+      return;
+    }
+
+    const awareness = provider.awareness;
+    awarenessRef.current = awareness;
+    activitySeen.current = new Map();
+    peerNames.current = new Map();
+    setConnected(provider.synced ?? false);
+
+    // Remote updates arrive with `origin === provider`; local transactions have
+    // a null origin — that is what labels the log entry.
+    const onDocUpdate = (update: Uint8Array, origin: unknown) => {
+      pushLog({
+        kind: 'doc',
+        origin: origin === provider ? 'remote' : 'local',
+        detail: `doc update · ${update.byteLength} bytes`,
+      });
+    };
+    doc.on('update', onDocUpdate);
+
+    const onSync = (isSynced: boolean) => {
+      setConnected(isSynced);
+      pushLog({
+        kind: 'sync',
+        detail: isSynced ? 'synced with server' : 'disconnected',
+      });
+    };
+    provider.on('sync', onSync);
+
+    const onStatus = (event: { status?: string }) => {
+      if (event?.status === 'disconnected') setConnected(false);
+    };
+    provider.on('status', onStatus);
+
+    const onAwareness = () => {
+      const others: CollabPeer[] = [];
+      const present = new Map<number, string>();
+      let freshest: CollabRemoteEdit | null = null;
+
+      awareness.getStates().forEach((state, clientId) => {
+        if (clientId === awareness.clientID) return; // skip this window
+        const peer = state.user as CollabPeer | undefined;
+        if (peer?.name) {
+          others.push({ name: peer.name, color: peer.color });
+          present.set(clientId, peer.name);
+        }
+        const activity = state.activity as EditActivity | undefined;
+        if (
+          activity &&
+          activity.at > (activitySeen.current.get(clientId) ?? 0)
+        ) {
+          activitySeen.current.set(clientId, activity.at);
+          if (!freshest || activity.at > freshest.at) {
+            const sameUser = !!peer?.name && peer.name === selfNameRef.current;
+            freshest = {
+              fields: activity.fields,
+              by: sameUser ? 'You (another window)' : peer?.name,
+              at: activity.at,
+            };
+          }
+        }
+      });
+
+      for (const [clientId, name] of present) {
+        if (!peerNames.current.has(clientId)) {
+          pushLog({
+            kind: 'awareness',
+            origin: 'remote',
+            detail: `${name} joined the room`,
+          });
+        }
+      }
+      for (const [clientId, name] of peerNames.current) {
+        if (!present.has(clientId)) {
+          pushLog({
+            kind: 'awareness',
+            origin: 'remote',
+            detail: `${name} left the room`,
+          });
+        }
+      }
+      peerNames.current = present;
+      setPeers(others);
+
+      if (freshest) {
+        const edit = freshest as CollabRemoteEdit;
+        setLastRemoteEdit(edit);
+        pushLog({
+          kind: 'awareness',
+          origin: 'remote',
+          detail: `${edit.by ?? 'peer'} edited ${edit.fields.join(', ')}`,
+        });
+      }
+    };
+    awareness.on('change', onAwareness);
+
+    return () => {
+      doc.off('update', onDocUpdate);
+      provider.off('sync', onSync);
+      provider.off('status', onStatus);
+      awareness.off('change', onAwareness);
+      awarenessRef.current = null;
+      activitySeen.current = new Map();
+      peerNames.current = new Map();
+      setConnected(false);
+      setPeers([]);
+      setLastRemoteEdit(null);
+      setLog([]);
+    };
+  }, [doc, provider, pushLog]);
+
+  // Publish (and re-publish) this window's presence without tearing the room
+  // down when the display name changes. Runs after the room effect above, which
+  // is what populates `awarenessRef`.
+  React.useEffect(() => {
+    const awareness = awarenessRef.current;
+    if (!awareness) return;
+    const name = selfName || `User ${awareness.clientID}`;
+    selfNameRef.current = name;
+    awareness.setLocalStateField('user', { name, color: selfColor });
+  }, [provider, selfName, selfColor]);
+
+  const publishActivity = React.useCallback(
+    (fields: string[]) => {
+      awarenessRef.current?.setLocalStateField('activity', {
+        at: Date.now(),
+        fields,
+      } satisfies EditActivity);
+      pushLog({
+        kind: 'patch',
+        origin: 'local',
+        detail: `edited ${fields.join(', ')}`,
+      });
+    },
+    [pushLog]
+  );
+
+  const room: CollabRoomInfo | null =
+    doc && provider
+      ? {
+          name: roomName ?? provider.roomname ?? 'room',
+          url: url ?? provider.url,
+          clientId: doc.clientID,
+          userId,
+        }
+      : null;
+
+  return { connected, peers, log, room, lastRemoteEdit, publishActivity };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export * from './components/Checkbox';
 export * from './components/CodeLookup/context';
 export * from './components/ConditionEditor';
 export * from './components/CheckrIntegration';
+export * from './components/CollabStatus';
 export * from './components/Collapsible';
 export * from './components/CommandPalette';
 export * from './components/ConnectionStatus';

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -418,6 +418,11 @@ export const miewebUISafelist = [
   'text-[11px]',
   // CodeLookup memory picklist (frequently-used pick count)
   'text-primary-600',
+  // CollabStatus debug panel (fixed-width portal, definition grid, log grid)
+  'w-[26rem]',
+  'max-w-[calc(100vw-1rem)]',
+  'grid-cols-[auto_1fr]',
+  'grid-cols-[auto_auto_1fr]',
   // SuperChat (participant chips, unread badge, active/hover states)
   'bg-primary-100',
   'bg-primary-600',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     'components/Button/index': 'src/components/Button/index.ts',
     'components/Card/index': 'src/components/Card/index.ts',
     'components/Checkbox/index': 'src/components/Checkbox/index.ts',
+    'components/CollabStatus/index': 'src/components/CollabStatus/index.ts',
     'components/Collapsible/index': 'src/components/Collapsible/index.ts',
     'components/CountryCodeDropdown/index': 'src/components/CountryCodeDropdown/index.ts',
     'components/DateInput/index': 'src/components/DateInput/index.ts',


### PR DESCRIPTION
Adds `CollabStatus`, a connection dot + `Live`/`Connecting…` label + "who is editing" summary with a click-to-open panel showing room identity and a rolling event log. The component is transport-agnostic — it renders whatever presence state it is handed.

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/1e47aa70-7c4a-4f95-a74a-ad048240d315" />

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/2efb7610-de09-4aca-aa3e-97e25d418ab9" />


`useYjsCollabStatus` binds it to a Yjs `y-websocket` room in three lines. The doc/awareness/provider are typed structurally, so the library keeps a zero runtime dependency on Yjs (yjs, y-protocols and y-websocket are devDependencies used only by the stories and tests).

Stories include a simulated room (a real Y.Doc + Awareness relayed in memory, so it works with no server and in CI) and a live server room, plus autodocs covering the binding recipe.