### PR TITLE
fix(icons): export Icons module from package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,18 @@ export {
 } from './components/WebChartReportViewer';
 export * from './components/WebsiteInput';
 
+// Icons (lucide-react re-exports)
+// Note: CloseIcon, RefreshIcon, SendIcon, and SparklesIcon are ambiguous with
+// the AI module's custom icons; the explicit AI exports below take precedence
+// so existing consumers keep the same components.
+export * from './components/Icons';
+export {
+  CloseIcon,
+  RefreshIcon,
+  SendIcon,
+  SparklesIcon,
+} from './components/AI';
+
 // Hooks
 export * from './hooks';
 


### PR DESCRIPTION
## Problem

A dev reported "icons not exported out". The Icons module (src/components/Icons/index.ts, ~200 lucide-react icon re-exports) documents `import { HomeIcon } from '@mieweb/ui'` as the intended usage — but it was never exported from `src/index.ts`, so none of the icons were available from the package root.

## Fix

Single-file change to `src/index.ts`:

- `export * from './components/Icons'`
- Explicit re-exports of `CloseIcon`, `RefreshIcon`, `SendIcon`, `SparklesIcon` from the AI module. These four names exist in both modules; without the explicit exports the two star-exports would be ambiguous and get silently dropped, breaking existing AI icon consumers. Explicit exports take precedence, preserving current behavior.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