### PR TITLE
fix(StepIndicator): render step circle above connector lines

### DIFF
--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -137,7 +137,7 @@ export function StepIndicator({
       onClick={() => handleStepClick(index)}
       disabled={!clickable}
       aria-label={`Step ${index + 1}: ${step.label}`}
-      className={`${sizes.circle} flex shrink-0 items-center justify-center rounded-full font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-neutral-900 ${clickable ? 'cursor-pointer' : 'cursor-default'} ${
+      className={`${sizes.circle} relative z-10 flex shrink-0 items-center justify-center rounded-full font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-neutral-900 ${clickable ? 'cursor-pointer' : 'cursor-default'} ${
         step.hasError
           ? 'bg-red-100 text-red-600 focus:ring-red-500 dark:bg-red-900/30 dark:text-red-400'
           : status === 'completed'


### PR DESCRIPTION
## Problem

In the horizontal StepIndicator, the connector bars overlay the current step's circle — the ring around the active circle was being painted over by the adjacent connector lines.

## Fix

Add `relative z-10` to the step circle button so it (and its ring) renders above the connector bars.

## Verification

- Verified visually in Storybook (`StepIndicator — Clickable All Steps`)
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm format:fix` ✅