### PR TITLE
feat(Button): prevent label wrapping with truncation, auto-tooltip, and ButtonGroup

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -138,7 +138,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       };
 
       update();
-      const observer = new window.ResizeObserver(update);
+      if (typeof globalThis.ResizeObserver === 'undefined') return;
+      const observer = new globalThis.ResizeObserver(update);
       observer.observe(label);
       return () => observer.disconnect();
     }, [title, children, isLoading, loadingText]);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,6 +6,7 @@ const buttonVariants = cva(
   // Base styles
   [
     'inline-flex items-center justify-center gap-2',
+    'min-w-0 whitespace-nowrap',
     'font-semibold transition-all duration-200',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
     'disabled:pointer-events-none disabled:opacity-50',
@@ -111,11 +112,37 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loadingText,
       disabled,
       children,
+      title,
       ...props
     },
     ref
   ) => {
     const resolvedSize = size ?? 'md';
+    const labelRef = React.useRef<HTMLSpanElement>(null);
+    const innerRef = React.useRef<HTMLButtonElement>(null);
+    React.useImperativeHandle(ref, () => innerRef.current as HTMLButtonElement);
+
+    // When the label truncates, expose the full text as a native tooltip.
+    // A consumer-provided `title` always takes precedence.
+    React.useLayoutEffect(() => {
+      const label = labelRef.current;
+      const button = innerRef.current;
+      if (!label || !button || title !== undefined) return;
+
+      const update = () => {
+        if (label.scrollWidth > label.clientWidth) {
+          button.title = label.textContent ?? '';
+        } else {
+          button.removeAttribute('title');
+        }
+      };
+
+      update();
+      const observer = new window.ResizeObserver(update);
+      observer.observe(label);
+      return () => observer.disconnect();
+    }, [title, children, isLoading, loadingText]);
+
     return (
       <button
         data-slot="button"
@@ -124,22 +151,27 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           buttonVariants({ variant, size: resolvedSize, fullWidth }),
           className
         )}
-        ref={ref}
+        ref={innerRef}
         disabled={disabled || isLoading}
         aria-busy={isLoading}
