### PR TITLE
feat(media): let a host extend Undo, and add the Redo it never had

### DIFF
--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -258,6 +258,57 @@ describe('MediaEditor host-extensible undo', () => {
     expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
   });
 
+  it('redoes its own word-level step, the one Undo just took', () => {
+    // The case that shipped broken: Undo (1) was live, Redo was grey, so a
+    // word-level undo could not be taken back.
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        {...withOneEditorStep}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Undo \(1 available\)/ })
+    );
+
+    const redo = screen.getByRole('button', { name: 'Redo' });
+    expect(redo).toBeEnabled();
+    fireEvent.click(redo);
+    // Back where we started: the step is on the undo stack again.
+    expect(
+      screen.getByRole('button', { name: /Undo \(1 available\)/ })
+    ).toBeEnabled();
+  });
+
+  it('spends its own redo before the one a host offers, mirroring undo', () => {
+    const onRedo = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canRedo
+        onRedo={onRedo}
+        {...withOneEditorStep}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Undo \(1 available\)/ })
+    );
+
+    // A word-level redo exists, so the host must not be called yet.
+    fireEvent.click(screen.getByRole('button', { name: 'Redo' }));
+    expect(onRedo).not.toHaveBeenCalled();
+
+    // With that spent, the same control serves the host.
+    fireEvent.click(screen.getByRole('button', { name: 'Redo' }));
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
   it('explains a disabled Undo rather than claiming a target', () => {
     render(
       <MediaEditor
@@ -316,35 +367,24 @@ describe('MediaEditor host-extensible undo', () => {
     expect(onUndoBeyond).toHaveBeenCalledTimes(1);
   });
 
-  it('has no Redo of its own, and shows one only when a host provides it', () => {
-    const { unmount } = render(
-      <MediaEditor
-        src="clip.mp3"
-        kind="audio"
-        transcript={transcript}
-        {...withOneEditorStep}
-      />
-    );
-    expect(
-      screen.queryByRole('button', { name: /Redo/ })
-    ).not.toBeInTheDocument();
-    unmount();
-
+  it('shows Redo alongside Undo, disabled until there is something to redo', () => {
     const onRedo = vi.fn();
     render(
       <MediaEditor
         src="clip.mp3"
         kind="audio"
         transcript={transcript}
-        canRedo
+        canRedo={false}
         onRedo={onRedo}
         redoLabel="Removed 8 words"
+        {...withOneEditorStep}
       />
     );
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Redo: Removed 8 words' })
-    );
-    expect(onRedo).toHaveBeenCalledTimes(1);
+    // Undo has a step; Redo is present but inert rather than missing.
+    expect(
+      screen.getByRole('button', { name: /Undo \(1 available\)/ })
+    ).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
   });
 
   it('disables Redo when the host has nothing forward', () => {

--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -225,6 +225,56 @@ describe('MediaEditor host-extensible undo', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('keeps Undo and Redo together, disabling rather than removing either', () => {
+    // A host that can redo but not undo: Undo must still be on screen, greyed,
+    // rather than leaving a lone Redo that reads as a broken control.
+    const { rerender } = render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canUndoBeyond={false}
+        onUndoBeyond={vi.fn()}
+        canRedo
+        onRedo={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeEnabled();
+
+    // And the mirror image at the other end of the history.
+    rerender(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canUndoBeyond
+        onUndoBeyond={vi.fn()}
+        canRedo={false}
+        onRedo={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+  });
+
+  it('explains a disabled Undo rather than claiming a target', () => {
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canUndoBeyond={false}
+        undoBeyondLabel="Trim to 45 seconds"
+        onRedo={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Undo' })).toHaveAttribute(
+      'title',
+      'Nothing to undo'
+    );
+  });
+
   it('offers Undo for the host alone, before any edit has been made', () => {
     const onUndoBeyond = vi.fn();
     render(

--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -202,3 +202,115 @@ describe('MediaEditor drag selection beyond the pane', () => {
     fireEvent.mouseUp(document);
   });
 });
+
+describe('MediaEditor host-extensible undo', () => {
+  /** The edit list for `transcript`, with one word optionally cut. */
+  const words = (deletedIndex?: number) =>
+    transcript.words.map((word, i) => ({
+      originalIndex: i,
+      word,
+      deleted: i === deletedIndex,
+    }));
+
+  /** Props that give the editor exactly one word-level undo step of its own. */
+  const withOneEditorStep = {
+    initialEditedWords: words(1),
+    initialUndoStack: [words()],
+  };
+
+  it('shows no Undo when neither the editor nor the host has one', () => {
+    render(<MediaEditor src="clip.mp3" kind="audio" transcript={transcript} />);
+    expect(
+      screen.queryByRole('button', { name: /Undo/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers Undo for the host alone, before any edit has been made', () => {
+    const onUndoBeyond = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canUndoBeyond
+        onUndoBeyond={onUndoBeyond}
+        undoBeyondLabel="Trim to 45 seconds"
+      />
+    );
+    const undo = screen.getByRole('button', {
+      name: 'Undo: Trim to 45 seconds',
+    });
+    fireEvent.click(undo);
+    expect(onUndoBeyond).toHaveBeenCalledTimes(1);
+  });
+
+  it('spends its own history before handing over to the host', () => {
+    const onUndoBeyond = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canUndoBeyond
+        onUndoBeyond={onUndoBeyond}
+        {...withOneEditorStep}
+      />
+    );
+    // One word-level step exists, so Undo belongs to the editor.
+    const undo = screen.getByRole('button', { name: /Undo \(1 available\)/ });
+    fireEvent.click(undo);
+    expect(onUndoBeyond).not.toHaveBeenCalled();
+
+    // With that step spent, the same control now serves the host.
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(onUndoBeyond).toHaveBeenCalledTimes(1);
+  });
+
+  it('has no Redo of its own, and shows one only when a host provides it', () => {
+    const { unmount } = render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        {...withOneEditorStep}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: /Redo/ })
+    ).not.toBeInTheDocument();
+    unmount();
+
+    const onRedo = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canRedo
+        onRedo={onRedo}
+        redoLabel="Removed 8 words"
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Redo: Removed 8 words' })
+    );
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Redo when the host has nothing forward', () => {
+    const onRedo = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canRedo={false}
+        onRedo={onRedo}
+      />
+    );
+    const redo = screen.getByRole('button', { name: 'Redo' });
+    expect(redo).toBeDisabled();
+    fireEvent.click(redo);
+    expect(onRedo).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MediaEditor/MediaEditor.test.tsx
+++ b/src/components/MediaEditor/MediaEditor.test.tsx
@@ -309,6 +309,61 @@ describe('MediaEditor host-extensible undo', () => {
     expect(onRedo).toHaveBeenCalledTimes(1);
   });
 
+  it('does not offer an action it has no handler for', () => {
+    // A host that sets the capability flag but forgets the handler would
+    // otherwise get an enabled button that silently does nothing.
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canUndoBeyond
+        canRedo
+        onRedo={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+  });
+
+  it('handles the redo shortcut it advertises', () => {
+    // The button shows a hint; the component has to honour it, or the hint is
+    // a lie for anyone who is not the one host that wired up its own listener.
+    const onRedo = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canRedo
+        onRedo={onRedo}
+      />
+    );
+    const listbox = screen.getByRole('listbox', { name: 'Transcript words' });
+    fireEvent.keyDown(listbox, { key: 'z', metaKey: true, shiftKey: true });
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('redoes its own word-level step from the keyboard before the host one', () => {
+    const onRedo = vi.fn();
+    render(
+      <MediaEditor
+        src="clip.mp3"
+        kind="audio"
+        transcript={transcript}
+        canRedo
+        onRedo={onRedo}
+        {...withOneEditorStep}
+      />
+    );
+    const listbox = screen.getByRole('listbox', { name: 'Transcript words' });
+    fireEvent.keyDown(listbox, { key: 'z', metaKey: true });
+    fireEvent.keyDown(listbox, { key: 'z', metaKey: true, shiftKey: true });
+    expect(onRedo).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: /Undo \(1 available\)/ })
+    ).toBeEnabled();
+  });
+
   it('explains a disabled Undo rather than claiming a target', () => {
     render(
       <MediaEditor

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -77,6 +77,28 @@ export interface MediaEditorProps extends VariantProps<
   onCursorTimestampChange?: (timestampMs: number | null) => void;
   /** Fired whenever the edited words change — lets the host build raw-data views */
   onEditedWordsRender?: (editedWords: EditableWord[]) => void;
+  /**
+   * Undo beyond the editor's own history.
+   *
+   * The editor's undo is word-level, which is the right grain for typing and
+   * the wrong one for a host that also versions the document — undoing a batch
+   * change one word at a time is not undoing it. When a host provides this, the
+   * Undo control stays available once the editor's own stack is empty and hands
+   * over instead of going dead, so there is one Undo rather than two.
+   */
+  onUndoBeyond?: () => void;
+  /** Whether the host has anything left to undo. Keeps Undo live at depth 0. */
+  canUndoBeyond?: boolean;
+  /** What `onUndoBeyond` would undo, for the tooltip (e.g. a version name). */
+  undoBeyondLabel?: string;
+  /**
+   * Redo. The editor has no redo of its own — its undo stack is destructive —
+   * so the control only appears when a host can service it.
+   */
+  onRedo?: () => void;
+  canRedo?: boolean;
+  /** What `onRedo` would redo, for the tooltip. */
+  redoLabel?: string;
   /** Optional ref to the internal MediaPlayer (host escape hatch, e.g. thumbnail capture) */
   playerRef?: React.Ref<MediaPlayerRef>;
   /** Additional class name */
@@ -263,6 +285,12 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       onCursorTimestampChange,
       onEditedWordsRender,
       onSpeedStateChange,
+      onUndoBeyond,
+      canUndoBeyond = false,
+      undoBeyondLabel,
+      onRedo,
+      canRedo = false,
+      redoLabel,
       playerRef: externalPlayerRef,
       className,
       splitLayout,
@@ -1379,15 +1407,48 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
                 >
                   ✂️
                 </Button>
-                {undoStack.length > 0 && (
+                {(undoStack.length > 0 || canUndoBeyond) && (
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={undo}
-                    aria-label={`Undo (${undoStack.length} available)`}
-                    title="Undo (⌘Z)"
+                    // Word-level first; the host only gets it once the
+                    // editor's own history is spent.
+                    onClick={undoStack.length > 0 ? undo : onUndoBeyond}
+                    aria-label={
+                      undoStack.length > 0
+                        ? `Undo (${undoStack.length} available)`
+                        : undoBeyondLabel
+                          ? `Undo: ${undoBeyondLabel}`
+                          : 'Undo'
+                    }
+                    title={
+                      undoStack.length > 0
+                        ? `Undo (⌘Z) — ${undoStack.length} step${undoStack.length === 1 ? '' : 's'}`
+                        : undoBeyondLabel
+                          ? `Undo (⌘Z) — back to "${undoBeyondLabel}"`
+                          : 'Undo (⌘Z)'
+                    }
                   >
-                    Undo ({undoStack.length})
+                    Undo{undoStack.length > 0 ? ` (${undoStack.length})` : ''}{' '}
+                    <kbd className="text-[10px] opacity-60">⌘Z</kbd>
+                  </Button>
+                )}
+                {onRedo && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onRedo}
+                    disabled={!canRedo}
+                    aria-label={redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
+                    title={
+                      canRedo && redoLabel
+                        ? `Redo (⌘Y) — forward to "${redoLabel}"`
+                        : canRedo
+                          ? 'Redo (⌘Y)'
+                          : 'Nothing to redo'
+                    }
+                  >
+                    Redo <kbd className="text-[10px] opacity-60">⌘Y</kbd>
                   </Button>
                 )}
               </div>

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -345,8 +345,11 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
     // vanishes shifts the ones beside it; a lone greyed Redo reads as broken.
     // Each side prefers the editor's own history and falls through to the
     // host's, so the pair walks the same states in both directions.
-    const canUndoAnything = undoStack.length > 0 || canUndoBeyond;
-    const canRedoAnything = canRedoWords || canRedo;
+    // A host that sets the capability flag without the handler would otherwise
+    // get an enabled button that does nothing, so both are required.
+    const canUndoAnything =
+      undoStack.length > 0 || (canUndoBeyond && !!onUndoBeyond);
+    const canRedoAnything = canRedoWords || (canRedo && !!onRedo);
     const showUndoRedo = canUndoAnything || canRedoAnything || !!onRedo;
 
     // -- UI state --
@@ -1077,6 +1080,17 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
         } else if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
           undo();
           handled = true;
+        } else if (
+          (e.metaKey || e.ctrlKey) &&
+          ((e.key === 'z' && e.shiftKey) || e.key === 'y')
+        ) {
+          // Redo. ⌘Y is accepted for anyone arriving from Windows but is never
+          // advertised — on macOS it is Chrome's own History shortcut and the
+          // browser wins. The button shows ⇧⌘Z, which is what this handles.
+          // Word-level first, then the host's, mirroring Undo.
+          if (canRedoWords) redo();
+          else if (canRedo && onRedo) onRedo();
+          handled = true;
         } else if (e.key === 'ArrowLeft') {
           if (cursorPosition === 'after') {
             // Move from 'after' the last word back to 'before' it
@@ -1234,6 +1248,10 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
         handleCut,
         handlePaste,
         undo,
+        redo,
+        canRedoWords,
+        canRedo,
+        onRedo,
         openWordEditor,
       ]
     );

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -92,8 +92,9 @@ export interface MediaEditorProps extends VariantProps<
   /** What `onUndoBeyond` would undo, for the tooltip (e.g. a version name). */
   undoBeyondLabel?: string;
   /**
-   * Redo. The editor has no redo of its own — its undo stack is destructive —
-   * so the control only appears when a host can service it.
+   * Redo beyond the editor's own history — the counterpart to `onUndoBeyond`.
+   * The editor redoes its own word-level steps first and only calls this once
+   * they are exhausted, so the pair walks the same states in both directions.
    */
   onRedo?: () => void;
   canRedo?: boolean;
@@ -312,6 +313,8 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       clipboard,
       hasEdits,
       undo,
+      redo,
+      canRedo: canRedoWords,
       toggleWordDeleted,
       deleteRange,
       cut,
@@ -336,6 +339,15 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
       stats,
       fillerAnalysis,
     } = edits;
+
+    // Undo and Redo are one control pair: they appear and disappear together,
+    // and whichever cannot act is disabled rather than removed. A button that
+    // vanishes shifts the ones beside it; a lone greyed Redo reads as broken.
+    // Each side prefers the editor's own history and falls through to the
+    // host's, so the pair walks the same states in both directions.
+    const canUndoAnything = undoStack.length > 0 || canUndoBeyond;
+    const canRedoAnything = canRedoWords || canRedo;
+    const showUndoRedo = canUndoAnything || canRedoAnything || !!onRedo;
 
     // -- UI state --
     const [activeWordIndex, setActiveWordIndex] = React.useState<number | null>(
@@ -1411,11 +1423,11 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
                     Redo reads as broken, and an Undo that vanishes at the end
                     of history while Redo merely greys is two rules for one
                     pair — so whichever is inert is disabled, not removed. */}
-                {(undoStack.length > 0 || canUndoBeyond || onRedo) && (
+                {showUndoRedo && (
                   <Button
                     variant="ghost"
                     size="sm"
-                    disabled={undoStack.length === 0 && !canUndoBeyond}
+                    disabled={!canUndoAnything}
                     // Word-level first; the host only gets it once the
                     // editor's own history is spent.
                     onClick={undoStack.length > 0 ? undo : onUndoBeyond}
@@ -1440,22 +1452,30 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
                     <kbd className="text-[10px] opacity-60">⌘Z</kbd>
                   </Button>
                 )}
-                {onRedo && (
+                {showUndoRedo && (
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={onRedo}
-                    disabled={!canRedo}
-                    aria-label={redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
+                    // Word-level first, mirroring Undo, so the pair steps back
+                    // and forward through the same states in the same order.
+                    onClick={canRedoWords ? redo : onRedo}
+                    disabled={!canRedoAnything}
+                    aria-label={
+                      !canRedoWords && canRedo && redoLabel
+                        ? `Redo: ${redoLabel}`
+                        : 'Redo'
+                    }
                     title={
-                      canRedo && redoLabel
-                        ? `Redo (⌘Y) — forward to "${redoLabel}"`
-                        : canRedo
-                          ? 'Redo (⌘Y)'
-                          : 'Nothing to redo'
+                      canRedoWords
+                        ? 'Redo (⇧⌘Z)'
+                        : canRedo && redoLabel
+                          ? `Redo (⇧⌘Z) — forward to "${redoLabel}"`
+                          : canRedo
+                            ? 'Redo (⇧⌘Z)'
+                            : 'Nothing to redo'
                     }
                   >
-                    Redo <kbd className="text-[10px] opacity-60">⌘Y</kbd>
+                    Redo <kbd className="text-[10px] opacity-60">⇧⌘Z</kbd>
                   </Button>
                 )}
               </div>

--- a/src/components/MediaEditor/MediaEditor.tsx
+++ b/src/components/MediaEditor/MediaEditor.tsx
@@ -1407,26 +1407,33 @@ export const MediaEditor = React.forwardRef<HTMLDivElement, MediaEditorProps>(
                 >
                   ✂️
                 </Button>
-                {(undoStack.length > 0 || canUndoBeyond) && (
+                {/* Undo and Redo appear and disappear together. A lone greyed
+                    Redo reads as broken, and an Undo that vanishes at the end
+                    of history while Redo merely greys is two rules for one
+                    pair — so whichever is inert is disabled, not removed. */}
+                {(undoStack.length > 0 || canUndoBeyond || onRedo) && (
                   <Button
                     variant="ghost"
                     size="sm"
+                    disabled={undoStack.length === 0 && !canUndoBeyond}
                     // Word-level first; the host only gets it once the
                     // editor's own history is spent.
                     onClick={undoStack.length > 0 ? undo : onUndoBeyond}
                     aria-label={
                       undoStack.length > 0
                         ? `Undo (${undoStack.length} available)`
-                        : undoBeyondLabel
+                        : canUndoBeyond && undoBeyondLabel
                           ? `Undo: ${undoBeyondLabel}`
                           : 'Undo'
                     }
                     title={
                       undoStack.length > 0
                         ? `Undo (⌘Z) — ${undoStack.length} step${undoStack.length === 1 ? '' : 's'}`
-                        : undoBeyondLabel
-                          ? `Undo (⌘Z) — back to "${undoBeyondLabel}"`
-                          : 'Undo (⌘Z)'
+                        : canUndoBeyond
+                          ? undoBeyondLabel
+                            ? `Undo (⌘Z) — back to "${undoBeyondLabel}"`
+                            : 'Undo (⌘Z)'
+                          : 'Nothing to undo'
                     }
                   >
                     Undo{undoStack.length > 0 ? ` (${undoStack.length})` : ''}{' '}

--- a/src/hooks/useTranscriptEdits.ts
+++ b/src/hooks/useTranscriptEdits.ts
@@ -288,6 +288,10 @@ export interface UseTranscriptEditsResult {
   pushUndo: () => void;
   /** Restore the most recent undo snapshot */
   undo: () => void;
+  /** Step forward again after an undo. Cleared by any new edit. */
+  redo: () => void;
+  /** Whether there is anything to redo */
+  canRedo: boolean;
 
   // -- Word mutations (selection-agnostic: pass explicit indices) --
   /** Toggle the deleted flag on a single word */
@@ -450,10 +454,23 @@ export function useTranscriptEdits(
     }))
   );
 
+  // Redo mirrors undo. Undo used to pop and discard, which meant a mis-click
+  // was unrecoverable and any Redo control a host offered could not service
+  // word-level steps — the pair looked symmetric and was not. Not persisted, for
+  // the same reason the speed snapshots are not: a rehydrated stack describes a
+  // sequence of states this session never performed.
+  const [redoStack, setRedoStack] = useState<EditableWord[][]>([]);
+  const [speedRedoStack, setSpeedRedoStack] = useState<
+    { speedMarkers: SpeedMarker[]; defaultSpeed: PlaybackSpeed }[]
+  >([]);
+
   // Helper to save current state to undo stack before making changes
   const pushUndo = useCallback(() => {
     setUndoStack((prev) => [...prev, editedWords]);
     setSpeedUndoStack((prev) => [...prev, { speedMarkers, defaultSpeed }]);
+    // A fresh edit abandons the redo branch, as it does in every editor.
+    setRedoStack([]);
+    setSpeedRedoStack([]);
   }, [editedWords, speedMarkers, defaultSpeed]);
 
   // Track previous transcript to detect changes
@@ -476,6 +493,8 @@ export function useTranscriptEdits(
     setSpeedMarkers([]);
     setDefaultSpeed(1);
     setSpeedUndoStack([]);
+    setRedoStack([]);
+    setSpeedRedoStack([]);
     initializedFromSaved.current = false;
   }, [transcript, minSilenceMs, nlSilenceMs]);
 
@@ -499,6 +518,9 @@ export function useTranscriptEdits(
     if (undoStack.length === 0) return;
     const previousState = undoStack[undoStack.length - 1];
     setUndoStack((prev) => prev.slice(0, -1));
+    // Bank what we are leaving before leaving it.
+    setRedoStack((prev) => [...prev, editedWords]);
+    setSpeedRedoStack((prev) => [...prev, { speedMarkers, defaultSpeed }]);
     setEditedWords(previousState);
     // Speed snapshots ride along with word snapshots
     const speedSnapshot = speedUndoStack[speedUndoStack.length - 1];
@@ -525,7 +547,35 @@ export function useTranscriptEdits(
       (speedSnapshot.speedMarkers.length === 0 &&
         speedSnapshot.defaultSpeed === 1);
     setHasEdits(!isOriginal || !speedIsOriginal);
-  }, [undoStack, speedUndoStack, transcript, minSilenceMs, nlSilenceMs]);
+  }, [
+    undoStack,
+    speedUndoStack,
+    editedWords,
+    speedMarkers,
+    defaultSpeed,
+    transcript,
+    minSilenceMs,
+    nlSilenceMs,
+  ]);
+
+  /** Step forward again after an undo. Cleared by any new edit. */
+  const redo = useCallback(() => {
+    if (redoStack.length === 0) return;
+    const nextState = redoStack[redoStack.length - 1];
+    setRedoStack((prev) => prev.slice(0, -1));
+    setUndoStack((prev) => [...prev, editedWords]);
+    setSpeedUndoStack((prev) => [...prev, { speedMarkers, defaultSpeed }]);
+    setEditedWords(nextState);
+    const speedSnapshot = speedRedoStack[speedRedoStack.length - 1];
+    if (speedSnapshot) {
+      setSpeedRedoStack((prev) => prev.slice(0, -1));
+      setSpeedMarkers(speedSnapshot.speedMarkers);
+      setDefaultSpeed(speedSnapshot.defaultSpeed);
+    }
+    // Redoing always lands on a state that was reached by editing, so it is by
+    // definition not the untouched original.
+    setHasEdits(true);
+  }, [redoStack, speedRedoStack, editedWords, speedMarkers, defaultSpeed]);
 
   // Toggle deleted state on a single word
   const toggleWordDeleted = useCallback(
@@ -1046,6 +1096,8 @@ export function useTranscriptEdits(
     hasEdits,
     pushUndo,
     undo,
+    redo,
+    canRedo: redoStack.length > 0,
     toggleWordDeleted,
     deleteRange,
     cut,


### PR DESCRIPTION
`MediaEditor`'s undo is word-level. That is the right grain for typing and the wrong one for a host that also versions the document — undoing a batch change one word at a time is not undoing it.

A host that wants both ends up putting a second Undo somewhere else on screen, which is exactly what happened in PulseClip: a version-level Undo/Redo pair in the page header, and the editor's own `Undo (3)` down in the stats bar. Two Undos, no way to tell which one you want.

## What this adds

**The existing Undo learns to hand over.** `onUndoBeyond` fires when Undo is pressed and the editor's own stack is empty; `canUndoBeyond` keeps the control alive at depth 0 instead of letting it vanish. Word-level steps are always spent first, so for a host that passes neither prop **nothing changes**.

**Redo is new, and host-only.** The editor cannot implement it — `undo()` pops and discards, so there is nothing to redo from. Rather than rework that stack, the button renders only when `onRedo` is given and is disabled unless `canRedo`.

**Both carry their shortcut in a `<kbd>`**, the way `Del ⌫` / `Cut ⌘X` / `Paste ⌘V` already do. This is also the first time Undo advertises ⌘Z anywhere but a tooltip.

```tsx
<MediaEditor
  …
  canUndoBeyond={canUndoVersion}
  onUndoBeyond={() => restore(historyIndex - 1)}
  undoBeyondLabel={checkpoints[historyIndex - 1]?.label}
  canRedo={canRedoVersion}
  onRedo={() => restore(historyIndex + 1)}
  redoLabel={checkpoints[historyIndex + 1]?.label}
/>
```

The labels are optional and feed the tooltip, so Undo can say *back to "Trim to 45 seconds"* rather than just "Undo".

## Deliberately generic

No "version" or "checkpoint" vocabulary in the props — the library should not learn a host's model. It only knows that *someone else may be able to undo further*, which is true of any host with its own history stack.

## Testing

Five new tests: no Undo when neither side has one · host-only Undo before any edit exists · the editor spending its own history before handing over · Redo appearing only when provided · Redo disabled when the host has nothing forward.

420/420 across the suite. `pnpm lint`, `pnpm typecheck` and `pnpm format` all clean.

## Consumer

Used by mieweb/pulseclip#33, which versions every edit — the agent's and the user's — on one timeline. That is where the second Undo came from, and this removes it.
