### PR TITLE
chore(release): v0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mieweb/ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A themeable, accessible React component library built with Tailwind CSS",
   "author": "Medical Informatics Engineering, Inc.",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Bumps the package version to 0.7.2 for a stable npm release.

Once merged, tagging `v0.7.2` on main will trigger the Release workflow to publish `@mieweb/ui@0.7.2` to npm `@latest`.

Since 0.7.1 this brings (among others):
- eSheet v0.5 (`@esheet/*` 0.0.5, submodule at v0.0.5 tag) — page navigation, section icons/design, nested width overrides, field layout defaults (#347)
- BusinessHoursEditor rules variant with grouped preview (#369)