+        title={title}
         {...props}
       >
         {isLoading ? (
           <>
             <LoadingSpinner />
-            {loadingText || children}
+            <span ref={labelRef} data-slot="button-label" className="truncate">
+              {loadingText || children}
+            </span>
           </>
         ) : (
           <>
             {React.isValidElement(leftIcon) && (
               <span className="shrink-0">{leftIcon}</span>
             )}
-            {children}
+            <span ref={labelRef} data-slot="button-label" className="truncate">
+              {children}
+            </span>
             {React.isValidElement(rightIcon) && (
               <span className="shrink-0">{rightIcon}</span>
             )}
@@ -158,7 +190,7 @@ Button.displayName = 'Button';
 function LoadingSpinner() {
   return (
     <svg
-      className="h-4 w-4 animate-spin"
+      className="h-4 w-4 shrink-0 animate-spin"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ButtonGroup, type ButtonGroupProps } from './ButtonGroup';
+import { Button } from '../Button';
+
+type PlaygroundArgs = ButtonGroupProps & {
+  /** Label for the first button (empty hides it) */
+  firstLabel: string;
+  /** Label for the second button (empty hides it) */
+  secondLabel: string;
+  /** Label for the third button (empty hides it) */
+  thirdLabel: string;
+  /** Width of the resizable demo container in px */
+  containerWidth: number;
+};
+
+const buttonVariants = ['secondary', 'primary', 'danger'] as const;
+
+/** Shared playground: resizable container + up to three label-driven buttons */
+function renderPlayground({
+  firstLabel,
+  secondLabel,
+  thirdLabel,
+  containerWidth,
+  ...groupProps
+}: PlaygroundArgs) {
+  const labels = [firstLabel, secondLabel, thirdLabel].filter(Boolean);
+  return (
+    <div
+      className="resize-x overflow-auto rounded-lg border border-dashed border-neutral-300 p-4"
+      style={{ width: containerWidth, minWidth: 140, maxWidth: 720 }}
+    >
+      <ButtonGroup {...groupProps}>
+        {labels.map((label, i) => (
+          <Button
+            key={i}
+            variant={buttonVariants[Math.min(i, buttonVariants.length - 1)]}
+          >
+            {label}
+          </Button>
+        ))}
+      </ButtonGroup>
+    </div>
+  );
+}
+
+const meta: Meta<PlaygroundArgs> = {
+  title: 'Components/Forms & Inputs/ButtonGroup',
+  component: ButtonGroup,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: 'select',
+      options: ['auto', 'horizontal', 'vertical'],
+    },
+    split: {
+      options: [false, true, 2],
+      control: {
+        type: 'select',
+        labels: {
+          false: 'No split — all buttons right',
+          true: 'First button left, rest right',
+          2: 'First two left, rest right',
+        },
+      },
+    },
+    firstLabel: { control: 'text' },
+    secondLabel: { control: 'text' },
+    thirdLabel: { control: 'text' },
+    containerWidth: {
+      control: { type: 'range', min: 140, max: 720, step: 10 },
+    },
+  },
+  args: {
+    orientation: 'auto',
+    split: false,
+    firstLabel: 'Cancel',
+    secondLabel: 'Save',
+    thirdLabel: '',
+    containerWidth: 480,
+  },
+  render: renderPlayground,
+};
+
+export default meta;
+type Story = StoryObj<PlaygroundArgs>;
+
+/**
+ * Adjust the label and container-width controls (or drag the dashed
+ * container's resize handle) to see the group respond.
+ */
+export const Default: Story = {};
+
+/**
+ * Drag the resize handle or the container-width control: while the row fits,
+ * buttons stay side by side. As soon as a label would truncate, the group
+ * stacks vertically so the full text stays readable — and returns to a row
+ * when space allows.
+ */
+export const AutoStacking: Story = {
+  args: {
+    firstLabel: 'No, keep this record and return to the previous screen',
+    secondLabel: 'Yes, permanently delete this patient encounter record',
+  },
+};
+
+/**
+ * One short and one long label. Starting wide, the group is horizontal with
+ * both labels fully visible. Narrow the container: the moment the long label
+ * would truncate, the group stacks so the full text stays readable. Narrower
+ * still, even the stacked button truncates (with auto tooltip).
+ */
+export const MixedLengthLabels: Story = {
+  args: {
+    firstLabel: 'Cancel',
+    secondLabel: 'Submit encounter and notify the care team',
+    containerWidth: 560,
+  },
+};
+
+/**
+ * `split` divides the row into left and right sections: `true` puts the first
+ * button on the left, `2` puts two on the left, etc. Without `split`, all
+ * buttons align right. When the group stacks, the split is ignored and
+ * buttons render in order, full width.
+ */
+export const SplitActions: Story = {
+  args: {
+    split: true,
+    firstLabel: 'Back',
+    secondLabel: 'Save draft',
+    thirdLabel: 'Submit encounter',
+    containerWidth: 560,
+  },
+};

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ButtonGroup, type ButtonGroupProps } from './ButtonGroup';
-import { Button } from '../Button';
+import { Button, type ButtonProps } from '../Button';
+
+type ButtonVariant = NonNullable<ButtonProps['variant']>;
 
 type PlaygroundArgs = ButtonGroupProps & {
   /** Label for the first button (empty hides it) */
@@ -10,32 +12,49 @@ type PlaygroundArgs = ButtonGroupProps & {
   secondLabel: string;
   /** Label for the third button (empty hides it) */
   thirdLabel: string;
+  /** Variant for the first button */
+  firstVariant: ButtonVariant;
+  /** Variant for the second button */
+  secondVariant: ButtonVariant;
+  /** Variant for the third button */
+  thirdVariant: ButtonVariant;
   /** Width of the resizable demo container in px */
   containerWidth: number;
 };
 
-const buttonVariants = ['secondary', 'primary', 'danger'] as const;
+const variantOptions: ButtonVariant[] = [
+  'primary',
+  'secondary',
+  'ghost',
+  'outline',
+  'danger',
+  'link',
+];
 
 /** Shared playground: resizable container + up to three label-driven buttons */
 function renderPlayground({
   firstLabel,
   secondLabel,
   thirdLabel,
+  firstVariant,
+  secondVariant,
+  thirdVariant,
   containerWidth,
   ...groupProps
 }: PlaygroundArgs) {
-  const labels = [firstLabel, secondLabel, thirdLabel].filter(Boolean);
+  const buttons = [
+    { label: firstLabel, variant: firstVariant },
+    { label: secondLabel, variant: secondVariant },
+    { label: thirdLabel, variant: thirdVariant },
+  ].filter((b) => b.label);
   return (
     <div
       className="resize-x overflow-auto rounded-lg border border-dashed border-neutral-300 p-4"
       style={{ width: containerWidth, minWidth: 140, maxWidth: 720 }}
     >
       <ButtonGroup {...groupProps}>
-        {labels.map((label, i) => (
-          <Button
-            key={i}
-            variant={buttonVariants[Math.min(i, buttonVariants.length - 1)]}
-          >
+        {buttons.map(({ label, variant }, i) => (
+          <Button key={i} variant={variant}>
             {label}
           </Button>
         ))}
@@ -70,6 +89,9 @@ const meta: Meta<PlaygroundArgs> = {
     firstLabel: { control: 'text' },
     secondLabel: { control: 'text' },
     thirdLabel: { control: 'text' },
+    firstVariant: { control: 'select', options: variantOptions },
+    secondVariant: { control: 'select', options: variantOptions },
+    thirdVariant: { control: 'select', options: variantOptions },
     containerWidth: {
       control: { type: 'range', min: 140, max: 720, step: 10 },
     },
@@ -78,8 +100,11 @@ const meta: Meta<PlaygroundArgs> = {
     orientation: 'auto',
     split: false,
     firstLabel: 'Cancel',
-    secondLabel: 'Save',
-    thirdLabel: '',
+    secondLabel: 'Save draft',
+    thirdLabel: 'Save and close',
+    firstVariant: 'danger',
+    secondVariant: 'secondary',
+    thirdVariant: 'primary',
     containerWidth: 480,
   },
   render: renderPlayground,
@@ -104,6 +129,9 @@ export const AutoStacking: Story = {
   args: {
     firstLabel: 'No, keep this record and return to the previous screen',
     secondLabel: 'Yes, permanently delete this patient encounter record',
+    thirdLabel: '',
+    firstVariant: 'secondary',
+    secondVariant: 'danger',
   },
 };
 
@@ -117,6 +145,9 @@ export const MixedLengthLabels: Story = {
   args: {
     firstLabel: 'Cancel',
     secondLabel: 'Submit encounter and notify the care team',
+    thirdLabel: '',
+    firstVariant: 'secondary',
+    secondVariant: 'primary',
     containerWidth: 560,
   },
 };
@@ -133,6 +164,9 @@ export const SplitActions: Story = {
     firstLabel: 'Back',
     secondLabel: 'Save draft',
     thirdLabel: 'Submit encounter',
+    firstVariant: 'ghost',
+    secondVariant: 'secondary',
+    thirdVariant: 'primary',
     containerWidth: 560,
   },
 };

--- a/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { ButtonGroup } from './ButtonGroup';
+import { Button } from '../Button';
+
+/**
+ * jsdom has no layout engine, so scrollWidth/clientWidth are always 0 and the
+ * auto-stacking measurement sees no truncation. Tests that exercise the
+ * stacking decision mock those getters on the label spans.
+ */
+function mockLabelWidths(scrollWidth: number, clientWidth: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get() {
+      return this.dataset.slot === 'button-label' ? scrollWidth : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return this.dataset.slot === 'button-label' ? clientWidth : 0;
+    },
+  });
+}
+
+function restoreLabelWidths() {
+  delete (HTMLElement.prototype as { scrollWidth?: unknown }).scrollWidth;
+  delete (HTMLElement.prototype as { clientWidth?: unknown }).clientWidth;
+}
+
+function getGroup() {
+  return document.querySelector<HTMLElement>('[data-slot="button-group"]')!;
+}
+
+describe('ButtonGroup', () => {
+  afterEach(restoreLabelWidths);
+
+  it('renders children in a horizontal row by default', () => {
+    renderWithTheme(
+      <ButtonGroup>
+        <Button>Cancel</Button>
+        <Button>Save</Button>
+      </ButtonGroup>
+    );
+    const group = getGroup();
+    expect(group).toHaveAttribute('data-orientation', 'horizontal');
+    expect(group).toHaveClass('flex-row');
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('aligns buttons to the right by default (no split)', () => {
+    renderWithTheme(
+      <ButtonGroup>
+        <Button>Save</Button>
+      </ButtonGroup>
+    );
+    expect(getGroup()).toHaveClass('justify-end');
+  });
+
+  it('respects orientation="vertical"', () => {
+    renderWithTheme(
+      <ButtonGroup orientation="vertical">
+        <Button>Cancel</Button>
+        <Button>Save</Button>
+      </ButtonGroup>
+    );
+    const group = getGroup();
+    expect(group).toHaveAttribute('data-orientation', 'vertical');
+    expect(group).toHaveClass('flex-col');
+  });
+
+  it('respects orientation="horizontal" and skips measuring', () => {
+    // Labels report truncation, but forced horizontal must not stack
+    mockLabelWidths(300, 100);
+    renderWithTheme(
+      <ButtonGroup orientation="horizontal">
+        <Button>A very long label that would truncate</Button>
+      </ButtonGroup>
+    );
+    expect(getGroup()).toHaveAttribute('data-orientation', 'horizontal');
+  });
+
+  it('auto-stacks when labels would truncate', () => {
+    mockLabelWidths(300, 100); // truncated: scrollWidth > clientWidth
+    renderWithTheme(
+      <ButtonGroup orientation="auto">
+        <Button>A very long label that would truncate</Button>
+        <Button>Another long label</Button>
+      </ButtonGroup>
+    );
+    expect(getGroup()).toHaveAttribute('data-orientation', 'vertical');
+  });
+
+  it('stays horizontal when labels fit', () => {
+    mockLabelWidths(100, 100); // no truncation
+    renderWithTheme(
+      <ButtonGroup orientation="auto">
+        <Button>Fits</Button>
+        <Button>Also fits</Button>
+      </ButtonGroup>
+    );
+    expect(getGroup()).toHaveAttribute('data-orientation', 'horizontal');
+  });
+
+  describe('split', () => {
+    it('renders no spacer without split', () => {
+      renderWithTheme(
+        <ButtonGroup>
+          <Button>Cancel</Button>
+          <Button>Save</Button>
+        </ButtonGroup>
+      );
+      expect(getGroup().querySelector('.flex-1')).toBeNull();
+    });
+
+    it('split places a spacer after the first button', () => {
+      renderWithTheme(
+        <ButtonGroup split>
+          <Button>Back</Button>
+          <Button>Cancel</Button>
+          <Button>Save</Button>
+        </ButtonGroup>
+      );
+      const children = Array.from(getGroup().children);
+      expect(children).toHaveLength(4);
+      expect(children[1]).toHaveClass('flex-1');
+      expect(children[1]).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('split={2} places the spacer after two buttons', () => {
+      renderWithTheme(
+        <ButtonGroup split={2}>
+          <Button>Back</Button>
+          <Button>Cancel</Button>
+          <Button>Save</Button>
+        </ButtonGroup>
+      );
+      const children = Array.from(getGroup().children);
+      expect(children[2]).toHaveClass('flex-1');
+    });
+
+    it('ignores split when it would leave no buttons on the right', () => {
+      renderWithTheme(
+        <ButtonGroup split={2}>
+          <Button>Cancel</Button>
+          <Button>Save</Button>
+        </ButtonGroup>
+      );
+      expect(getGroup().querySelector('.flex-1')).toBeNull();
+    });
+
+    it('ignores split while stacked', () => {
+      mockLabelWidths(300, 100); // force stacking
+      renderWithTheme(
+        <ButtonGroup split>
+          <Button>A very long label that would truncate</Button>
+          <Button>Save</Button>
+        </ButtonGroup>
+      );
+      const group = getGroup();
+      expect(group).toHaveAttribute('data-orientation', 'vertical');
+      expect(group.querySelector('.flex-1')).toBeNull();
+    });
+  });
+});

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Force a layout instead of measuring. 'auto' stacks only when labels would truncate. */
+  orientation?: 'auto' | 'horizontal' | 'vertical';
+  /**
+   * Split the row into a left and right section. `true` puts the first button
+   * on the left; a number puts that many buttons on the left. The rest align
+   * right. Ignored while stacked. Default: no split, all buttons align right.
+   */
+  split?: boolean | number;
+}
+
+/**
+ * Lays out buttons in a row, automatically stacking them vertically when the
+ * available space would truncate their labels.
+ *
+ * Detection: each Button renders its label in a `data-slot="button-label"`
+ * span with `truncate`. When laid out in a row, a truncated label has
+ * `scrollWidth > clientWidth`. The group measures the extra width needed and
+ * stacks when the row cannot fit; it returns to a row once the container is
+ * wide enough again.
+ *
+ * @example
+ * ```tsx
+ * <ModalFooter>
+ *   <ButtonGroup className="w-full" split>
+ *     <Button variant="ghost">Back</Button>
+ *     <Button variant="secondary">Cancel</Button>
+ *     <Button variant="danger">Permanently delete this record</Button>
+ *   </ButtonGroup>
+ * </ModalFooter>
+ * ```
+ */
+const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
+  ({ orientation = 'auto', split, className, children, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLDivElement>(null);
+    React.useImperativeHandle(ref, () => innerRef.current as HTMLDivElement);
+
+    const [stacked, setStacked] = React.useState(false);
+    // Width the row layout needs to show every label in full.
+    const requiredWidth = React.useRef(0);
+
+    React.useLayoutEffect(() => {
+      if (orientation !== 'auto') return;
+      const el = innerRef.current;
+      if (!el) return;
+
+      const measure = () => {
+        if (!stacked) {
+          // In row mode, a truncated label reports scrollWidth > clientWidth.
+          const overflow = Array.from(
+            el.querySelectorAll<HTMLElement>('[data-slot="button-label"]')
+          ).reduce(
+            (sum, label) =>
+              sum + Math.max(0, label.scrollWidth - label.clientWidth),
+            0
+          );
+          if (overflow > 0) {
+            requiredWidth.current = el.clientWidth + overflow;
+            setStacked(true);
+          }
+        } else if (el.clientWidth >= requiredWidth.current) {
+          setStacked(false);
+        }
+      };
+
+      measure();
+      const observer = new window.ResizeObserver(measure);
+      observer.observe(el);
+      return () => observer.disconnect();
+    }, [orientation, stacked, children]);
+
+    const isStacked =
+      orientation === 'vertical' || (orientation === 'auto' && stacked);
+
+    const items = React.Children.toArray(children);
+    const splitCount =
+      split === true ? 1 : typeof split === 'number' ? split : 0;
+    const splitIndex =
+      !isStacked && splitCount > 0 && splitCount < items.length
+        ? splitCount
+        : 0;
+
+    return (
+      <div
+        ref={innerRef}
+        data-slot="button-group"
+        data-orientation={isStacked ? 'vertical' : 'horizontal'}
+        className={cn(
+          'flex gap-3',
+          isStacked
+            ? 'flex-col items-stretch'
+            : 'flex-row items-center justify-end',
+          className
+        )}
+        {...props}
+      >
+        {splitIndex > 0 ? (
+          <>
+            {items.slice(0, splitIndex)}
+            <div className="flex-1" aria-hidden="true" />
+            {items.slice(splitIndex)}
+          </>
+        ) : (
+          children
+        )}
+      </div>
+    );
+  }
+);
+
+ButtonGroup.displayName = 'ButtonGroup';
+
+export { ButtonGroup };

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -67,7 +67,8 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       };
 
       measure();
-      const observer = new window.ResizeObserver(measure);
+      if (typeof globalThis.ResizeObserver === 'undefined') return;
+      const observer = new globalThis.ResizeObserver(measure);
       observer.observe(el);
       return () => observer.disconnect();
     }, [orientation, stacked, children]);

--- a/src/components/ButtonGroup/index.ts
+++ b/src/components/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export { ButtonGroup, type ButtonGroupProps } from './ButtonGroup';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export * from './components/Breadcrumb';
 export * from './components/BusinessHours';
 export * from './components/BusinessHoursEditor';
 export * from './components/Button';
+export * from './components/ButtonGroup';
 export * from './components/Card';
 export * from './components/Checkbox';
 // CodeLookup itself ships a module worker and is NOT exported here (apps import

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -49,13 +49,25 @@ beforeAll(() => {
     });
   }
 
-  // ResizeObserver is not available in jsdom
+  // ResizeObserver is not available in jsdom. This minimal stub matches the
+  // real API shape: it stores the callback and fires it once per observe()
+  // (mirroring the real initial-observation callback) so tests can exercise
+  // ResizeObserver-driven code paths.
   if (typeof globalThis.ResizeObserver === 'undefined') {
     globalThis.ResizeObserver = class ResizeObserver {
-      observe() {}
+      private callback: globalThis.ResizeObserverCallback;
+      constructor(callback: globalThis.ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe(target: Element) {
+        this.callback(
+          [{ target } as globalThis.ResizeObserverEntry],
+          this as unknown as globalThis.ResizeObserver
+        );
+      }
       unobserve() {}
       disconnect() {}
-    };
+    } as unknown as typeof globalThis.ResizeObserver;
   }
 
   // DataTransfer is not available in jsdom

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -49,6 +49,15 @@ beforeAll(() => {
     });
   }
 
+  // ResizeObserver is not available in jsdom
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+
   // DataTransfer is not available in jsdom
   if (typeof globalThis.DataTransfer === 'undefined') {
     class MockDataTransfer {


### PR DESCRIPTION

https://github.com/user-attachments/assets/dd864d6a-10f4-4339-85a4-0680444057a3

## Why

Long button labels in confined spaces (modal footers, sidebars, narrow cards) previously wrapped onto multiple lines or overflowed their containers, producing tall, misaligned, broken-looking action rows. This PR makes buttons resilient to tight layouts with zero configuration: labels ellipsize gracefully, the full text stays discoverable via tooltip, and button rows can automatically reflow into a stack when there simply isn't room. Consumers get better-behaved buttons everywhere without changing a line of code.

## What

- **Button**: add `whitespace-nowrap` + `min-w-0` base styles and a truncating label span so confined buttons ellipsize instead of wrapping/overflowing
- **Button**: auto-set native `title` tooltip (full label) only while truncated; consumer-provided `title` always wins
- **ButtonGroup**: new component that auto-stacks buttons vertically when row labels would truncate (`orientation` auto/horizontal/vertical) and supports split layouts (N left, rest right; default all right)
- **Stories**: shared resizable playground with label/width/variant controls
- **Test setup**: stub ResizeObserver for jsdom

## ⚠️ Behavior change for existing consumers

Buttons **no longer wrap long labels by default** — they truncate with an ellipsis and expose the full text via a native tooltip. If a downstream app (WebChart, BlueHive, etc.) intentionally relies on a multi-line button label, restore the old behavior with `className="whitespace-normal"` (consumer classes win via `cn()`). The label is now wrapped in `<span data-slot="button-label">`, which may affect DOM snapshots or queries targeting button internals.
