### PR TITLE
feat: add CountryDropdown (country-only variant of CountryCodeDropdown)

### DIFF
--- a/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
+++ b/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
@@ -41,6 +41,8 @@ export interface CountryCodeDropdownProps {
   placement?: 'bottom-start' | 'bottom-end';
   /** Placeholder text for the search field */
   searchPlaceholder?: string;
+  /** id for the trigger button, enabling `<label htmlFor>` association */
+  id?: string;
   /** Label for accessibility — visually hidden */
   'aria-label'?: string;
 }
@@ -174,6 +176,7 @@ function CountryDropdownBase({
   className,
   placement = 'bottom-start',
   searchPlaceholder = 'Search countries…',
+  id,
   showDialCode = true,
   'aria-label': ariaLabel = 'Select country code',
 }: CountryDropdownBaseProps) {
@@ -306,6 +309,7 @@ function CountryDropdownBase({
       {/* Trigger button */}
       <button
         type="button"
+        id={id}
         data-slot="country-dropdown-trigger"
         onClick={handleToggle}
         disabled={disabled}

--- a/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
+++ b/src/components/CountryCodeDropdown/CountryCodeDropdown.tsx
@@ -157,34 +157,26 @@ export function formatE164(phoneNumber: string, countryCode: string): string {
 // Component
 // =============================================================================
 
+/** Internal base props — `showDialCode` is not part of the public API. */
+interface CountryDropdownBaseProps extends CountryCodeDropdownProps {
+  /** Show dial codes on the trigger and in the list (default: true) */
+  showDialCode?: boolean;
+}
+
 /**
- * A country-code selector dropdown designed to sit beside a phone number input.
- *
- * Defaults to United States (+1) with the 🇺🇸 flag. Clicking the trigger opens
- * a searchable list of all supported countries with their dial codes and flags.
- *
- * Uses Google's libphonenumber for the canonical country/code list and provides
- * a `validatePhoneNumber` helper for phone validation.
- *
- * @example
- * ```tsx
- * const [country, setCountry] = useState<CountryData>();
- *
- * <div className="flex gap-2">
- *   <CountryCodeDropdown value={country?.code} onChange={setCountry} />
- *   <Input placeholder="Phone number" />
- * </div>
- * ```
+ * Shared implementation behind {@link CountryCodeDropdown} (dial-code mode)
+ * and `CountryDropdown` (country-only mode). Not exported from the package.
  */
-function CountryCodeDropdown({
+function CountryDropdownBase({
   value,
   onChange,
   disabled = false,
   className,
   placement = 'bottom-start',
   searchPlaceholder = 'Search countries…',
+  showDialCode = true,
   'aria-label': ariaLabel = 'Select country code',
-}: CountryCodeDropdownProps) {
+}: CountryDropdownBaseProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
   const [internalValue, setInternalValue] = React.useState(value ?? 'US');
@@ -229,10 +221,10 @@ function CountryCodeDropdown({
     return countries.filter(
       (c) =>
         c.name.toLowerCase().includes(q) ||
-        c.dialCode.includes(q) ||
+        (showDialCode && c.dialCode.includes(q)) ||
         c.code.toLowerCase().includes(q)
     );
-  }, [search, countries]);
+  }, [search, countries, showDialCode]);
 
   // Close helpers
   const close = React.useCallback(() => {
@@ -338,7 +330,13 @@ function CountryCodeDropdown({
         >
           {selected.flag}
         </span>
-        <span data-slot="country-dropdown-dialcode">{selected.dialCode}</span>
+        {showDialCode ? (
+          <span data-slot="country-dropdown-dialcode">{selected.dialCode}</span>
+        ) : (
+          <span data-slot="country-dropdown-name" className="min-w-0 truncate">
+            {selected.name}
+          </span>
+        )}
         <svg
           data-slot="country-dropdown-chevron"
           className={cn(
@@ -441,12 +439,14 @@ function CountryCodeDropdown({
                     >
                       {country.name}
                     </span>
-                    <span
-                      data-slot="country-dropdown-option-dialcode"
-                      className="text-muted-foreground shrink-0 text-xs"
-                    >
-                      {country.dialCode}
-                    </span>
+                    {showDialCode && (
+                      <span
+                        data-slot="country-dropdown-option-dialcode"
+                        className="text-muted-foreground shrink-0 text-xs"
+                      >
+                        {country.dialCode}
+                      </span>
+                    )}
                   </button>
                 ))
               )}
@@ -458,6 +458,33 @@ function CountryCodeDropdown({
   );
 }
 
+CountryDropdownBase.displayName = 'CountryDropdownBase';
+
+/**
+ * A country-code selector dropdown designed to sit beside a phone number input.
+ *
+ * Defaults to United States (+1) with the 🇺🇸 flag. Clicking the trigger opens
+ * a searchable list of all supported countries with their dial codes and flags.
+ *
+ * Uses Google's libphonenumber for the canonical country/code list and provides
+ * a `validatePhoneNumber` helper for phone validation.
+ *
+ * For a country selector without dial codes, use `CountryDropdown`.
+ *
+ * @example
+ * ```tsx
+ * const [country, setCountry] = useState<CountryData>();
+ *
+ * <div className="flex gap-2">
+ *   <CountryCodeDropdown value={country?.code} onChange={setCountry} />
+ *   <Input placeholder="Phone number" />
+ * </div>
+ * ```
+ */
+function CountryCodeDropdown(props: CountryCodeDropdownProps) {
+  return <CountryDropdownBase {...props} />;
+}
+
 CountryCodeDropdown.displayName = 'CountryCodeDropdown';
 
-export { CountryCodeDropdown };
+export { CountryCodeDropdown, CountryDropdownBase };

--- a/src/components/CountryDropdown/CountryDropdown.stories.tsx
+++ b/src/components/CountryDropdown/CountryDropdown.stories.tsx
@@ -59,12 +59,16 @@ export const InAForm: Story = {
     return (
       <div style={{ width: '360px' }}>
         <label
-          htmlFor="country-dropdown-trigger"
+          htmlFor="country-select"
           className="text-foreground mb-1.5 block text-sm font-medium"
         >
           Country
         </label>
-        <CountryDropdown value={country?.code} onChange={setCountry} />
+        <CountryDropdown
+          id="country-select"
+          value={country?.code}
+          onChange={setCountry}
+        />
       </div>
     );
   },

--- a/src/components/CountryDropdown/CountryDropdown.stories.tsx
+++ b/src/components/CountryDropdown/CountryDropdown.stories.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CountryDropdown } from './CountryDropdown';
+import type { CountryData } from '../CountryCodeDropdown';
+
+const meta: Meta<typeof CountryDropdown> = {
+  title: 'Components/Forms & Inputs/CountryDropdown',
+  component: CountryDropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const PreselectedCountry: Story = {
+  args: {
+    value: 'GB',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const Controlled: Story = {
+  render: function ControlledExample() {
+    const [country, setCountry] = useState<CountryData>({
+      code: 'US',
+      name: 'United States',
+      dialCode: '+1',
+      flag: '🇺🇸',
+    });
+
+    return (
+      <div className="space-y-4">
+        <CountryDropdown value={country.code} onChange={setCountry} />
+        <div className="text-muted-foreground space-y-1 text-sm">
+          <p>Country: {country.name}</p>
+          <p>Code: {country.code}</p>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const InAForm: Story = {
+  render: function InAFormExample() {
+    const [country, setCountry] = useState<CountryData>();
+
+    return (
+      <div style={{ width: '360px' }}>
+        <label
+          htmlFor="country-dropdown-trigger"
+          className="text-foreground mb-1.5 block text-sm font-medium"
+        >
+          Country
+        </label>
+        <CountryDropdown value={country?.code} onChange={setCountry} />
+      </div>
+    );
+  },
+};

--- a/src/components/CountryDropdown/CountryDropdown.test.tsx
+++ b/src/components/CountryDropdown/CountryDropdown.test.tsx
@@ -30,6 +30,19 @@ describe('CountryDropdown', () => {
     );
   });
 
+  it('applies id to the trigger for label association', () => {
+    renderWithTheme(
+      <>
+        <label htmlFor="country-select">Country</label>
+        <CountryDropdown id="country-select" />
+      </>
+    );
+    expect(screen.getByLabelText('Country')).toHaveAttribute(
+      'data-slot',
+      'country-dropdown-trigger'
+    );
+  });
+
   it('does not match dial codes when searching', async () => {
     const user = userEvent.setup();
     renderWithTheme(<CountryDropdown />);

--- a/src/components/CountryDropdown/CountryDropdown.test.tsx
+++ b/src/components/CountryDropdown/CountryDropdown.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithTheme } from '../../test/test-utils';
+import { CountryDropdown } from './CountryDropdown';
+
+describe('CountryDropdown', () => {
+  it('shows the country name (not the dial code) on the trigger', () => {
+    renderWithTheme(<CountryDropdown value="GB" />);
+    const trigger = screen.getByRole('button', { name: 'Select country' });
+    expect(trigger).toHaveTextContent('United Kingdom');
+    expect(trigger).not.toHaveTextContent('+44');
+  });
+
+  it('lists countries without dial codes and fires onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithTheme(<CountryDropdown onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select country' }));
+    const listbox = screen.getByRole('listbox');
+    expect(
+      listbox.querySelector('[data-slot="country-dropdown-option-dialcode"]')
+    ).toBeNull();
+
+    await user.type(screen.getByLabelText('Search countries'), 'Germany');
+    await user.click(screen.getByRole('option', { name: /Germany/ }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'DE', name: 'Germany' })
+    );
+  });
+
+  it('does not match dial codes when searching', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<CountryDropdown />);
+
+    await user.click(screen.getByRole('button', { name: 'Select country' }));
+    await user.type(screen.getByLabelText('Search countries'), '+44');
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getByText('No countries found')).toBeInTheDocument();
+  });
+});

--- a/src/components/CountryDropdown/CountryDropdown.tsx
+++ b/src/components/CountryDropdown/CountryDropdown.tsx
@@ -1,0 +1,35 @@
+import {
+  CountryDropdownBase,
+  type CountryCodeDropdownProps,
+} from '../CountryCodeDropdown/CountryCodeDropdown';
+
+export type CountryDropdownProps = CountryCodeDropdownProps;
+
+/**
+ * A searchable country selector — {@link CountryCodeDropdown} without the
+ * dial codes. The trigger shows the flag and country name; the dropdown
+ * lists flag + name only.
+ *
+ * @example
+ * ```tsx
+ * const [country, setCountry] = useState<CountryData>();
+ *
+ * <CountryDropdown value={country?.code} onChange={setCountry} />
+ * ```
+ */
+function CountryDropdown({
+  'aria-label': ariaLabel = 'Select country',
+  ...props
+}: CountryDropdownProps) {
+  return (
+    <CountryDropdownBase
+      {...props}
+      aria-label={ariaLabel}
+      showDialCode={false}
+    />
+  );
+}
+
+CountryDropdown.displayName = 'CountryDropdown';
+
+export { CountryDropdown };

--- a/src/components/CountryDropdown/index.ts
+++ b/src/components/CountryDropdown/index.ts
@@ -1,0 +1,1 @@
+export { CountryDropdown, type CountryDropdownProps } from './CountryDropdown';

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export * from './components/CommandPalette';
 export * from './components/ConnectionStatus';
 export * from './components/CountBadge';
 export * from './components/CountryCodeDropdown';
+export * from './components/CountryDropdown';
 export * from './components/CookieConsent';
 export * from './components/CSVColumnMapper';
 export * from './components/DashboardWidget';


### PR DESCRIPTION
- Refactor CountryCodeDropdown into a shared CountryDropdownBase with an internal showDialCode flag; public API unchanged
- CountryDropdown shows flag + country name on the trigger, lists flag + name only, and excludes dial codes from search matching
- Stories (Default, Preselected, Disabled, Controlled, InAForm) and tests