### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mieweb/ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A themeable, accessible React component library built with Tailwind CSS",
   "author": "Medical Informatics Engineering, Inc.",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Bump version 0.7.0 → 0.7.1 for release.

Includes the DateInput calendar clipping fix (#352), verified in `0.7.0-dev.187`.

After merge, tag the merge commit `v0.7.1` to publish `@mieweb/ui@0.7.1` to npm `latest`.