### PR TITLE
feat(case-management-header): built-in actions, age next to DOB, hori…

### DIFF
--- a/src/components/CaseManagementHeader/CaseManagementHeader.stories.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.stories.tsx
@@ -6,10 +6,8 @@ import {
   type CasePatient,
   type CaseDetailItem,
 } from './CaseManagementHeader';
-import { Button } from '../Button';
 import { CollabStatus } from '../CollabStatus';
 import { Alert, AlertTitle } from '../Alert';
-import { PlusIcon, FilePlusIcon, CheckCircleIcon } from '../Icons';
 
 const meta: Meta<typeof CaseManagementHeader> = {
   title: 'Components/Text & Data Display/CaseManagementHeader',
@@ -31,6 +29,8 @@ const meta: Meta<typeof CaseManagementHeader> = {
     collabStatus: { table: { disable: true } },
     alert: { table: { disable: true } },
     onBack: { action: 'back-clicked' },
+    onAddCaseNote: { action: 'add-case-note' },
+    onCloseCase: { action: 'close-case' },
     onExpandedChange: { action: 'expanded-changed' },
   },
 };
@@ -68,6 +68,7 @@ const richPatient: CasePatient = {
   name: 'Lisa Ryan',
   mrn: 'MR-004821',
   dob: '03/18/1978',
+  age: 48,
 };
 
 const richDetails: CaseDetailItem[] = [
@@ -76,47 +77,6 @@ const richDetails: CaseDetailItem[] = [
   { label: 'Follow-up', value: '11/16/2025' },
   { label: 'Disability Date', value: '11/04/2025' },
 ];
-
-/**
- * Desktop buttons are unchanged; below `md` (768px) they swap for icon-only
- * equivalents (a +doc icon, and a check — not an X, which implies delete).
- */
-const addCaseNoteAction = (
-  <>
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label="Add Case Note"
-      className="h-8 w-8 md:hidden"
-    >
-      <FilePlusIcon size={16} />
-    </Button>
-    <Button
-      variant="ghost"
-      size="sm"
-      leftIcon={<PlusIcon size={16} />}
-      className="hidden md:inline-flex"
-    >
-      Add Case Note
-    </Button>
-  </>
-);
-
-const closeCaseAction = (
-  <>
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label="Close Case"
-      className="h-8 w-8 md:hidden"
-    >
-      <CheckCircleIcon size={16} />
-    </Button>
-    <Button variant="ghost" size="sm" className="hidden md:inline-flex">
-      Close Case
-    </Button>
-  </>
-);
 
 const liveStatus = <CollabStatus connected showLog={false} />;
 
@@ -131,13 +91,13 @@ export const Default: Story = {
     patient: samplePatient,
     details: sampleDetails,
     showBackButton: true,
-    actions: addCaseNoteAction,
+    onAddCaseNote: () => {},
     editingUsers,
     collabStatus: liveStatus,
   },
 };
 
-/** Expanded details grid with multiple actions (POC layout). */
+/** Expanded details grid with the built-in actions (POC layout). */
 export const Expanded: Story = {
   args: {
     caseInfo: richCase,
@@ -145,12 +105,8 @@ export const Expanded: Story = {
     details: richDetails,
     showBackButton: true,
     defaultExpanded: true,
-    actions: (
-      <>
-        {addCaseNoteAction}
-        {closeCaseAction}
-      </>
-    ),
+    onAddCaseNote: () => {},
+    onCloseCase: () => {},
     editingUsers,
     collabStatus: liveStatus,
   },
@@ -164,7 +120,7 @@ export const ExplicitDaysOpen: Story = {
     details: sampleDetails,
     showBackButton: true,
     defaultExpanded: true,
-    actions: addCaseNoteAction,
+    onAddCaseNote: () => {},
     collabStatus: liveStatus,
   },
 };
@@ -188,7 +144,7 @@ export const WithoutContextBar: Story = {
     details: richDetails,
     showContextBar: false,
     showBackButton: true,
-    actions: addCaseNoteAction,
+    onAddCaseNote: () => {},
   },
 };
 
