### PR TITLE
feat(BusinessHoursEditor): add rules variant with multi-day time rules

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,39 +1,6 @@
-<style>
-  /* Fix boolean toggle control text visibility in dark mode */
-  /* Storybook boolean controls have dark background in dark mode that hides text */
-  
-  /* Target boolean toggle labels - give them a visible light background in dark mode */
-  @media (prefers-color-scheme: dark) {
-    /* The toggle switch background */
-    label[for^="control-"] {
-      background-color: #52525b !important;
-    }
-    
-    /* The "False" span (left side) */
-    label[for^="control-"] > span:first-of-type {
-      color: #e4e4e7 !important;
-      background-color: #71717a !important;
-    }
-    
-    /* The "True" span (right side) */
-    label[for^="control-"] > span:last-of-type {
-      color: #a1a1aa !important;
-    }
-    
-    /* When checked/active state - "True" is active */
-    label[for^="control-"] input:checked ~ span:last-of-type {
-      color: #e4e4e7 !important;
-      background-color: #71717a !important;
-    }
-    
-    label[for^="control-"] input:checked ~ span:first-of-type {
-      background-color: transparent !important;
-      color: #a1a1aa !important;
-    }
-    
-    /* Make checkbox input transparent */
-    label[for^="control-"] input[type="checkbox"] {
-      background: transparent !important;
-    }
-  }
-</style>
+<!--
+  Dark-mode styling for controls (boolean toggles etc.) is handled by the
+  dynamic theme CSS injected in manager.ts (injectBrandCSS), which keys off
+  the Storybook theme global. Do not add prefers-color-scheme overrides here:
+  they follow the OS theme and clash with the in-app light/dark toggle.
+-->

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -206,6 +206,13 @@ function injectBrandCSS(brandKey: BrandKey, isDark = false) {
   style.id = styleId;
   style.textContent = `
     /* Dynamic brand theming for Storybook manager */
+    /* Keep native form controls (radios, checkboxes) in sync with the app
+       theme instead of the OS theme. Storybook's app root sets
+       "color-scheme: light dark" on #root > div, so override there too. */
+    :root, #root, #root > div {
+      color-scheme: ${isDark ? 'dark' : 'light'};
+    }
+
     :root {
       --mieweb-manager-primary: ${brand.primary};
       --mieweb-manager-secondary: ${brand.secondary};
@@ -362,8 +369,9 @@ function injectBrandCSS(brandKey: BrandKey, isDark = false) {
       color: ${textMuted} !important;
     }
     
-    /* Input fields */
-    input, select, textarea {
+    /* Input fields (skip radios/checkboxes: painting native pickers breaks
+       their rendering) */
+    input:not([type="radio"]):not([type="checkbox"]), select, textarea {
       background-color: ${inputBg} !important;
       border-color: ${inputBorder} !important;
       color: ${textColor} !important;
@@ -377,37 +385,39 @@ function injectBrandCSS(brandKey: BrandKey, isDark = false) {
     
     /* ============================================
        BOOLEAN TOGGLE CONTROL FIX
-       The toggle has dark bg that hides text
+       The toggle has dark bg that hides text.
+       :has(input[role="switch"]) scopes this to boolean toggles only —
+       radio controls share the label[for^="control-"] pattern.
        ============================================ */
     /* Toggle switch background */
-    label[for^="control-"] {
+    label[for^="control-"]:has(input[role="switch"]) {
       background-color: #52525b !important;
     }
     
     /* "False" span (left side, selected by default) */
-    label[for^="control-"] > span:first-of-type {
+    label[for^="control-"]:has(input[role="switch"]) > span:first-of-type {
       color: #e4e4e7 !important;
       background-color: #71717a !important;
     }
     
     /* "True" span (right side, unselected by default) */
-    label[for^="control-"] > span:last-of-type {
+    label[for^="control-"]:has(input[role="switch"]) > span:last-of-type {
       color: #a1a1aa !important;
     }
     
     /* When checked: "True" becomes active */
-    label[for^="control-"] input:checked ~ span:last-of-type {
+    label[for^="control-"]:has(input[role="switch"]) input:checked ~ span:last-of-type {
       color: #e4e4e7 !important;
       background-color: #71717a !important;
     }
     
-    label[for^="control-"] input:checked ~ span:first-of-type {
+    label[for^="control-"]:has(input[role="switch"]) input:checked ~ span:first-of-type {
       background-color: transparent !important;
       color: #a1a1aa !important;
     }
     
     /* Make checkbox input transparent so it doesn't cover text */
-    label[for^="control-"] input[type="checkbox"] {
+    label[for^="control-"]:has(input[role="switch"]) input[type="checkbox"] {
       background: transparent !important;
     }
     ` : ''}

--- a/src/components/BusinessHours/BusinessHours.stories.tsx
+++ b/src/components/BusinessHours/BusinessHours.stories.tsx
@@ -125,6 +125,34 @@ export const SplitShifts: Story = {
   },
 };
 
