### PR TITLE
feat: add CaseManagementHeader component

### DIFF
--- a/src/components/CaseManagementHeader/CaseManagementHeader.stories.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.stories.tsx
@@ -1,0 +1,228 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  CaseManagementHeader,
+  CaseContextBar,
+  type CaseInfo,
+  type CasePatient,
+  type CaseDetailItem,
+} from './CaseManagementHeader';
+import { Button } from '../Button';
+import { CollabStatus } from '../CollabStatus';
+import { Alert, AlertTitle } from '../Alert';
+import { PlusIcon, FilePlusIcon, CheckCircleIcon } from '../Icons';
+
+const meta: Meta<typeof CaseManagementHeader> = {
+  title: 'Components/Text & Data Display/CaseManagementHeader',
+  component: CaseManagementHeader,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    sticky: { control: 'boolean' },
+    showBackButton: { control: 'boolean' },
+    showContextBar: { control: 'boolean' },
+    defaultExpanded: { control: 'boolean' },
+    expanded: { control: 'boolean' },
+    caseInfo: { table: { disable: true } },
+    patient: { table: { disable: true } },
+    details: { table: { disable: true } },
+    actions: { table: { disable: true } },
+    collabStatus: { table: { disable: true } },
+    alert: { table: { disable: true } },
+    onBack: { action: 'back-clicked' },
+    onExpandedChange: { action: 'expanded-changed' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CaseManagementHeader>;
+
+// ─── Sample Data ─────────────────────────────────────────────────────────────
+
+const sampleCase: CaseInfo = {
+  caseNumber: 'S2025-0001',
+  status: 'Open',
+  caseType: 'Absence management',
+  openedDate: '2025-01-21',
+};
+
+const samplePatient: CasePatient = {
+  name: 'Eleanor Washburn',
+};
+
+const sampleDetails: CaseDetailItem[] = [
+  { label: 'Case Manager', value: 'Unassigned' },
+  { label: 'Opened', value: 'Jan 21, 2025' },
+  { label: 'Follow-up', value: 'Feb 4, 2025' },
+];
+
+const richCase: CaseInfo = {
+  caseNumber: '20251102-3351',
+  status: 'Open',
+  caseType: 'Incident / Illness',
+  openedDate: '2025-11-02',
+};
+
+const richPatient: CasePatient = {
+  name: 'Lisa Ryan',
+  mrn: 'MR-004821',
+  dob: '03/18/1978',
+};
+
+const richDetails: CaseDetailItem[] = [
+  { label: 'Case Manager', value: 'Casey Manager' },
+  { label: 'Opened', value: '11/02/2025' },
+  { label: 'Follow-up', value: '11/16/2025' },
+  { label: 'Disability Date', value: '11/04/2025' },
+];
+
+/**
+ * Desktop buttons are unchanged; below `md` (768px) they swap for icon-only
+ * equivalents (a +doc icon, and a check — not an X, which implies delete).
+ */
+const addCaseNoteAction = (
+  <>
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Add Case Note"
+      className="h-8 w-8 md:hidden"
+    >
+      <FilePlusIcon size={16} />
+    </Button>
+    <Button
+      variant="ghost"
+      size="sm"
+      leftIcon={<PlusIcon size={16} />}
+      className="hidden md:inline-flex"
+    >
+      Add Case Note
+    </Button>
+  </>
+);
+
+const closeCaseAction = (
+  <>
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Close Case"
+      className="h-8 w-8 md:hidden"
+    >
+      <CheckCircleIcon size={16} />
+    </Button>
+    <Button variant="ghost" size="sm" className="hidden md:inline-flex">
+      Close Case
+    </Button>
+  </>
+);
+
+const liveStatus = <CollabStatus connected showLog={false} />;
+
+const editingUsers = ['User 3844575388'];
+
+// ─── Stories ─────────────────────────────────────────────────────────────────
+
+/** The mockup layout: context bar, patient row, collapsed details. */
+export const Default: Story = {
+  args: {
+    caseInfo: sampleCase,
+    patient: samplePatient,
+    details: sampleDetails,
+    showBackButton: true,
+    actions: addCaseNoteAction,
+    editingUsers,
+    collabStatus: liveStatus,
+  },
+};
+
+/** Expanded details grid with multiple actions (POC layout). */
+export const Expanded: Story = {
+  args: {
+    caseInfo: richCase,
+    patient: richPatient,
+    details: richDetails,
+    showBackButton: true,
+    defaultExpanded: true,
+    actions: (
+      <>
+        {addCaseNoteAction}
+        {closeCaseAction}
+      </>
+    ),
+    editingUsers,
+    collabStatus: liveStatus,
+  },
+};
+
+/** Days open supplied explicitly instead of computed from `openedDate`. */
+export const ExplicitDaysOpen: Story = {
+  args: {
+    caseInfo: { ...sampleCase, daysOpen: 568 },
+    patient: samplePatient,
+    details: sampleDetails,
+    showBackButton: true,
+    defaultExpanded: true,
+    actions: addCaseNoteAction,
+    collabStatus: liveStatus,
+  },
+};
+
+/** The context bar alone, for pinning case context to other pages. */
+export const ContextBarOnly: StoryObj<typeof CaseContextBar> = {
+  render: () => (
+    <CaseContextBar
+      caseInfo={sampleCase}
+      editingUsers={editingUsers}
+      collabStatus={liveStatus}
+    />
+  ),
+};
+
+/** Without the context bar — identity row and details only. */
+export const WithoutContextBar: Story = {
+  args: {
+    caseInfo: richCase,
+    patient: richPatient,
+    details: richDetails,
+    showContextBar: false,
+    showBackButton: true,
+    actions: addCaseNoteAction,
+  },
+};
+
+/** Validation alert attached to the bottom of the header via the `alert` slot. */
+export const WithAlert: Story = {
+  args: {
+    caseInfo: richCase,
+    patient: richPatient,
+    details: richDetails,
+    showBackButton: true,
+    defaultExpanded: true,
+    actions: (
+      <>
+        {addCaseNoteAction}
+        {closeCaseAction}
+      </>
+    ),
+    editingUsers,
+    collabStatus: liveStatus,
+    alert: (
+      <Alert
+        variant="danger"
+        className="rounded-none border-x-0 border-t-0 px-5 py-2.5"
+      >
+        <AlertTitle className="text-sm">
+          Complete these required fields to close the case:
+        </AlertTitle>
+        <ul className="list-disc ps-5 text-xs">
+          <li>IIR case number (IMPACT / Cority) — This field is required</li>
+          <li>Serious injury — This field is required</li>
+          <li>Permanent impairment — This field is required</li>
+          <li>Other recordable case — This field is required</li>
+        </ul>
+      </Alert>
+    ),
+  },
+};

--- a/src/components/CaseManagementHeader/CaseManagementHeader.test.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithTheme } from '../../test/test-utils';
+import { CaseManagementHeader, CaseContextBar } from './CaseManagementHeader';
+
+const caseInfo = {
+  caseNumber: 'S2025-0001',
+  status: 'Open',
+  caseType: 'Absence management',
+  daysOpen: 568,
+};
+
+const patient = { name: 'Eleanor Washburn', mrn: 'MR-004821' };
+
+const details = [
+  { label: 'Case Manager', value: 'Unassigned' },
+  { label: 'Opened', value: 'Jan 21, 2025' },
+];
+
+describe('CaseContextBar', () => {
+  it('renders case number, status, and type', () => {
+    renderWithTheme(<CaseContextBar caseInfo={caseInfo} />);
+    const caseNumber = screen.getByText('#S2025-0001');
+    expect(caseNumber).toBeInTheDocument();
+    expect(caseNumber).toHaveAttribute('title', 'Case# S2025-0001');
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Absence management')).toBeInTheDocument();
+  });
+
+  it('supports translated labels', () => {
+    renderWithTheme(
+      <CaseContextBar
+        caseInfo={caseInfo}
+        labels={{ caseNumberTooltip: (n) => `Fall Nr. ${n}` }}
+      />
+    );
+    expect(screen.getByText('#S2025-0001')).toHaveAttribute(
+      'title',
+      'Fall Nr. S2025-0001'
+    );
+  });
+});
+
+describe('CaseManagementHeader', () => {
+  it('renders patient name with MRN and DOB placeholder', () => {
+    renderWithTheme(
+      <CaseManagementHeader caseInfo={caseInfo} patient={patient} />
+    );
+    expect(screen.getByText('Eleanor Washburn')).toBeInTheDocument();
+    expect(screen.getByText('MRN: MR-004821')).toBeInTheDocument();
+    expect(screen.getByText('DOB: \u2014')).toBeInTheDocument();
+  });
+
+  it('hides details until the toggle is expanded', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        details={details}
+      />
+    );
+    expect(screen.queryByText('Case Manager')).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: 'Show case details' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(toggle);
+    expect(screen.getByText('Case Manager')).toBeInTheDocument();
+    expect(screen.getByText('Unassigned')).toBeInTheDocument();
+    // Built-in days-open item is appended to the grid.
+    expect(screen.getByText('Days Open')).toBeInTheDocument();
+    expect(screen.getByText('568')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Hide case details' })
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('computes days open from openedDate when daysOpen is omitted', async () => {
+    const user = userEvent.setup();
+    const opened = new Date(Date.now() - 3 * 86_400_000).toISOString();
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={{ caseNumber: 'X', status: 'Open', openedDate: opened }}
+        patient={patient}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Show case details' }));
+    expect(screen.getByText('Days Open')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('supports controlled expansion', async () => {
+    const user = userEvent.setup();
+    const onExpandedChange = vi.fn();
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        details={details}
+        expanded={false}
+        onExpandedChange={onExpandedChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Show case details' }));
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+    // Controlled: stays collapsed without a prop change.
+    expect(screen.queryByText('Case Manager')).not.toBeInTheDocument();
+  });
+
+  it('omits the toggle when there are no details', () => {
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={{ caseNumber: 'X', status: 'Open' }}
+        patient={patient}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Show case details' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onBack when the back button is clicked', async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        showBackButton
+        onBack={onBack}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Go back' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the context bar when showContextBar is false', () => {
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        showContextBar={false}
+      />
+    );
+    expect(screen.queryByTestId('case-context-bar')).not.toBeInTheDocument();
+  });
+
+  it('renders the alert slot', () => {
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        alert={<div role="alert">Complete these required fields</div>}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Complete these required fields'
+    );
+  });
+});

--- a/src/components/CaseManagementHeader/CaseManagementHeader.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.tsx
@@ -17,7 +17,7 @@ export interface CaseInfo {
   statusVariant?: BadgeProps['variant'];
   /** Case type, e.g. "Absence management" */
   caseType?: string;
-  /** Date the case was opened (ISO or parseable date string) */
+  /** Date the case was opened (ISO 8601 date/datetime string) */
   openedDate?: string;
   /** Days the case has been open; computed from `openedDate` when omitted */
   daysOpen?: number;
@@ -182,7 +182,7 @@ export const CaseContextBar = React.forwardRef<
             <span className="text-foreground text-sm">{caseInfo.caseType}</span>
           </>
         )}
-        <span className="ms-auto flex items-center gap-4">
+        <div className="ms-auto flex items-center gap-4">
           {editingUsers && editingUsers.length > 0 && (
             <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
               <UsersIcon size={14} aria-hidden="true" className="shrink-0" />
@@ -190,7 +190,7 @@ export const CaseContextBar = React.forwardRef<
             </span>
           )}
           {collabStatus}
-        </span>
+        </div>
       </div>
     );
   }

--- a/src/components/CaseManagementHeader/CaseManagementHeader.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.tsx
@@ -1,0 +1,430 @@
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+import { Badge, type BadgeProps } from '../Badge';
+import { Button } from '../Button';
+import { ArrowLeftIcon, ChevronDownIcon, UsersIcon } from '../Icons';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface CaseInfo {
+  /** Case number, e.g. "S2025-0001" (rendered with a leading #) */
+  caseNumber: string;
+  /** Status label, e.g. "Open" */
+  status: string;
+  /** Badge variant for the status pill (default: 'success') */
+  statusVariant?: BadgeProps['variant'];
+  /** Case type, e.g. "Absence management" */
+  caseType?: string;
+  /** Date the case was opened (ISO or parseable date string) */
+  openedDate?: string;
+  /** Days the case has been open; computed from `openedDate` when omitted */
+  daysOpen?: number;
+}
+
+export interface CasePatient {
+  /** Patient display name */
+  name: string;
+  /** Medical record number */
+  mrn?: string;
+  /** Date of birth (display string) */
+  dob?: string;
+}
+
+/** One label/value pair in the expandable case details grid */
+export interface CaseDetailItem {
+  label: string;
+  value: React.ReactNode;
+}
+
+/** Every user-facing string, so apps can translate the header */
+export interface CaseManagementHeaderLabels {
+  /** Tooltip on the case number, e.g. `Case# S2025-0001` */
+  caseNumberTooltip: (caseNumber: string) => string;
+  /** Label of the days-open item in the details grid, e.g. "Days Open" */
+  daysOpenTerm: string;
+  /** MRN field label */
+  mrn: string;
+  /** DOB field label */
+  dob: string;
+  /** Accessible name of the back button */
+  back: string;
+  /** Accessible name of the details toggle while collapsed */
+  expandDetails: string;
+  /** Accessible name of the details toggle while expanded */
+  collapseDetails: string;
+  /** Summary of who else is editing, e.g. `Ann, Bo are editing` */
+  editing: (names: string[]) => string;
+  /** Placeholder for missing values, e.g. "—" */
+  emptyValue: string;
+}
+
+export const defaultCaseManagementHeaderLabels: CaseManagementHeaderLabels = {
+  caseNumberTooltip: (caseNumber) => `Case# ${caseNumber}`,
+  daysOpenTerm: 'Days Open',
+  mrn: 'MRN',
+  dob: 'DOB',
+  back: 'Go back',
+  expandDetails: 'Show case details',
+  collapseDetails: 'Hide case details',
+  editing: (names) =>
+    `${names.join(', ')} ${names.length === 1 ? 'is' : 'are'} editing`,
+  emptyValue: '\u2014',
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const MS_PER_DAY = 86_400_000;
+
+function computeDaysOpen(openedDate?: string): number | null {
+  if (!openedDate) return null;
+  const opened = Date.parse(openedDate);
+  if (Number.isNaN(opened)) return null;
+  return Math.max(0, Math.floor((Date.now() - opened) / MS_PER_DAY));
+}
+
+/** Thin vertical divider used between context bar segments */
+function BarDivider() {
+  return <span aria-hidden="true" className="bg-border h-4 w-px shrink-0" />;
+}
+
+// =============================================================================
+// CaseContextBar
+// =============================================================================
+
+export interface CaseContextBarProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'className'
+> {
+  /** Case identity shown on the bar */
+  caseInfo: CaseInfo;
+  /** Whether to show the back button (default: false) */
+  showBackButton?: boolean;
+  /** Called when the back button is clicked */
+  onBack?: () => void;
+  /** Names of other users currently editing the case */
+  editingUsers?: string[];
+  /** Slot for a live-collaboration indicator, e.g. `<CollabStatus />` */
+  collabStatus?: React.ReactNode;
+  /** Overrides for any user-facing string */
+  labels?: Partial<CaseManagementHeaderLabels>;
+  /** Additional CSS classes */
+  className?: string;
+  /** Test ID for testing */
+  'data-testid'?: string;
+}
+
+/**
+ * Persistent case context strip: case number, status, type, days open, and an
+ * optional live-collaboration slot. Rendered on top of
+ * {@link CaseManagementHeader}, but exported standalone so apps can pin case
+ * context to other pages.
+ */
+export const CaseContextBar = React.forwardRef<
+  HTMLDivElement,
+  CaseContextBarProps
+>(
+  (
+    {
+      caseInfo,
+      showBackButton = false,
+      onBack,
+      editingUsers,
+      collabStatus,
+      labels,
+      className,
+      'data-testid': testId = 'case-context-bar',
+      ...props
+    },
+    ref
+  ) => {
+    const l = { ...defaultCaseManagementHeaderLabels, ...labels };
+
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        data-slot="case-context-bar"
+        className={cn(
+          'bg-primary-50 dark:bg-primary-950',
+          'flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-1.5',
+          className
+        )}
+        {...props}
+      >
+        {showBackButton && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onBack}
+            disabled={!onBack}
+            aria-label={l.back}
+            className="-ms-2 h-6 w-6 shrink-0"
+          >
+            <ArrowLeftIcon size={16} />
+          </Button>
+        )}
+        <span
+          title={l.caseNumberTooltip(caseInfo.caseNumber)}
+          className="text-foreground text-sm font-bold whitespace-nowrap"
+        >
+          #{caseInfo.caseNumber}
+        </span>
+        <Badge variant={caseInfo.statusVariant ?? 'success'} size="sm">
+          {caseInfo.status}
+        </Badge>
+        {caseInfo.caseType && (
+          <>
+            <BarDivider />
+            <span className="text-foreground text-sm">{caseInfo.caseType}</span>
+          </>
+        )}
+        <span className="ms-auto flex items-center gap-4">
+          {editingUsers && editingUsers.length > 0 && (
+            <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <UsersIcon size={14} aria-hidden="true" className="shrink-0" />
+              {l.editing(editingUsers)}
+            </span>
+          )}
+          {collabStatus}
+        </span>
+      </div>
+    );
+  }
+);
+
+CaseContextBar.displayName = 'CaseContextBar';
+
+// =============================================================================
+// CaseManagementHeader
+// =============================================================================
+
+export interface CaseManagementHeaderProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'className'
+> {
+  /** Case identity shown on the context bar */
+  caseInfo: CaseInfo;
+  /** Patient the case belongs to */
+  patient: CasePatient;
+  /** Label/value pairs shown in the expandable details section */
+  details?: CaseDetailItem[];
+  /** Stick to top of viewport */
+  sticky?: boolean;
+  /** Whether to show the back button (default: false) */
+  showBackButton?: boolean;
+  /** Called when the back button is clicked */
+  onBack?: () => void;
+  /** Slot for action buttons on the right, e.g. "Add Case Note" */
+  actions?: React.ReactNode;
+  /** Names of other users currently editing the case, shown on the context bar */
+  editingUsers?: string[];
+  /** Slot for a live-collaboration indicator on the context bar */
+  collabStatus?: React.ReactNode;
+  /**
+   * Slot for an alert attached to the bottom of the header, e.g. an
+   * `<Alert variant="danger">` listing required fields blocking case close.
+   */
+  alert?: React.ReactNode;
+  /** Whether to render the case context bar (default: true) */
+  showContextBar?: boolean;
+  /** Initial expanded state of the details section (uncontrolled) */
+  defaultExpanded?: boolean;
+  /** Controlled expanded state of the details section */
+  expanded?: boolean;
+  /** Called when the details toggle is clicked */
+  onExpandedChange?: (expanded: boolean) => void;
+  /** Overrides for any user-facing string */
+  labels?: Partial<CaseManagementHeaderLabels>;
+  /** Additional CSS classes */
+  className?: string;
+  /** Test ID for testing */
+  'data-testid'?: string;
+}
+
+/**
+ * A case management header: a persistent {@link CaseContextBar} (case number,
+ * status, type, days open, live status) over a patient identity row with an
+ * actions slot and an expandable case details grid.
+ *
+ * Reuses existing components: `Badge`, `Button`, and icons from
+ * `Icons/`.
+ *
+ * @example
+ * ```tsx
+ * <CaseManagementHeader
+ *   caseInfo={{
+ *     caseNumber: 'S2025-0001',
+ *     status: 'Open',
+ *     caseType: 'Absence management',
+ *     openedDate: '2025-01-21',
+ *   }}
+ *   patient={{ name: 'Eleanor Washburn' }}
+ *   details={[
+ *     { label: 'Case Manager', value: 'Unassigned' },
+ *     { label: 'Opened', value: 'Jan 21, 2025' },
+ *   ]}
+ *   actions={<Button variant="ghost">+ Add Case Note</Button>}
+ * />
+ * ```
+ */
+export const CaseManagementHeader = React.forwardRef<
+  HTMLDivElement,
+  CaseManagementHeaderProps
+>(
+  (
+    {
+      caseInfo,
+      patient,
+      details = [],
+      sticky = false,
+      showBackButton = false,
+      onBack,
+      actions,
+      editingUsers,
+      collabStatus,
+      alert,
+      showContextBar = true,
+      defaultExpanded = false,
+      expanded,
+      onExpandedChange,
+      labels,
+      className,
+      'data-testid': testId = 'case-management-header',
+      ...props
+    },
+    ref
+  ) => {
+    const l = { ...defaultCaseManagementHeaderLabels, ...labels };
+
+    // Expanded state: uncontrolled with `defaultExpanded`, or controlled
+    // via `expanded` + `onExpandedChange`.
+    const [internalExpanded, setInternalExpanded] =
+      React.useState(defaultExpanded);
+    const isExpanded = expanded ?? internalExpanded;
+    const detailsId = React.useId();
+
+    // Built-in days-open item, appended after the consumer's details.
+    const days = caseInfo.daysOpen ?? computeDaysOpen(caseInfo.openedDate);
+    const allDetails: CaseDetailItem[] =
+      days != null
+        ? [...details, { label: l.daysOpenTerm, value: days }]
+        : details;
+    const hasDetails = allDetails.length > 0;
+
+    const toggleExpanded = () => {
+      const next = !isExpanded;
+      if (expanded === undefined) setInternalExpanded(next);
+      onExpandedChange?.(next);
+    };
+
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        data-slot="case-management-header"
+        className={cn('w-full', sticky && 'sticky top-0 z-40', className)}
+        {...props}
+      >
+        <div
+          className={cn(
+            'border-border bg-card text-card-foreground border-b',
+            'transition-colors duration-200'
+          )}
+        >
+          {showContextBar && (
+            <CaseContextBar
+              caseInfo={caseInfo}
+              showBackButton={showBackButton}
+              onBack={onBack}
+              editingUsers={editingUsers}
+              collabStatus={collabStatus}
+              labels={labels}
+            />
+          )}
+
+          {/* ─── Patient identity row + expandable details ─── */}
+          <div className="flex items-center gap-3 px-5 py-3">
+            {/* Back button lives on the context bar; keep it here as a
+                fallback when the bar is hidden. */}
+            {!showContextBar && showBackButton && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onBack}
+                disabled={!onBack}
+                aria-label={l.back}
+                className="-ms-2 h-8 w-8 shrink-0"
+              >
+                <ArrowLeftIcon size={18} />
+              </Button>
+            )}
+
+            {/* Name + inline MRN/DOB */}
+            <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-4 gap-y-0.5">
+              <h2 className="text-foreground min-w-0 truncate text-xl font-bold">
+                {patient.name}
+              </h2>
+              <span className="text-muted-foreground text-sm whitespace-nowrap">
+                {l.mrn}: {patient.mrn ?? l.emptyValue}
+              </span>
+              <span className="text-muted-foreground text-sm whitespace-nowrap">
+                {l.dob}: {patient.dob ?? l.emptyValue}
+              </span>
+            </div>
+
+            {actions && (
+              <div className="flex shrink-0 items-center gap-2">{actions}</div>
+            )}
+
+            {hasDetails && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={toggleExpanded}
+                aria-label={isExpanded ? l.collapseDetails : l.expandDetails}
+                aria-expanded={isExpanded}
+                aria-controls={detailsId}
+                className="text-primary-600 dark:text-primary-400 h-8 w-8 shrink-0"
+              >
+                <ChevronDownIcon
+                  size={18}
+                  className={cn(
+                    'transition-transform duration-200',
+                    isExpanded && 'rotate-180'
+                  )}
+                />
+              </Button>
+            )}
+          </div>
+
+          {/* ─── Expandable case details grid ─── */}
+          {hasDetails && isExpanded && (
+            <dl
+              id={detailsId}
+              data-slot="case-details"
+              className="flex flex-wrap gap-x-10 gap-y-3 px-5 pb-4"
+            >
+              {allDetails.map((item) => (
+                <div key={item.label} className="min-w-0">
+                  <dt className="text-foreground/70 text-[11px] font-medium">
+                    {item.label}
+                  </dt>
+                  <dd className="text-foreground text-sm">{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </div>
+
+        {/* ─── Alert slot flush below the header border ─── */}
+        {alert && <div data-slot="case-header-alert">{alert}</div>}
+      </div>
+    );
+  }
+);
+
+CaseManagementHeader.displayName = 'CaseManagementHeader';

--- a/src/components/CaseManagementHeader/index.ts
+++ b/src/components/CaseManagementHeader/index.ts
@@ -1,0 +1,11 @@
+export {
+  CaseManagementHeader,
+  CaseContextBar,
+  defaultCaseManagementHeaderLabels,
+  type CaseManagementHeaderProps,
+  type CaseContextBarProps,
+  type CaseManagementHeaderLabels,
+  type CaseInfo,
+  type CasePatient,
+  type CaseDetailItem,
+} from './CaseManagementHeader';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './components/BusinessHoursEditor';
 export * from './components/Button';
 export * from './components/ButtonGroup';
 export * from './components/Card';
+export * from './components/CaseManagementHeader';
 export * from './components/Checkbox';
 // CodeLookup itself ships a module worker and is NOT exported here (apps import
 // it from their own bundler). Only its worker-free provider/context is safe to

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -10,6 +10,9 @@ module.exports = {
   // Safelist classes used by @mieweb/ui components that may not be detected
   // when components are imported from node_modules (especially with Tailwind CSS 4)
   safelist: [
+    // CaseManagementHeader — logical spacing, details grid:
+    '-ms-2',
+    'gap-x-10',
     // Semantic colors
     'border-border',
     'border-input',

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -39,6 +39,9 @@
  * @deprecated For Tailwind CSS 4 users — use the `@source` directive instead.
  */
 export const miewebUISafelist = [
+  // CaseManagementHeader — logical spacing, details grid:
+  '-ms-2',
+  'gap-x-10',
   // PatientHeader showCountBadges={false} — hides CountBadge roots in the
   // actions slot (ui#367):
   '[&_[data-slot=count-badge-root]]:hidden',


### PR DESCRIPTION

<img width="1600" height="148" alt="image" src="https://github.com/user-attachments/assets/22f6de84-1864-4344-a767-7017e4cae8fa" />

<img width="1600" height="148" alt="image" src="https://github.com/user-attachments/assets/c6a8f4c5-a0d6-4be1-86dd-a0f1946feb3b" />

<img width="1601" height="376" alt="image" src="https://github.com/user-attachments/assets/a0a95db0-169e-42bf-9891-8af81efd2e0e" />

Case management header composed of a persistent CaseContextBar (back button, case number with tooltip, status badge, case type, editing users, live-collab slot) over a patient identity row with an actions slot, an expandable case details grid with built-in days-open, and an alert slot rendered flush below the header border.

- CaseContextBar also exported standalone for pinning case context
- Fully translatable via labels overrides
- Stories: Default, Expanded, ExplicitDaysOpen, ContextBarOnly, WithoutContextBar, WithAlert (with responsive icon-only actions)
- 10 unit tests; safelist entries added to both Tailwind presets