@@ -200,12 +156,8 @@ export const WithAlert: Story = {
     details: richDetails,
     showBackButton: true,
     defaultExpanded: true,
-    actions: (
-      <>
-        {addCaseNoteAction}
-        {closeCaseAction}
-      </>
-    ),
+    onAddCaseNote: () => {},
+    onCloseCase: () => {},
     editingUsers,
     collabStatus: liveStatus,
     alert: (

--- a/src/components/CaseManagementHeader/CaseManagementHeader.stories.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 import {
   CaseManagementHeader,
   CaseContextBar,
@@ -29,8 +30,9 @@ const meta: Meta<typeof CaseManagementHeader> = {
     collabStatus: { table: { disable: true } },
     alert: { table: { disable: true } },
     onBack: { action: 'back-clicked' },
-    onAddCaseNote: { action: 'add-case-note' },
-    onCloseCase: { action: 'close-case' },
+    // onAddCaseNote / onCloseCase gate whether the built-in buttons render,
+    // so stories opt in with `fn()` args instead of an argTypes action (which
+    // would inject handlers into every story).
     onExpandedChange: { action: 'expanded-changed' },
   },
 };
@@ -91,7 +93,7 @@ export const Default: Story = {
     patient: samplePatient,
     details: sampleDetails,
     showBackButton: true,
-    onAddCaseNote: () => {},
+    onAddCaseNote: fn(),
     editingUsers,
     collabStatus: liveStatus,
   },
@@ -105,8 +107,8 @@ export const Expanded: Story = {
     details: richDetails,
     showBackButton: true,
     defaultExpanded: true,
-    onAddCaseNote: () => {},
-    onCloseCase: () => {},
+    onAddCaseNote: fn(),
+    onCloseCase: fn(),
     editingUsers,
     collabStatus: liveStatus,
   },
@@ -120,7 +122,7 @@ export const ExplicitDaysOpen: Story = {
     details: sampleDetails,
     showBackButton: true,
     defaultExpanded: true,
-    onAddCaseNote: () => {},
+    onAddCaseNote: fn(),
     collabStatus: liveStatus,
   },
 };
@@ -144,7 +146,7 @@ export const WithoutContextBar: Story = {
     details: richDetails,
     showContextBar: false,
     showBackButton: true,
-    onAddCaseNote: () => {},
+    onAddCaseNote: fn(),
   },
 };
 
@@ -156,8 +158,8 @@ export const WithAlert: Story = {
     details: richDetails,
     showBackButton: true,
     defaultExpanded: true,
-    onAddCaseNote: () => {},
-    onCloseCase: () => {},
+    onAddCaseNote: fn(),
+    onCloseCase: fn(),
     editingUsers,
     collabStatus: liveStatus,
     alert: (

--- a/src/components/CaseManagementHeader/CaseManagementHeader.test.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.test.tsx
@@ -205,7 +205,8 @@ describe('CaseManagementHeader', () => {
     expect(onAddCaseNote).toHaveBeenCalledTimes(2);
 
     await user.click(closeButtons[0]);
-    expect(onCloseCase).toHaveBeenCalledTimes(1);
+    await user.click(closeButtons[1]);
+    expect(onCloseCase).toHaveBeenCalledTimes(2);
   });
 
   it('supports translated labels for the built-in actions', () => {

--- a/src/components/CaseManagementHeader/CaseManagementHeader.test.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.test.tsx
@@ -159,4 +159,66 @@ describe('CaseManagementHeader', () => {
       'Complete these required fields'
     );
   });
+
+  it('renders age next to the DOB when provided', () => {
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={{ ...patient, dob: '03/18/1978', age: 48 }}
+      />
+    );
+    expect(screen.getByText('DOB: 03/18/1978 (48 y.o.)')).toBeInTheDocument();
+  });
+
+  it('wraps actions in a ButtonGroup', () => {
+    const { container } = renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        actions={<button>Custom Action</button>}
+      />
+    );
+    const group = container.querySelector('[data-slot="button-group"]');
+    expect(group).toHaveTextContent('Custom Action');
+  });
+
+  it('renders built-in actions with mobile twins and fires their callbacks', async () => {
+    const user = userEvent.setup();
+    const onAddCaseNote = vi.fn();
+    const onCloseCase = vi.fn();
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        onAddCaseNote={onAddCaseNote}
+        onCloseCase={onCloseCase}
+      />
+    );
+    // Each action ships a desktop text button plus an icon-only mobile twin.
+    const addButtons = screen.getAllByRole('button', { name: 'Add Case Note' });
+    const closeButtons = screen.getAllByRole('button', { name: 'Close Case' });
+    expect(addButtons).toHaveLength(2);
+    expect(closeButtons).toHaveLength(2);
+
+    await user.click(addButtons[0]);
+    await user.click(addButtons[1]);
+    expect(onAddCaseNote).toHaveBeenCalledTimes(2);
+
+    await user.click(closeButtons[0]);
+    expect(onCloseCase).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports translated labels for the built-in actions', () => {
+    renderWithTheme(
+      <CaseManagementHeader
+        caseInfo={caseInfo}
+        patient={patient}
+        onAddCaseNote={() => {}}
+        labels={{ addCaseNote: 'Notiz hinzuf\u00fcgen' }}
+      />
+    );
+    expect(
+      screen.getAllByRole('button', { name: 'Notiz hinzuf\u00fcgen' })
+    ).toHaveLength(2);
+  });
 });

