### PR TITLE
feat(AIChat): add renderMessageFooter slot for per-message actions

### DIFF
--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -16,6 +16,7 @@ import type {
   AIChatSession,
   AISuggestedAction,
   AIChatCallbacks,
+  AIRenderMessageFooter,
   AIRenderTextContent,
   MCPResourceLink,
 } from './types';
@@ -284,7 +285,7 @@ export interface AIChatProps
    */
   renderTextContent?: AIRenderTextContent;
   /** Optional per-message footer rendered below each bubble (e.g. actions). */
-  renderMessageFooter?: (message: AIMessage) => React.ReactNode;
+  renderMessageFooter?: AIRenderMessageFooter;
   /** Additional class name */
   className?: string;
 }

--- a/src/components/AI/AIChat.tsx
+++ b/src/components/AI/AIChat.tsx
@@ -283,6 +283,8 @@ export interface AIChatProps
    * text block with `{ messageId, streaming, role }`. Host must sanitize.
    */
   renderTextContent?: AIRenderTextContent;
+  /** Optional per-message footer rendered below each bubble (e.g. actions). */
+  renderMessageFooter?: (message: AIMessage) => React.ReactNode;
   /** Additional class name */
   className?: string;
 }
@@ -317,6 +319,7 @@ export function AIChat({
   onClear,
   onClose,
   renderTextContent,
+  renderMessageFooter,
 }: AIChatProps) {
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
@@ -440,6 +443,7 @@ export function AIChat({
                 showTimestamp={showTimestamps}
                 onLinkClick={handleLinkClick}
                 renderTextContent={renderTextContent}
+                renderMessageFooter={renderMessageFooter}
               />
             ))}
             <div ref={messagesEndRef} />

--- a/src/components/AI/AIMessage.tsx
+++ b/src/components/AI/AIMessage.tsx
@@ -497,6 +497,12 @@ export interface AIMessageDisplayProps {
    * text block with `{ messageId, streaming, role }`. Host must sanitize.
    */
   renderTextContent?: AIRenderTextContent;
+  /**
+   * Optional renderer for a per-message footer shown below the bubble (e.g.
+   * message action controls). Aligned with the message (right for user, left
+   * for assistant).
+   */
+  renderMessageFooter?: (message: AIMessage) => React.ReactNode;
   /** Additional class name */
   className?: string;
 }
@@ -511,6 +517,7 @@ export function AIMessageDisplay({
   showTimestamp = false,
   onLinkClick,
   renderTextContent,
+  renderMessageFooter,
   className,
 }: AIMessageDisplayProps) {
   const isStreaming = message.status === 'streaming';
@@ -589,6 +596,10 @@ export function AIMessageDisplay({
             </div>
           ) : null}
         </ChatBubble>
+
+        {renderMessageFooter && (
+          <div data-slot="ai-message-footer">{renderMessageFooter(message)}</div>
+        )}
 
         {showTimestamp && (
           <span

--- a/src/components/AI/AIMessage.tsx
+++ b/src/components/AI/AIMessage.tsx
@@ -10,6 +10,7 @@ import { cn } from '../../utils/cn';
 import type {
   AIMessage,
   AIMessageContent,
+  AIRenderMessageFooter,
   AIRenderTextContent,
   MCPResourceLink,
 } from './types';
@@ -502,7 +503,7 @@ export interface AIMessageDisplayProps {
    * message action controls). Aligned with the message (right for user, left
    * for assistant).
    */
-  renderMessageFooter?: (message: AIMessage) => React.ReactNode;
+  renderMessageFooter?: AIRenderMessageFooter;
   /** Additional class name */
   className?: string;
 }
@@ -522,6 +523,7 @@ export function AIMessageDisplay({
 }: AIMessageDisplayProps) {
   const isStreaming = message.status === 'streaming';
   const hasContent = message.content.length > 0;
+  const messageFooter = renderMessageFooter?.(message);
 
   const formatTime = (timestamp: Date | string) => {
     const date = new Date(timestamp);
@@ -597,8 +599,10 @@ export function AIMessageDisplay({
           ) : null}
         </ChatBubble>
 
-        {renderMessageFooter && (
-          <div data-slot="ai-message-footer">{renderMessageFooter(message)}</div>
+        {messageFooter != null && messageFooter !== false && (
+          <div data-slot="ai-message-footer" className="w-fit max-w-[85%]">
+            {messageFooter}
+          </div>
         )}
 
         {showTimestamp && (

--- a/src/components/AI/types.ts
+++ b/src/components/AI/types.ts
@@ -216,6 +216,9 @@ export type AIRenderTextContent = (
   ctx: AITextRenderContext
 ) => React.ReactNode;
 
+/** Render-prop for appending custom content below a message bubble. */
+export type AIRenderMessageFooter = (message: AIMessage) => React.ReactNode;
+
 // ============================================================================
 // AI Chat Types
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds an optional `renderMessageFooter` render prop to `AIChat` and `AIMessageDisplay`. It renders **below the chat bubble** and is aligned with the message (right for user, left for assistant), matching the ChatGPT-style message action bar.

This lets host apps attach per-message controls (edit, version/branch navigation, copy, etc.) **without forking the component** — the same host-owned extension philosophy as the existing `renderTextContent` seam.

## Motivation

Consumers (e.g. Ozwell) need per-message action controls that live *outside* the bubble. Previously the only extension point was `renderTextContent`, which renders content blocks *inside* the bubble — so actions ended up visually inside the message. A dedicated footer slot keeps the business logic in the host while the library owns layout/alignment.

## Changes

- `AIMessageDisplay`: new optional prop `renderMessageFooter?: (message: AIMessage) => React.ReactNode`, rendered in the message column right after the `ChatBubble` (before the timestamp). Exposed via `data-slot="ai-message-footer"`.
- `AIChat`: threads the same prop through to `AIMessageDisplay`.

```tsx
<AIChat
  messages={messages}
  renderMessageFooter={(m) => <MessageActions message={m} />}
/>
```

## Notes

- **Backward compatible** — the prop is optional; when omitted nothing renders and existing behavior is unchanged.
- Presentational only; no new dependencies. Host owns whatever the footer renders (and its sanitization).

15 insertions across 2 files.