+// Days sharing identical hours collapse into one row
+export const GroupedDays: Story = {
+  args: {
+    schedule: {
+      officeHours: [
+        { day: 0, hours: [] },
+        { day: 1, hours: [{ start: '08:00', end: '11:00' }] },
+        { day: 2, hours: [{ start: '15:00', end: '17:00' }] },
+        { day: 3, hours: [{ start: '08:00', end: '11:00' }] },
+        { day: 4, hours: [{ start: '15:00', end: '17:00' }] },
+        { day: 5, hours: [{ start: '08:00', end: '11:00' }] },
+        { day: 6, hours: [{ start: '10:00', end: '16:00' }] },
+      ],
+    },
+    groupDays: true,
+    useShortDayNames: true,
+    showStatus: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `groupDays`, days sharing identical hours collapse into one row — e.g. "Mon, Wed, Fri · 8:00 AM - 11:00 AM". Closed days group into a final row.',
+      },
+    },
+  },
+};
+
 // Text-only when structured hours unavailable
 export const TextOnly: Story = {
   args: {

--- a/src/components/BusinessHours/BusinessHours.tsx
+++ b/src/components/BusinessHours/BusinessHours.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../utils/cn';
+import { scheduleToRules } from '../BusinessHoursEditor/BusinessHoursEditor';
 
 // ============================================================================
 // Types
@@ -436,6 +437,77 @@ function DayScheduleRow({
 }
 
 // ============================================================================
+// Grouped Rows (days sharing identical hours collapse into one row)
+// ============================================================================
+
+interface GroupedScheduleRowsProps {
+  officeHours: DayHours[];
+  useShortDayNames?: boolean;
+  use24Hour?: boolean;
+}
+
+function GroupedScheduleRows({
+  officeHours,
+  useShortDayNames = false,
+  use24Hour = false,
+}: GroupedScheduleRowsProps) {
+  const normalized = officeHours.map((dayHours) => ({
+    day: parseDayToNumber(dayHours.day),
+    hours: (dayHours.hours ?? []).map((range) => ({
+      start: range.start ?? '',
+      end: range.end ?? '',
+      ...(range.description ? { description: range.description } : {}),
+    })),
+  }));
+
+  const rules = scheduleToRules(normalized);
+  const closedDays = normalized
+    .filter((dayHours) => dayHours.hours.length === 0)
+    .map((dayHours) => dayHours.day);
+  const dayNames = useShortDayNames ? DAY_NAMES_SHORT : DAY_NAMES;
+  const formatDays = (days: number[]) =>
+    days.map((day) => dayNames[day]).join(', ');
+
+  return (
+    <>
+      {rules.map((rule) => (
+        <div
+          key={rule.id}
+          data-slot="business-hours-grouped-row"
+          className={cn(dayRowVariants({ isToday: false }))}
+        >
+          <span
+            data-slot="business-hours-day-name"
+            className="min-w-[80px] font-medium"
+          >
+            {formatDays(rule.days)}
+          </span>
+          <div data-slot="business-hours-day-hours" className="text-end">
+            <TimeRangeDisplay range={rule} use24Hour={use24Hour} />
+          </div>
+        </div>
+      ))}
+      {closedDays.length > 0 && (
+        <div
+          data-slot="business-hours-grouped-row"
+          className={cn(dayRowVariants({ isToday: false }))}
+        >
+          <span
+            data-slot="business-hours-day-name"
+            className="min-w-[80px] font-medium"
+          >
+            {formatDays(closedDays)}
+          </span>
+          <div data-slot="business-hours-day-hours" className="text-end">
+            <span className="text-muted-foreground">Closed</span>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ============================================================================
 // Main BusinessHours Component
 // ============================================================================
 
@@ -452,6 +524,8 @@ export interface BusinessHoursProps extends VariantProps<
   useShortDayNames?: boolean;
   /** Use 24-hour time format */
   use24Hour?: boolean;
+  /** Group days sharing identical hours into one row (e.g. "Mon, Wed, Fri · 8:00 AM - 11:00 AM") */
+  groupDays?: boolean;
   /** Show header with icon */
   showHeader?: boolean;
   /** Custom header text */
@@ -468,6 +542,7 @@ export function BusinessHours({
   highlightToday = true,
   useShortDayNames = false,
   use24Hour = false,
+  groupDays = false,
   showHeader = true,
   headerText = 'Hours',
   className,
@@ -580,16 +655,24 @@ export function BusinessHours({
           data-slot="business-hours-schedule"
           className="space-y-1 divide-y divide-neutral-100 dark:divide-neutral-800"
         >
-          {schedule.officeHours.map((dayHours, idx) => (
-            <DayScheduleRow
-              key={idx}
-              dayHours={dayHours}
-              isToday={parseDayToNumber(dayHours.day) === currentDay}
-              highlightToday={highlightToday}
+          {groupDays ? (
+            <GroupedScheduleRows
+              officeHours={schedule.officeHours}
               useShortDayNames={useShortDayNames}
               use24Hour={use24Hour}
             />
-          ))}
+          ) : (
+            schedule.officeHours.map((dayHours, idx) => (
+              <DayScheduleRow
+                key={idx}
+                dayHours={dayHours}
+                isToday={parseDayToNumber(dayHours.day) === currentDay}
+                highlightToday={highlightToday}
+                useShortDayNames={useShortDayNames}
+                use24Hour={use24Hour}
+              />
+            ))
+          )}
         </div>
 
         {schedule.timezone && (

--- a/src/components/BusinessHours/BusinessHours.tsx
+++ b/src/components/BusinessHours/BusinessHours.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../utils/cn';
-import { scheduleToRules } from '../BusinessHoursEditor/BusinessHoursEditor';
+import { scheduleToRules } from '../BusinessHoursEditor/scheduleRules';
 
 // ============================================================================
 // Types

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
@@ -348,8 +348,12 @@ const patientAvailability: DaySchedule[] = [
 function RulesVariantWrapper({
   value: initialValue,
   onChange: _,
+  groupPreview = true,
   ...restProps
-}: Partial<React.ComponentProps<typeof BusinessHoursEditor>>) {
+}: Partial<React.ComponentProps<typeof BusinessHoursEditor>> & {
+  /** Toggle the preview between grouped rows and a per-day list */
+  groupPreview?: boolean;
+}) {
   const [schedule, setSchedule] = useState<DaySchedule[]>(initialValue || []);
 
   return (
@@ -365,24 +369,37 @@ function RulesVariantWrapper({
         schedule={{ officeHours: schedule }}
         headerText="Availability Preview"
         showStatus={false}
+        groupDays={groupPreview}
+        useShortDayNames={groupPreview}
       />
     </div>
   );
 }
 
+const rulesStoryArgTypes = {
+  variant: { table: { disable: true } },
+  groupPreview: {
+    control: 'boolean',
+    description:
+      'Switch the Availability Preview between grouped rows (e.g. "Mon, Wed, Fri · 8:00 AM - 11:00 AM") and a per-day list',
+  },
+} as const;
+
 export const RulesVariant: Story = {
   render: (args) => <RulesVariantWrapper {...args} />,
+  argTypes: rulesStoryArgTypes,
   args: {
-    variant: 'rules',
     value: patientAvailability,
     showDescription: false,
     addHoursLabel: 'Add availability',
+    // @ts-expect-error story-only control for the preview display
+    groupPreview: true,
   },
   parameters: {
     docs: {
       description: {
         story:
-          'The rules variant groups days that share the same hours into one row — ideal for capturing patient availability like "Mon/Wed/Fri 8–11am, Tue/Thu 3–5pm, Sat 10am–4pm". It reads and emits the same DaySchedule[] as the default variant, previewed here with the BusinessHours display component.',
+          'The rules variant groups days that share the same hours into one row — ideal for capturing patient availability like "Mon/Wed/Fri 8–11am, Tue/Thu 3–5pm, Sat 10am–4pm". It reads and emits the same DaySchedule[] as the default variant, previewed here with the BusinessHours display component. Use the groupPreview control to switch the preview between grouped and per-day views.',
       },
     },
   },
@@ -390,10 +407,13 @@ export const RulesVariant: Story = {
 
 export const RulesVariantEmpty: Story = {
   render: (args) => <RulesVariantWrapper {...args} />,
+  argTypes: rulesStoryArgTypes,
   args: {
-    variant: 'rules',
     value: [],
     showDescription: false,
     addHoursLabel: 'Add availability',
+    use24Hour: true,
+    // @ts-expect-error story-only control for the preview display
+    groupPreview: true,
   },
 };

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
@@ -7,6 +7,7 @@ import {
   create24HourSchedule,
   createWeekdaySchedule,
 } from './BusinessHoursEditor';
+import { BusinessHours } from '../BusinessHours';
 
 const meta: Meta<typeof BusinessHoursEditor> = {
   title: 'Components/Forms & Inputs/BusinessHoursEditor',
@@ -29,6 +30,12 @@ const meta: Meta<typeof BusinessHoursEditor> = {
     // use24Hour is not implemented in the component (native time inputs use browser locale)
     use24Hour: { table: { disable: true } },
 
+    variant: {
+      control: 'radio',
+      options: ['days', 'rules'],
+      description:
+        "Editing layout: per-day sections or grouped day/time rules ('rules')",
+    },
     disabled: {
       control: 'boolean',
       description: 'Whether the editor is disabled',
@@ -314,5 +321,74 @@ export const Mobile: Story = {
     viewport: {
       defaultViewport: 'mobile1',
     },
+  },
+};
+
+// ============================================================================
+// Rules Variant
+// ============================================================================
+
+/** Patient availability: M/W/F 8–11am, Tu/Th 3–5pm, Sat 10am–4pm, Sun unavailable */
+const patientAvailability: DaySchedule[] = [
+  { day: 0, hours: [] },
+  { day: 1, hours: [{ id: '1', start: '08:00', end: '11:00' }] },
+  { day: 2, hours: [{ id: '2', start: '15:00', end: '17:00' }] },
+  { day: 3, hours: [{ id: '3', start: '08:00', end: '11:00' }] },
+  { day: 4, hours: [{ id: '4', start: '15:00', end: '17:00' }] },
+  { day: 5, hours: [{ id: '5', start: '08:00', end: '11:00' }] },
+  { day: 6, hours: [{ id: '6', start: '10:00', end: '16:00' }] },
+];
+
+// Interactive wrapper with a live read-only BusinessHours preview
+function RulesVariantWrapper({
+  value: initialValue,
+  onChange: _,
+  ...restProps
+}: Partial<React.ComponentProps<typeof BusinessHoursEditor>>) {
+  const [schedule, setSchedule] = useState<DaySchedule[]>(initialValue || []);
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <BusinessHoursEditor
+        {...restProps}
+        variant="rules"
+        value={schedule}
+        onChange={setSchedule}
+      />
+
+      <BusinessHours
+        schedule={{ officeHours: schedule }}
+        headerText="Availability Preview"
+        showStatus={false}
+      />
+    </div>
+  );
+}
+
+export const RulesVariant: Story = {
+  render: (args) => <RulesVariantWrapper {...args} />,
+  args: {
+    variant: 'rules',
+    value: patientAvailability,
+    showDescription: false,
+    addHoursLabel: 'Add availability',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The rules variant groups days that share the same hours into one row — ideal for capturing patient availability like "Mon/Wed/Fri 8–11am, Tue/Thu 3–5pm, Sat 10am–4pm". It reads and emits the same DaySchedule[] as the default variant, previewed here with the BusinessHours display component.',
+      },
+    },
+  },
+};
+
+export const RulesVariantEmpty: Story = {
+  render: (args) => <RulesVariantWrapper {...args} />,
+  args: {
+    variant: 'rules',
+    value: [],
+    showDescription: false,
+    addHoursLabel: 'Add availability',
   },
 };

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.stories.tsx
@@ -27,8 +27,13 @@ const meta: Meta<typeof BusinessHoursEditor> = {
     value: { table: { disable: true } },
     onChange: { table: { disable: true } },
     className: { table: { disable: true } },
-    // use24Hour is not implemented in the component (native time inputs use browser locale)
-    use24Hour: { table: { disable: true } },
+    // use24Hour only affects the rules variant; the days variant uses native
+    // time inputs (browser locale)
+    use24Hour: {
+      control: 'boolean',
+      description:
+        "Use 24-hour time display in the rules variant's time pickers",
+    },
 
     variant: {
       control: 'radio',

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.test.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import {
+  BusinessHoursEditor,
+  scheduleToRules,
+  rulesToSchedule,
+  type DaySchedule,
+} from './BusinessHoursEditor';
+
+/** M/W/F 8–11, Tu/Th 15–17, Sat 10–16, Sun unavailable */
+const patientAvailability: DaySchedule[] = [
+  { day: 0, hours: [] },
+  { day: 1, hours: [{ id: '1', start: '08:00', end: '11:00' }] },
+  { day: 2, hours: [{ id: '2', start: '15:00', end: '17:00' }] },
+  { day: 3, hours: [{ id: '3', start: '08:00', end: '11:00' }] },
+  { day: 4, hours: [{ id: '4', start: '15:00', end: '17:00' }] },
+  { day: 5, hours: [{ id: '5', start: '08:00', end: '11:00' }] },
+  { day: 6, hours: [{ id: '6', start: '10:00', end: '16:00' }] },
+];
+
+function slotsOf(schedule: DaySchedule[], day: number) {
+  return (schedule.find((d) => d.day === day)?.hours ?? []).map((slot) => ({
+    start: slot.start,
+    end: slot.end,
+  }));
+}
+
+describe('scheduleToRules / rulesToSchedule', () => {
+  it('groups days with identical hours into one rule', () => {
+    const rules = scheduleToRules(patientAvailability);
+
+    expect(rules).toHaveLength(3);
+    expect(rules[0]).toMatchObject({
+      days: [1, 3, 5],
+      start: '08:00',
+      end: '11:00',
+    });
+    expect(rules[1]).toMatchObject({
+      days: [2, 4],
+      start: '15:00',
+      end: '17:00',
+    });
+    expect(rules[2]).toMatchObject({ days: [6], start: '10:00', end: '16:00' });
+  });
+
+  it('round-trips back to an equivalent schedule', () => {
+    const schedule = rulesToSchedule(scheduleToRules(patientAvailability));
+
+    for (let day = 0; day < 7; day++) {
+      expect(slotsOf(schedule, day)).toEqual(slotsOf(patientAvailability, day));
+    }
+  });
+
+  it('keeps days with different descriptions in separate rules', () => {
+    const rules = scheduleToRules([
+      { day: 1, hours: [{ start: '08:00', end: '11:00', description: 'AM' }] },
+      { day: 2, hours: [{ start: '08:00', end: '11:00' }] },
+    ]);
+
+    expect(rules).toHaveLength(2);
+  });
+});
+
+describe('BusinessHoursEditor variant="rules"', () => {
+  it('renders one row per rule with day toggles pressed', () => {
+    renderWithTheme(
+      <BusinessHoursEditor
+        variant="rules"
+        value={patientAvailability}
+        onChange={vi.fn()}
+      />
+    );
+
+    const groups = screen.getAllByRole('group');
+    expect(groups).toHaveLength(3);
+
+    // First rule: Mon, Wed, Fri pressed
+    const monday = screen.getAllByRole('button', { name: 'Monday' })[0];
+    const sunday = screen.getAllByRole('button', { name: 'Sunday' })[0];
+    expect(monday).toHaveAttribute('aria-pressed', 'true');
+    expect(sunday).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('toggling a day emits the expanded schedule', () => {
+    const onChange = vi.fn();
+    renderWithTheme(
+      <BusinessHoursEditor
+        variant="rules"
+        value={patientAvailability}
+        onChange={onChange}
+      />
+    );
+
+    // Add Sunday to the Sat 10:00–16:00 rule (third rule row)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Sunday' })[2]);
+
+    const emitted = onChange.mock.calls[0][0] as DaySchedule[];
+    expect(slotsOf(emitted, 0)).toEqual([{ start: '10:00', end: '16:00' }]);
+    // Existing days untouched
+    expect(slotsOf(emitted, 1)).toEqual([{ start: '08:00', end: '11:00' }]);
+  });
+
+  it('changing a time applies to every day in the rule', () => {
+    const onChange = vi.fn();
+    renderWithTheme(
+      <BusinessHoursEditor
+        variant="rules"
+        value={patientAvailability}
+        onChange={onChange}
+      />
+    );
+
+    // Open the time picker for the first rule's start time (08:00 AM)
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Open time picker' })[0]
+    );
+    fireEvent.change(screen.getByLabelText('Select hour'), {
+      target: { value: '09' },
+    });
+
+    const emitted = onChange.mock.calls[0][0] as DaySchedule[];
+    for (const day of [1, 3, 5]) {
+      expect(slotsOf(emitted, day)).toEqual([{ start: '09:00', end: '11:00' }]);
+    }
+  });
+
+  it('removing a rule clears its days', () => {
+    const onChange = vi.fn();
+    renderWithTheme(
+      <BusinessHoursEditor
+        variant="rules"
+        value={patientAvailability}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Remove availability rule' })[2]
+    );
+
+    const emitted = onChange.mock.calls[0][0] as DaySchedule[];
+    expect(slotsOf(emitted, 6)).toEqual([]);
+    expect(slotsOf(emitted, 1)).toEqual([{ start: '08:00', end: '11:00' }]);
+  });
+
+  it('adds a draft rule without emitting until a day is selected', () => {
+    const onChange = vi.fn();
+    renderWithTheme(
+      <BusinessHoursEditor variant="rules" value={[]} onChange={onChange} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add hours/i }));
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tuesday' }));
+    const emitted = onChange.mock.calls[0][0] as DaySchedule[];
+    expect(slotsOf(emitted, 2)).toEqual([{ start: '09:00', end: '17:00' }]);
+  });
+
+  it('supports a day appearing in multiple rules', () => {
+    const twoRanges: DaySchedule[] = [
+      {
+        day: 1,
+        hours: [
+          { start: '08:00', end: '11:00' },
+          { start: '15:00', end: '17:00' },
+        ],
+      },
+    ];
+
+    renderWithTheme(
+      <BusinessHoursEditor
+        variant="rules"
+        value={twoRanges}
+        onChange={vi.fn()}
+      />
+    );
+
+    const mondayToggles = screen.getAllByRole('button', { name: 'Monday' });
+    expect(mondayToggles).toHaveLength(2);
+    expect(mondayToggles[0]).toHaveAttribute('aria-pressed', 'true');
+    expect(mondayToggles[1]).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.test.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.test.tsx
@@ -52,6 +52,28 @@ describe('scheduleToRules / rulesToSchedule', () => {
     }
   });
 
+  it('preserves duplicate identical slots on the same day', () => {
+    const withDuplicates: DaySchedule[] = [
+      {
+        day: 1,
+        hours: [
+          { start: '08:00', end: '11:00' },
+          { start: '08:00', end: '11:00' },
+        ],
+      },
+      { day: 3, hours: [{ start: '08:00', end: '11:00' }] },
+    ];
+
+    const rules = scheduleToRules(withDuplicates);
+    expect(rules).toHaveLength(2);
+    expect(rules[0]).toMatchObject({ days: [1, 3], start: '08:00' });
+    expect(rules[1]).toMatchObject({ days: [1], start: '08:00' });
+
+    const schedule = rulesToSchedule(rules);
+    expect(slotsOf(schedule, 1)).toHaveLength(2);
+    expect(slotsOf(schedule, 3)).toHaveLength(1);
+  });
+
   it('keeps days with different descriptions in separate rules', () => {
     const rules = scheduleToRules([
       { day: 1, hours: [{ start: '08:00', end: '11:00', description: 'AM' }] },

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
@@ -7,22 +7,20 @@ import { Input } from '../Input/Input';
 import { DateInput } from '../DateInput';
 import { Dropdown, DropdownItem } from '../Dropdown';
 import { cn } from '../../utils/cn';
+import {
+  generateId,
+  rulesToSchedule,
+  scheduleToRules,
+  type DaySchedule,
+  type HoursRule,
+} from './scheduleRules';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface TimeSlot {
-  id?: string;
-  start: string;
-  end: string;
-  description?: string;
-}
-
-export interface DaySchedule {
-  day: number; // 0-6 (Sunday to Saturday)
-  hours: TimeSlot[];
-}
+export type { DaySchedule, TimeSlot } from './scheduleRules';
+export { rulesToSchedule, scheduleToRules } from './scheduleRules';
 
 export interface BusinessHoursEditorProps {
   /** Current schedule data */
@@ -69,10 +67,6 @@ const DAY_NAMES_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 // ============================================================================
 // Utilities
 // ============================================================================
-
-function generateId(): string {
-  return Math.random().toString(36).substring(2, 9);
-}
 
 function getOrderedDays(weekStartsOn: 0 | 1): number[] {
   if (weekStartsOn === 1) {
@@ -403,64 +397,6 @@ function BusinessHoursDaysEditor({
 // ============================================================================
 // Rules Variant
 // ============================================================================
-
-interface HoursRule {
-  id: string;
-  days: number[];
-  start: string;
-  end: string;
-  description?: string;
-}
-
-function ruleSignature(slot: TimeSlot): string {
-  return `${slot.start}\u0000${slot.end}\u0000${slot.description ?? ''}`;
-}
-
-/** Collapse a schedule into rules: days sharing an identical time range group into one row. */
-export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
-  const rulesBySignature = new Map<string, HoursRule[]>();
-  const orderedRules: HoursRule[] = [];
-
-  for (const day of schedule) {
-    for (const slot of day.hours) {
-      const signature = ruleSignature(slot);
-      const candidates = rulesBySignature.get(signature) ?? [];
-      // Duplicate identical slots on the same day each get their own rule so
-      // the schedule round-trips without dropping slots.
-      let rule = candidates.find((r) => !r.days.includes(day.day));
-      if (!rule) {
-        rule = {
-          id: generateId(),
-          days: [],
-          start: slot.start,
-          end: slot.end,
-          description: slot.description,
-        };
-        candidates.push(rule);
-        rulesBySignature.set(signature, candidates);
-        orderedRules.push(rule);
-      }
-      rule.days.push(day.day);
-    }
-  }
-
-  return orderedRules;
-}
-
-/** Expand rules into the canonical DaySchedule[] shape (all 7 days present). */
-export function rulesToSchedule(rules: HoursRule[]): DaySchedule[] {
-  return Array.from({ length: 7 }, (_, day) => ({
-    day,
-    hours: rules
-      .filter((rule) => rule.days.includes(day))
-      .map((rule) => ({
-        id: generateId(),
-        start: rule.start,
-        end: rule.end,
-        ...(rule.description ? { description: rule.description } : {}),
-      })),
-  }));
-}
 
 /** Normalized, id-free representation used to detect external value changes. */
 function normalizeSchedule(schedule: DaySchedule[]): string {

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
@@ -418,27 +418,33 @@ function ruleSignature(slot: TimeSlot): string {
 
 /** Collapse a schedule into rules: days sharing an identical time range group into one row. */
 export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
-  const rules = new Map<string, HoursRule>();
+  const rulesBySignature = new Map<string, HoursRule[]>();
+  const orderedRules: HoursRule[] = [];
 
   for (const day of schedule) {
     for (const slot of day.hours) {
       const signature = ruleSignature(slot);
-      const existing = rules.get(signature);
-      if (existing) {
-        if (!existing.days.includes(day.day)) existing.days.push(day.day);
-      } else {
-        rules.set(signature, {
+      const candidates = rulesBySignature.get(signature) ?? [];
+      // Duplicate identical slots on the same day each get their own rule so
+      // the schedule round-trips without dropping slots.
+      let rule = candidates.find((r) => !r.days.includes(day.day));
+      if (!rule) {
+        rule = {
           id: generateId(),
-          days: [day.day],
+          days: [],
           start: slot.start,
           end: slot.end,
           description: slot.description,
-        });
+        };
+        candidates.push(rule);
+        rulesBySignature.set(signature, candidates);
+        orderedRules.push(rule);
       }
+      rule.days.push(day.day);
     }
   }
 
-  return Array.from(rules.values());
+  return orderedRules;
 }
 
 /** Expand rules into the canonical DaySchedule[] shape (all 7 days present). */
@@ -587,7 +593,7 @@ function BusinessHoursRulesEditor({
                     'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
                     'disabled:cursor-not-allowed disabled:opacity-50',
                     selected
-                      ? 'border-primary bg-primary text-primary-foreground'
+                      ? 'border-primary-800 bg-primary-800 text-white'
                       : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
                   )}
                 >
@@ -673,7 +679,7 @@ function BusinessHoursRulesEditor({
         disabled={disabled}
         className="text-xs"
       >
-        <PlusIcon className="mr-1 h-3 w-3" />
+        <PlusIcon className="me-1 h-3 w-3" />
         {addHoursLabel}
       </Button>
     </div>

--- a/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
+++ b/src/components/BusinessHoursEditor/BusinessHoursEditor.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
+import { DateInput } from '../DateInput';
 import { Dropdown, DropdownItem } from '../Dropdown';
 import { cn } from '../../utils/cn';
 
@@ -28,6 +29,13 @@ export interface BusinessHoursEditorProps {
   value: DaySchedule[];
   /** Callback when schedule changes */
   onChange: (schedule: DaySchedule[]) => void;
+  /**
+   * Editing layout:
+   * - 'days' (default): one section per weekday, add hours per day
+   * - 'rules': compact rows where one time range applies to multiple days
+   *   (e.g. Mon/Wed/Fri 8:00–11:00). Emits the same DaySchedule[] shape.
+   */
+  variant?: 'days' | 'rules';
   /** Whether the editor is disabled */
   disabled?: boolean;
   /** Whether to show description field for each time slot */
@@ -89,8 +97,24 @@ function ensureAllDays(schedule: DaySchedule[]): DaySchedule[] {
 /**
  * BusinessHoursEditor provides an editable interface for managing business hours.
  * Supports multiple time slots per day with optional descriptions.
+ *
+ * The 'rules' variant edits the same schedule as grouped rows — each row is a
+ * set of day toggles plus one time range — which is faster when several days
+ * share the same hours.
  */
 export function BusinessHoursEditor({
+  variant = 'days',
+  ...props
+}: BusinessHoursEditorProps) {
+  if (variant === 'rules') {
+    return <BusinessHoursRulesEditor {...props} />;
+  }
+  return <BusinessHoursDaysEditor {...props} />;
+}
+
+type BusinessHoursVariantProps = Omit<BusinessHoursEditorProps, 'variant'>;
+
+function BusinessHoursDaysEditor({
   value,
   onChange,
   disabled = false,
@@ -99,7 +123,7 @@ export function BusinessHoursEditor({
   weekStartsOn = 0,
   className,
   addHoursLabel = 'Add Hours',
-}: BusinessHoursEditorProps) {
+}: BusinessHoursVariantProps) {
   // Ensure all 7 days are present
   const schedule = ensureAllDays(value);
   const orderedDays = getOrderedDays(weekStartsOn);
@@ -372,6 +396,286 @@ export function BusinessHoursEditor({
           </div>
         );
       })}
+    </div>
+  );
+}
+
+// ============================================================================
+// Rules Variant
+// ============================================================================
+
+interface HoursRule {
+  id: string;
+  days: number[];
+  start: string;
+  end: string;
+  description?: string;
+}
+
+function ruleSignature(slot: TimeSlot): string {
+  return `${slot.start}\u0000${slot.end}\u0000${slot.description ?? ''}`;
+}
+
+/** Collapse a schedule into rules: days sharing an identical time range group into one row. */
+export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
+  const rules = new Map<string, HoursRule>();
+
+  for (const day of schedule) {
+    for (const slot of day.hours) {
+      const signature = ruleSignature(slot);
+      const existing = rules.get(signature);
+      if (existing) {
+        if (!existing.days.includes(day.day)) existing.days.push(day.day);
+      } else {
+        rules.set(signature, {
+          id: generateId(),
+          days: [day.day],
+          start: slot.start,
+          end: slot.end,
+          description: slot.description,
+        });
+      }
+    }
+  }
+
+  return Array.from(rules.values());
+}
+
+/** Expand rules into the canonical DaySchedule[] shape (all 7 days present). */
+export function rulesToSchedule(rules: HoursRule[]): DaySchedule[] {
+  return Array.from({ length: 7 }, (_, day) => ({
+    day,
+    hours: rules
+      .filter((rule) => rule.days.includes(day))
+      .map((rule) => ({
+        id: generateId(),
+        start: rule.start,
+        end: rule.end,
+        ...(rule.description ? { description: rule.description } : {}),
+      })),
+  }));
+}
+
+/** Normalized, id-free representation used to detect external value changes. */
+function normalizeSchedule(schedule: DaySchedule[]): string {
+  return JSON.stringify(
+    ensureAllDays(schedule).map((day) => ({
+      day: day.day,
+      hours: day.hours.map((slot) => ({
+        start: slot.start,
+        end: slot.end,
+        description: slot.description ?? '',
+      })),
+    }))
+  );
+}
+
+function BusinessHoursRulesEditor({
+  value,
+  onChange,
+  disabled = false,
+  showDescription = true,
+  use24Hour = false,
+  weekStartsOn = 0,
+  className,
+  addHoursLabel = 'Add Hours',
+}: BusinessHoursVariantProps) {
+  // Rules are internal state so draft rows (no days selected yet) survive, and
+  // rows keep their identity while editing. External value changes re-derive.
+  const [rules, setRules] = React.useState<HoursRule[]>(() =>
+    scheduleToRules(value)
+  );
+  const timeFormat = use24Hour ? '24-hour' : '12-hour';
+  const lastScheduleRef = React.useRef(normalizeSchedule(value));
+
+  React.useEffect(() => {
+    const incoming = normalizeSchedule(value);
+    if (incoming !== lastScheduleRef.current) {
+      lastScheduleRef.current = incoming;
+      setRules(scheduleToRules(value));
+    }
+  }, [value]);
+
+  const emit = useCallback(
+    (nextRules: HoursRule[]) => {
+      setRules(nextRules);
+      const schedule = rulesToSchedule(nextRules);
+      const normalized = normalizeSchedule(schedule);
+      if (normalized !== lastScheduleRef.current) {
+        lastScheduleRef.current = normalized;
+        onChange(schedule);
+      }
+    },
+    [onChange]
+  );
+
+  const handleAddRule = useCallback(() => {
+    emit([
+      ...rules,
+      { id: generateId(), days: [], start: '09:00', end: '17:00' },
+    ]);
+  }, [emit, rules]);
+
+  const handleRemoveRule = useCallback(
+    (ruleId: string) => {
+      emit(rules.filter((rule) => rule.id !== ruleId));
+    },
+    [emit, rules]
+  );
+
+  const handleToggleDay = useCallback(
+    (ruleId: string, day: number) => {
+      emit(
+        rules.map((rule) =>
+          rule.id === ruleId
+            ? {
+                ...rule,
+                days: rule.days.includes(day)
+                  ? rule.days.filter((d) => d !== day)
+                  : [...rule.days, day],
+              }
+            : rule
+        )
+      );
+    },
+    [emit, rules]
+  );
+
+  const handleRuleChange = useCallback(
+    (ruleId: string, field: 'start' | 'end' | 'description', value: string) => {
+      emit(
+        rules.map((rule) =>
+          rule.id === ruleId ? { ...rule, [field]: value } : rule
+        )
+      );
+    },
+    [emit, rules]
+  );
+
+  const orderedDays = getOrderedDays(weekStartsOn);
+
+  return (
+    <div
+      data-slot="business-hours-editor"
+      className={cn('business-hours-editor space-y-3', className)}
+    >
+      {rules.map((rule) => (
+        <fieldset
+          key={rule.id}
+          data-slot="business-hours-rule"
+          className="flex flex-wrap items-center gap-2 border-b border-gray-200 pb-3 last:border-0 dark:border-gray-700"
+        >
+          <legend className="sr-only">Availability rule</legend>
+
+          {/* Day toggles */}
+          <div
+            data-slot="business-hours-rule-days"
+            className="flex shrink-0 gap-1"
+          >
+            {orderedDays.map((day) => {
+              const selected = rule.days.includes(day);
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  aria-pressed={selected}
+                  aria-label={DAY_NAMES[day]}
+                  disabled={disabled}
+                  onClick={() => handleToggleDay(rule.id, day)}
+                  className={cn(
+                    'inline-flex h-7 w-9 items-center justify-center rounded-full border text-xs font-medium transition-colors',
+                    'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+                    'disabled:cursor-not-allowed disabled:opacity-50',
+                    selected
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+                  )}
+                >
+                  {DAY_NAMES_SHORT[day]}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Start Time */}
+          <div className="w-32 sm:w-36">
+            <DateInput
+              inputType="time"
+              timeFormat={timeFormat}
+              minuteStep={15}
+              value={rule.start}
+              onChange={(time) => handleRuleChange(rule.id, 'start', time)}
+              disabled={disabled}
+              size="sm"
+              className="text-sm"
+              label="Start time"
+              hideLabel
+            />
+          </div>
+
+          <span data-slot="business-hours-separator" className="text-gray-400">
+            –
+          </span>
+
+          {/* End Time */}
+          <div className="w-32 sm:w-36">
+            <DateInput
+              inputType="time"
+              timeFormat={timeFormat}
+              minuteStep={15}
+              value={rule.end}
+              onChange={(time) => handleRuleChange(rule.id, 'end', time)}
+              disabled={disabled}
+              size="sm"
+              className="text-sm"
+              label="End time"
+              hideLabel
+            />
+          </div>
+
+          {/* Description */}
+          {showDescription && (
+            <div className="min-w-[120px] flex-1">
+              <Input
+                type="text"
+                value={rule.description || ''}
+                onChange={(e) =>
+                  handleRuleChange(rule.id, 'description', e.target.value)
+                }
+                placeholder="Description (optional)"
+                disabled={disabled}
+                className="text-sm"
+                aria-label="Description"
+              />
+            </div>
+          )}
+
+          {/* Remove Button */}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleRemoveRule(rule.id)}
+            disabled={disabled}
+            className="text-red-500 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20"
+            aria-label="Remove availability rule"
+          >
+            <XIcon className="h-4 w-4" />
+          </Button>
+        </fieldset>
+      ))}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={handleAddRule}
+        disabled={disabled}
+        className="text-xs"
+      >
+        <PlusIcon className="mr-1 h-3 w-3" />
+        {addHoursLabel}
+      </Button>
     </div>
   );
 }

--- a/src/components/BusinessHoursEditor/scheduleRules.ts
+++ b/src/components/BusinessHoursEditor/scheduleRules.ts
@@ -32,7 +32,11 @@ function ruleSignature(slot: TimeSlot): string {
   return `${slot.start}\u0000${slot.end}\u0000${slot.description ?? ''}`;
 }
 
-/** Collapse a schedule into rules: days sharing an identical time range group into one row. */
+/**
+ * Collapse a schedule into rules: days sharing an identical time range group
+ * into one row. Rule ids are deterministic (derived from position) so results
+ * are stable across renders — safe as React keys and for SSR hydration.
+ */
 export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
   const rulesBySignature = new Map<string, HoursRule[]>();
   const orderedRules: HoursRule[] = [];
@@ -46,7 +50,7 @@ export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
       let rule = candidates.find((r) => !r.days.includes(day.day));
       if (!rule) {
         rule = {
-          id: generateId(),
+          id: `rule-${orderedRules.length}`,
           days: [],
           start: slot.start,
           end: slot.end,
@@ -63,14 +67,14 @@ export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
   return orderedRules;
 }
 
-/** Expand rules into the canonical DaySchedule[] shape (all 7 days present). */
+/** Expand rules into the canonical DaySchedule[] shape (all 7 days present). Slot ids are deterministic. */
 export function rulesToSchedule(rules: HoursRule[]): DaySchedule[] {
   return Array.from({ length: 7 }, (_, day) => ({
     day,
     hours: rules
       .filter((rule) => rule.days.includes(day))
-      .map((rule) => ({
-        id: generateId(),
+      .map((rule, index) => ({
+        id: `slot-${day}-${index}`,
         start: rule.start,
         end: rule.end,
         ...(rule.description ? { description: rule.description } : {}),

--- a/src/components/BusinessHoursEditor/scheduleRules.ts
+++ b/src/components/BusinessHoursEditor/scheduleRules.ts
@@ -1,0 +1,79 @@
+// ============================================================================
+// Pure schedule <-> rules logic shared by BusinessHoursEditor (rules variant)
+// and BusinessHours (groupDays display). Kept free of React/component imports
+// so display-only consumers don't pull in the editor bundle.
+// ============================================================================
+
+export interface TimeSlot {
+  id?: string;
+  start: string;
+  end: string;
+  description?: string;
+}
+
+export interface DaySchedule {
+  day: number; // 0-6 (Sunday to Saturday)
+  hours: TimeSlot[];
+}
+
+export interface HoursRule {
+  id: string;
+  days: number[];
+  start: string;
+  end: string;
+  description?: string;
+}
+
+export function generateId(): string {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+function ruleSignature(slot: TimeSlot): string {
+  return `${slot.start}\u0000${slot.end}\u0000${slot.description ?? ''}`;
+}
+
+/** Collapse a schedule into rules: days sharing an identical time range group into one row. */
+export function scheduleToRules(schedule: DaySchedule[]): HoursRule[] {
+  const rulesBySignature = new Map<string, HoursRule[]>();
+  const orderedRules: HoursRule[] = [];
+
+  for (const day of schedule) {
+    for (const slot of day.hours) {
+      const signature = ruleSignature(slot);
+      const candidates = rulesBySignature.get(signature) ?? [];
+      // Duplicate identical slots on the same day each get their own rule so
+      // the schedule round-trips without dropping slots.
+      let rule = candidates.find((r) => !r.days.includes(day.day));
+      if (!rule) {
+        rule = {
+          id: generateId(),
+          days: [],
+          start: slot.start,
+          end: slot.end,
+          description: slot.description,
+        };
+        candidates.push(rule);
+        rulesBySignature.set(signature, candidates);
+        orderedRules.push(rule);
+      }
+      rule.days.push(day.day);
+    }
+  }
+
+  return orderedRules;
+}
+
+/** Expand rules into the canonical DaySchedule[] shape (all 7 days present). */
+export function rulesToSchedule(rules: HoursRule[]): DaySchedule[] {
+  return Array.from({ length: 7 }, (_, day) => ({
+    day,
+    hours: rules
+      .filter((rule) => rule.days.includes(day))
+      .map((rule) => ({
+        id: generateId(),
+        start: rule.start,
+        end: rule.end,
+        ...(rule.description ? { description: rule.description } : {}),
+      })),
+  }));
+}

--- a/src/components/DateInput/DateInput.stories.tsx
+++ b/src/components/DateInput/DateInput.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof DateInput> = {
   argTypes: {
     inputType: {
       control: 'select',
-      options: ['date', 'datetime-local', 'month', 'year'],
+      options: ['date', 'datetime-local', 'time', 'month', 'year'],
       description: 'Date value format and picker control',
     },
     timeFormat: {
@@ -104,6 +104,23 @@ export const DateTimeTwelveHour: Story = {
     inputType: 'datetime-local',
     timeFormat: '12-hour',
     value: '2026-07-21T21:30',
+  },
+};
+
+export const Time: Story = {
+  args: {
+    label: 'Start Time',
+    inputType: 'time',
+    value: '09:30',
+  },
+};
+
+export const TimeTwelveHour: Story = {
+  args: {
+    label: 'Start Time',
+    inputType: 'time',
+    timeFormat: '12-hour',
+    value: '15:30',
   },
 };
 

--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -79,4 +79,130 @@ describe('DateInput', () => {
 
     expect(onChange).toHaveBeenCalledWith('2026-07');
   });
+
+  describe('inputType="time"', () => {
+    it('displays the value in 12-hour format', () => {
+      renderWithTheme(
+        <DateInput
+          label="Start time"
+          inputType="time"
+          timeFormat="12-hour"
+          value="15:30"
+        />
+      );
+
+      expect(screen.getByLabelText('Start time')).toHaveValue('3:30 PM');
+    });
+
+    it('displays the value in 24-hour format by default', () => {
+      renderWithTheme(
+        <DateInput label="Start time" inputType="time" value="15:30" />
+      );
+
+      expect(screen.getByLabelText('Start time')).toHaveValue('15:30');
+    });
+
+    it('emits HH:MM when picking a time', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      renderWithTheme(
+        <DateInput
+          label="Start time"
+          inputType="time"
+          timeFormat="12-hour"
+          value="08:00"
+          onChange={onChange}
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Open time picker' })
+      );
+      await user.selectOptions(screen.getByLabelText('Select hour'), '09');
+
+      expect(onChange).toHaveBeenCalledWith('09:00');
+    });
+
+    it('converts to PM via the meridiem select', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      renderWithTheme(
+        <DateInput
+          label="Start time"
+          inputType="time"
+          timeFormat="12-hour"
+          value="08:30"
+          onChange={onChange}
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Open time picker' })
+      );
+      await user.selectOptions(screen.getByLabelText('Select AM or PM'), 'PM');
+
+      expect(onChange).toHaveBeenCalledWith('20:30');
+    });
+
+    it('shows no calendar grid in the time picker dialog', async () => {
+      const user = userEvent.setup();
+
+      renderWithTheme(
+        <DateInput label="Start time" inputType="time" value="08:00" />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Open time picker' })
+      );
+
+      const dialog = screen.getByRole('dialog', { name: 'Choose time' });
+      expect(dialog).toBeInTheDocument();
+      expect(screen.queryByLabelText('Select month')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Today' })).toBeNull();
+    });
+
+    it('limits minutes to the minuteStep increment', async () => {
+      const user = userEvent.setup();
+
+      renderWithTheme(
+        <DateInput
+          label="Start time"
+          inputType="time"
+          minuteStep={15}
+          value="08:00"
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Open time picker' })
+      );
+
+      const minutes = Array.from(
+        screen.getByLabelText('Select minute').querySelectorAll('option')
+      ).map((option) => option.value);
+
+      expect(minutes).toEqual(['00', '15', '30', '45']);
+    });
+
+    it('keeps an off-step value selectable', async () => {
+      const user = userEvent.setup();
+
+      renderWithTheme(
+        <DateInput
+          label="Start time"
+          inputType="time"
+          minuteStep={15}
+          value="08:37"
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Open time picker' })
+      );
+
+      expect(screen.getByLabelText('Select minute')).toHaveValue('37');
+    });
+  });
 });

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -10,7 +10,7 @@ import {
   calculateAge,
 } from '../../utils/date';
 import { Input, type InputProps } from '../Input';
-import { Calendar } from 'lucide-react';
+import { Calendar, Clock } from 'lucide-react';
 import { useAnchoredPosition } from '../../hooks/useAnchoredPosition';
 
 export type DateInputMode =
@@ -20,7 +20,12 @@ export type DateInputMode =
   | 'past'
   | 'future';
 
-export type DateInputType = 'date' | 'datetime-local' | 'month' | 'year';
+export type DateInputType =
+  | 'date'
+  | 'datetime-local'
+  | 'time'
+  | 'month'
+  | 'year';
 
 export type DateInputWidth = 'full' | 'fit' | 'fixed';
 
@@ -104,6 +109,19 @@ function parsePickerDate(
   return { month: month - 1, year, day };
 }
 
+function formatTimeDisplay(
+  time: string,
+  timeFormat: DateInputTimeFormat
+): string {
+  const [hour, minute] = time.split(':').map(Number);
+  if (timeFormat === '12-hour') {
+    const displayHour = hour % 12 || 12;
+    const meridiem = hour >= 12 ? 'PM' : 'AM';
+    return `${displayHour}:${String(minute).padStart(2, '0')} ${meridiem}`;
+  }
+  return time;
+}
+
 function formatPickerValue(
   value: string,
   inputType: DateInputType,
@@ -112,13 +130,13 @@ function formatPickerValue(
   if (inputType === 'datetime-local') {
     const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}:\d{2})$/.exec(value);
     if (!match) return '';
-    if (timeFormat === '12-hour') {
-      const [hour, minute] = match[4].split(':').map(Number);
-      const displayHour = hour % 12 || 12;
-      const meridiem = hour >= 12 ? 'PM' : 'AM';
-      return `${match[2]}/${match[3]}/${match[1]} ${displayHour}:${String(minute).padStart(2, '0')} ${meridiem}`;
-    }
-    return `${match[2]}/${match[3]}/${match[1]} ${match[4]}`;
+    return `${match[2]}/${match[3]}/${match[1]} ${formatTimeDisplay(match[4], timeFormat)}`;
+  }
+
+  if (inputType === 'time') {
+    return /^\d{2}:\d{2}$/.test(value)
+      ? formatTimeDisplay(value, timeFormat)
+      : '';
   }
 
   if (inputType === 'month') {
@@ -139,6 +157,8 @@ export interface DateInputProps extends Omit<
   onChange?: (value: string) => void;
   /** Date value format and picker control. */
   inputType?: DateInputType;
+  /** Minute increment for the time picker (e.g. 15 shows :00, :15, :30, :45). */
+  minuteStep?: number;
   /** Time picker display format for datetime values. */
   timeFormat?: DateInputTimeFormat;
   /** Validation mode for the date input */
@@ -258,6 +278,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       value = '',
       onChange,
       inputType = 'date',
+      minuteStep = 1,
       timeFormat = '24-hour',
       mode = 'default',
       minAge,
@@ -349,12 +370,31 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
     const [calendarMonth, setCalendarMonth] = React.useState(parsedDate.month);
     const [calendarYear, setCalendarYear] = React.useState(parsedDate.year);
-    const [selectedTime, setSelectedTime] = React.useState(() =>
-      inputType === 'datetime-local' &&
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)
+    const [selectedTime, setSelectedTime] = React.useState(() => {
+      if (inputType === 'time' && /^\d{2}:\d{2}$/.test(value)) {
+        return value;
+      }
+      return inputType === 'datetime-local' &&
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)
         ? value.slice(-5)
-        : '00:00'
-    );
+        : '00:00';
+    });
+
+    // Minute choices honor minuteStep; an off-step current value is kept
+    // selectable so it still displays correctly.
+    const minuteOptions = React.useMemo(() => {
+      const step = Math.min(Math.max(Math.floor(minuteStep), 1), 60);
+      const minutes = Array.from(
+        { length: Math.ceil(60 / step) },
+        (_, index) => index * step
+      );
+      const currentMinute = Number(selectedTime.slice(3));
+      if (!minutes.includes(currentMinute)) {
+        minutes.push(currentMinute);
+        minutes.sort((a, b) => a - b);
+      }
+      return minutes.map((minute) => String(minute).padStart(2, '0'));
+    }, [minuteStep, selectedTime]);
     const minimumDate = React.useMemo(
       () => (minDate ? parseDateValue(minDate) : null),
       [minDate]
@@ -425,6 +465,12 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
     // Update calendar view when value changes
     React.useEffect(() => {
+      if (inputType === 'time') {
+        if (/^\d{2}:\d{2}$/.test(displayValue)) {
+          setSelectedTime(displayValue);
+        }
+        return;
+      }
       const date = parsePickerDate(displayValue, inputType);
       if (!date) return;
       setCalendarMonth(date.month);
@@ -542,6 +588,12 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         part === 'hour' ? `${nextValue}:${minute}` : `${hour}:${nextValue}`;
       setSelectedTime(nextTime);
 
+      if (inputType === 'time') {
+        setDisplayValue(nextTime);
+        onChange?.(nextTime);
+        return;
+      }
+
       if (parsedDate.day === null) return;
       const month = String(parsedDate.month + 1).padStart(2, '0');
       const day = String(parsedDate.day).padStart(2, '0');
@@ -601,93 +653,98 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           ref={calendarRef}
           className={cn(
             'bg-background border-border rounded-lg border shadow-lg',
-            'w-72 overflow-auto p-3'
+            'overflow-auto p-3',
+            inputType === 'time' ? 'w-fit' : 'w-72'
           )}
           style={calendarStyle}
           role="dialog"
           aria-label={
             inputType === 'month'
               ? 'Choose month'
-              : inputType === 'datetime-local'
-                ? 'Choose date and time'
-                : 'Choose date'
+              : inputType === 'time'
+                ? 'Choose time'
+                : inputType === 'datetime-local'
+                  ? 'Choose date and time'
+                  : 'Choose date'
           }
         >
           {/* Header with month/year navigation */}
-          <div className="mb-3 flex items-center justify-between">
-            <button
-              type="button"
-              onClick={() => {
-                if (inputType === 'month') {
-                  setCalendarYear(calendarYear - 1);
-                } else if (calendarMonth === 0) {
-                  setCalendarMonth(11);
-                  setCalendarYear(calendarYear - 1);
-                } else {
-                  setCalendarMonth(calendarMonth - 1);
+          {inputType !== 'time' && (
+            <div className="mb-3 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  if (inputType === 'month') {
+                    setCalendarYear(calendarYear - 1);
+                  } else if (calendarMonth === 0) {
+                    setCalendarMonth(11);
+                    setCalendarYear(calendarYear - 1);
+                  } else {
+                    setCalendarMonth(calendarMonth - 1);
+                  }
+                }}
+                disabled={!canGoToPreviousCalendar}
+                className="enabled:hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={
+                  inputType === 'month' ? 'Previous year' : 'Previous month'
                 }
-              }}
-              disabled={!canGoToPreviousCalendar}
-              className="enabled:hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label={
-                inputType === 'month' ? 'Previous year' : 'Previous month'
-              }
-            >
-              <ChevronLeftIcon />
-            </button>
-            <div className="flex items-center gap-2">
-              {inputType !== 'month' && (
-                <select
-                  value={calendarMonth}
-                  onChange={(e) => setCalendarMonth(Number(e.target.value))}
-                  className="bg-background border-border rounded border px-2 py-1 text-sm"
-                  aria-label="Select month"
-                >
-                  {MONTH_NAMES.map((name, month) =>
-                    isCalendarMonthInRange(month, calendarYear) ? (
-                      <option key={name} value={month}>
-                        {name}
-                      </option>
-                    ) : null
-                  )}
-                </select>
-              )}
-              <select
-                value={calendarYear}
-                onChange={(e) =>
-                  handleCalendarYearChange(Number(e.target.value))
-                }
-                className="bg-background border-border rounded border px-2 py-1 text-sm"
-                aria-label="Select year"
               >
-                {calendarYears.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </select>
+                <ChevronLeftIcon />
+              </button>
+              <div className="flex items-center gap-2">
+                {inputType !== 'month' && (
+                  <select
+                    value={calendarMonth}
+                    onChange={(e) => setCalendarMonth(Number(e.target.value))}
+                    className="bg-background border-border rounded border px-2 py-1 text-sm"
+                    aria-label="Select month"
+                  >
+                    {MONTH_NAMES.map((name, month) =>
+                      isCalendarMonthInRange(month, calendarYear) ? (
+                        <option key={name} value={month}>
+                          {name}
+                        </option>
+                      ) : null
+                    )}
+                  </select>
+                )}
+                <select
+                  value={calendarYear}
+                  onChange={(e) =>
+                    handleCalendarYearChange(Number(e.target.value))
+                  }
+                  className="bg-background border-border rounded border px-2 py-1 text-sm"
+                  aria-label="Select year"
+                >
+                  {calendarYears.map((year) => (
+                    <option key={year} value={year}>
+                      {year}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  if (inputType === 'month') {
+                    setCalendarYear(calendarYear + 1);
+                  } else if (calendarMonth === 11) {
+                    setCalendarMonth(0);
+                    setCalendarYear(calendarYear + 1);
+                  } else {
+                    setCalendarMonth(calendarMonth + 1);
+                  }
+                }}
+                disabled={!canGoToNextCalendar}
+                className="hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={inputType === 'month' ? 'Next year' : 'Next month'}
+              >
+                <ChevronRightIcon />
+              </button>
             </div>
-            <button
-              type="button"
-              onClick={() => {
-                if (inputType === 'month') {
-                  setCalendarYear(calendarYear + 1);
-                } else if (calendarMonth === 11) {
-                  setCalendarMonth(0);
-                  setCalendarYear(calendarYear + 1);
-                } else {
-                  setCalendarMonth(calendarMonth + 1);
-                }
-              }}
-              disabled={!canGoToNextCalendar}
-              className="hover:bg-muted rounded-md p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label={inputType === 'month' ? 'Next year' : 'Next month'}
-            >
-              <ChevronRightIcon />
-            </button>
-          </div>
+          )}
 
-          {inputType === 'month' ? (
+          {inputType === 'time' ? null : inputType === 'month' ? (
             <div className="grid grid-cols-3 gap-1">
               {MONTH_NAMES.map((name, month) => (
                 <button
@@ -748,8 +805,14 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
             </>
           )}
 
-          {inputType === 'datetime-local' && (
-            <div className="border-border mt-3 flex items-center gap-2 border-t pt-3">
+          {(inputType === 'datetime-local' || inputType === 'time') && (
+            <div
+              className={cn(
+                'flex items-center gap-2',
+                inputType === 'datetime-local' &&
+                  'border-border mt-3 border-t pt-3'
+              )}
+            >
               <select
                 value={
                   timeFormat === '12-hour'
@@ -791,9 +854,9 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                 className="bg-background border-border rounded border px-2 py-1 text-sm"
                 aria-label="Select minute"
               >
-                {Array.from({ length: 60 }, (_, minute) => (
-                  <option key={minute} value={String(minute).padStart(2, '0')}>
-                    {String(minute).padStart(2, '0')}
+                {minuteOptions.map((minute) => (
+                  <option key={minute} value={minute}>
+                    {minute}
                   </option>
                 ))}
               </select>
@@ -814,31 +877,33 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           )}
 
           <div className="border-border mt-3 flex gap-2 border-t pt-3">
-            <button
-              type="button"
-              onClick={() => {
-                const today = new Date();
-                setCalendarMonth(today.getMonth());
-                setCalendarYear(today.getFullYear());
-                if (inputType === 'month') {
-                  handleMonthSelect(today.getMonth());
-                } else {
-                  handleDateSelect(today.getDate());
+            {inputType !== 'time' && (
+              <button
+                type="button"
+                onClick={() => {
+                  const today = new Date();
+                  setCalendarMonth(today.getMonth());
+                  setCalendarYear(today.getFullYear());
+                  if (inputType === 'month') {
+                    handleMonthSelect(today.getMonth());
+                  } else {
+                    handleDateSelect(today.getDate());
+                  }
+                }}
+                disabled={
+                  inputType === 'month'
+                    ? !isCalendarMonthInRange(
+                        new Date().getMonth(),
+                        new Date().getFullYear()
+                      )
+                    : !isDateInRange(new Date())
                 }
-              }}
-              disabled={
-                inputType === 'month'
-                  ? !isCalendarMonthInRange(
-                      new Date().getMonth(),
-                      new Date().getFullYear()
-                    )
-                  : !isDateInRange(new Date())
-              }
-              className="text-primary-800 flex-1 text-sm hover:underline disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Today
-            </button>
-            {inputType === 'datetime-local' && (
+                className="text-primary-800 flex-1 text-sm hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Today
+              </button>
+            )}
+            {(inputType === 'datetime-local' || inputType === 'time') && (
               <button
                 type="button"
                 onClick={() => setIsCalendarOpen(false)}
@@ -920,9 +985,11 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
               placeholder={
                 inputType === 'month'
                   ? 'Select month'
-                  : inputType === 'datetime-local'
-                    ? 'Select date and time'
-                    : placeholder
+                  : inputType === 'time'
+                    ? 'Select time'
+                    : inputType === 'datetime-local'
+                      ? 'Select date and time'
+                      : placeholder
               }
               value={formatPickerValue(displayValue, inputType, timeFormat)}
               onChange={handleChange}
@@ -965,11 +1032,17 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                 'focus:text-foreground focus:outline-none',
                 'transition-colors'
               )}
-              aria-label="Open calendar"
+              aria-label={
+                inputType === 'time' ? 'Open time picker' : 'Open calendar'
+              }
               aria-expanded={isCalendarOpen}
               aria-haspopup="dialog"
             >
-              <Calendar size={18} />
+              {inputType === 'time' ? (
+                <Clock size={18} />
+              ) : (
+                <Calendar size={18} />
+              )}
             </button>
           </div>
           {isCalendarOpen && createPortal(renderCalendar(), document.body)}

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -48,6 +48,10 @@ module.exports = {
     'bg-neutral-200',
     'dark:bg-neutral-700',
     'bg-primary-500',
+    // BusinessHoursEditor rules-variant day chips
+    'border-primary-800',
+    'bg-primary-800',
+    'text-white',
     'h-5',
     'w-9',
     'h-6',


### PR DESCRIPTION
- New variant="rules": rows of day toggles + one time range, grouping days that share hours (e.g. Mon/Wed/Fri 8-11am); emits the same DaySchedule[] as the default variant
- Add inputType="time" to DateInput with 12/24-hour display and a time-only picker popup; used for rule start/end times
- Add minuteStep prop to DateInput; rules variant uses 15-minute steps
- Wire up previously unused use24Hour prop in the rules variant
- Stories: rules variant with live BusinessHours preview, DateInput Time/TimeTwelveHour; 16 new unit tests


https://github.com/user-attachments/assets/39a8d1f5-7b43-4120-81cd-2455aaddeaa1