--- a/src/components/CaseManagementHeader/CaseManagementHeader.tsx
+++ b/src/components/CaseManagementHeader/CaseManagementHeader.tsx
@@ -2,7 +2,15 @@ import * as React from 'react';
 import { cn } from '../../utils/cn';
 import { Badge, type BadgeProps } from '../Badge';
 import { Button } from '../Button';
-import { ArrowLeftIcon, ChevronDownIcon, UsersIcon } from '../Icons';
+import { ButtonGroup } from '../ButtonGroup';
+import {
+  ArrowLeftIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  FilePlusIcon,
+  PlusIcon,
+  UsersIcon,
+} from '../Icons';
 
 // =============================================================================
 // Types
@@ -30,6 +38,8 @@ export interface CasePatient {
   mrn?: string;
   /** Date of birth (display string) */
   dob?: string;
+  /** Age shown next to the DOB, e.g. 48 */
+  age?: number | string;
 }
 
 /** One label/value pair in the expandable case details grid */
@@ -48,6 +58,12 @@ export interface CaseManagementHeaderLabels {
   mrn: string;
   /** DOB field label */
   dob: string;
+  /** Age rendered next to the DOB, e.g. `(48 y.o.)` */
+  formatAge: (age: number | string) => string;
+  /** Label of the built-in add-case-note action */
+  addCaseNote: string;
+  /** Label of the built-in close-case action */
+  closeCase: string;
   /** Accessible name of the back button */
   back: string;
   /** Accessible name of the details toggle while collapsed */
@@ -65,6 +81,9 @@ export const defaultCaseManagementHeaderLabels: CaseManagementHeaderLabels = {
   daysOpenTerm: 'Days Open',
   mrn: 'MRN',
   dob: 'DOB',
+  formatAge: (age) => `(${age} y.o.)`,
+  addCaseNote: 'Add Case Note',
+  closeCase: 'Close Case',
   back: 'Go back',
   expandDetails: 'Show case details',
   collapseDetails: 'Hide case details',
@@ -89,6 +108,45 @@ function computeDaysOpen(openedDate?: string): number | null {
 /** Thin vertical divider used between context bar segments */
 function BarDivider() {
   return <span aria-hidden="true" className="bg-border h-4 w-px shrink-0" />;
+}
+
+/**
+ * Standard header action: a text button on `md`+ screens that swaps for an
+ * icon-only equivalent below `md`.
+ */
+function HeaderActionButton({
+  label,
+  mobileIcon,
+  desktopLeftIcon,
+  onClick,
+}: {
+  label: string;
+  mobileIcon: React.ReactNode;
+  desktopLeftIcon?: React.ReactElement;
+  onClick?: () => void;
+}) {
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onClick}
+        aria-label={label}
+        className="h-8 w-8 md:hidden"
+      >
+        {mobileIcon}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onClick}
+        leftIcon={desktopLeftIcon}
+        className="hidden md:inline-flex"
+      >
+        {label}
+      </Button>
+    </>
+  );
 }
 
 // =============================================================================
@@ -218,7 +276,17 @@ export interface CaseManagementHeaderProps extends Omit<
   showBackButton?: boolean;
   /** Called when the back button is clicked */
   onBack?: () => void;
-  /** Slot for action buttons on the right, e.g. "Add Case Note" */
+  /**
+   * Renders the built-in "Add Case Note" action (text button on `md`+, an
+   * icon-only button below) and is called when it is clicked.
+   */
+  onAddCaseNote?: () => void;
+  /**
+   * Renders the built-in "Close Case" action (text button on `md`+, an
+   * icon-only button below) and is called when it is clicked.
+   */
+  onCloseCase?: () => void;
+  /** Slot for extra action buttons, rendered after the built-in actions */
   actions?: React.ReactNode;
   /** Names of other users currently editing the case, shown on the context bar */
   editingUsers?: string[];
@@ -267,7 +335,7 @@ export interface CaseManagementHeaderProps extends Omit<
  *     { label: 'Case Manager', value: 'Unassigned' },
  *     { label: 'Opened', value: 'Jan 21, 2025' },
  *   ]}
- *   actions={<Button variant="ghost">+ Add Case Note</Button>}
+ *   onAddCaseNote={() => openNoteEditor()}
  * />
  * ```
  */
@@ -283,6 +351,8 @@ export const CaseManagementHeader = React.forwardRef<
       sticky = false,
       showBackButton = false,
       onBack,
+      onAddCaseNote,
+      onCloseCase,
       actions,
       editingUsers,
       collabStatus,
@@ -373,11 +443,34 @@ export const CaseManagementHeader = React.forwardRef<
               </span>
               <span className="text-muted-foreground text-sm whitespace-nowrap">
                 {l.dob}: {patient.dob ?? l.emptyValue}
+                {patient.age != null && ` ${l.formatAge(patient.age)}`}
               </span>
             </div>
 
-            {actions && (
-              <div className="flex shrink-0 items-center gap-2">{actions}</div>
+            {(onAddCaseNote || onCloseCase || actions) && (
+              // Horizontal always: long labels truncate (Button's built-in
+              // ellipsis) instead of stacking or starving the identity block.
+              <ButtonGroup
+                orientation="horizontal"
+                className="max-w-[60%] min-w-0 gap-2"
+              >
+                {onAddCaseNote && (
+                  <HeaderActionButton
+                    label={l.addCaseNote}
+                    mobileIcon={<FilePlusIcon size={16} />}
+                    desktopLeftIcon={<PlusIcon size={16} />}
+                    onClick={onAddCaseNote}
+                  />
+                )}
+                {onCloseCase && (
+                  <HeaderActionButton
+                    label={l.closeCase}
+                    mobileIcon={<CheckCircleIcon size={16} />}
+                    onClick={onCloseCase}
+                  />
+                )}
+                {actions}
+              </ButtonGroup>
             )}
 
             {hasDetails && (

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -10,9 +10,14 @@ module.exports = {
   // Safelist classes used by @mieweb/ui components that may not be detected
   // when components are imported from node_modules (especially with Tailwind CSS 4)
   safelist: [
-    // CaseManagementHeader — logical spacing, details grid:
+    // CaseManagementHeader — logical spacing, details grid, responsive
+    // built-in actions (icon-only below md):
     '-ms-2',
     'gap-x-10',
+    'hidden',
+    'max-w-[60%]',
+    'md:hidden',
+    'md:inline-flex',
     // Semantic colors
     'border-border',
     'border-input',
@@ -157,7 +162,8 @@ module.exports = {
           foreground: 'var(--mieweb-muted-foreground, hsl(215.4 16.3% 46.9%))',
         },
         destructive: {
-          DEFAULT: 'var(--mieweb-destructive, var(--mieweb-destructive-500, hsl(0 72.2% 50.6%)))',
+          DEFAULT:
+            'var(--mieweb-destructive, var(--mieweb-destructive-500, hsl(0 72.2% 50.6%)))',
           foreground: 'var(--mieweb-destructive-foreground, hsl(210 40% 98%))',
         },
         success: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -39,9 +39,14 @@
  * @deprecated For Tailwind CSS 4 users — use the `@source` directive instead.
  */
 export const miewebUISafelist = [
-  // CaseManagementHeader — logical spacing, details grid:
+  // CaseManagementHeader — logical spacing, details grid, responsive
+  // built-in actions (icon-only below md):
   '-ms-2',
   'gap-x-10',
+  'hidden',
+  'max-w-[60%]',
+  'md:hidden',
+  'md:inline-flex',
   // PatientHeader showCountBadges={false} — hides CountBadge roots in the
   // actions slot (ui#367):
   '[&_[data-slot=count-badge-root]]:hidden',


### PR DESCRIPTION
…zontal ButtonGroup

- Add patient.age, rendered next to the DOB via a translatable formatAge label
- Ship built-in Add Case Note / Close Case actions (onAddCaseNote/onCloseCase) with icon-only mobile twins below md; labels translatable
- Wrap actions in a horizontal ButtonGroup capped at 60% so long labels truncate instead of wrapping or starving the patient identity block
- Safelist hidden, md:hidden, md:inline-flex, max-w-[60%] in both presets