### PR TITLE
docs(Autocomplete): add Live Wikipedia story demonstrating a real remote API

### DIFF
--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Autocomplete } from './Autocomplete';
 
@@ -297,8 +297,9 @@ interface WikiArticle {
 
 /**
  * Pattern 2 against a real third-party API: Wikipedia's opensearch endpoint
- * (CORS-enabled via `origin=*`). Debounced 250ms, previous request aborted on
- * each keystroke.
+ * (CORS-enabled via `origin=*`). Debounced 250ms; each keystroke aborts the
+ * previous request, and responses are ignored unless they belong to the
+ * current request.
  */
 function LiveWikipediaExample() {
   const [items, setItems] = useState<WikiArticle[]>([]);
@@ -308,6 +309,14 @@ function LiveWikipediaExample() {
     undefined
   );
   const abortRef = useRef<AbortController | undefined>(undefined);
+
+  // Cleanup on unmount: cancel the pending debounce and in-flight request.
+  useEffect(() => {
+    return () => {
+      clearTimeout(debounceTimer.current);
+      abortRef.current?.abort();
+    };
+  }, []);
 
   const search = (q: string) => {
     clearTimeout(debounceTimer.current);
@@ -326,12 +335,15 @@ function LiveWikipediaExample() {
           `https://en.wikipedia.org/w/api.php?action=opensearch&search=${encodeURIComponent(q)}&limit=8&format=json&origin=*`,
           { signal: ac.signal }
         );
+        if (!res.ok) throw new Error(`Wikipedia responded ${res.status}`);
         const [, titles, descriptions, urls] = (await res.json()) as [
           string,
           string[],
           string[],
           string[],
         ];
+        // Ignore stale responses: only the latest request may update state.
+        if (abortRef.current !== ac) return;
         setItems(
           titles.map((title, i) => ({
             title,
@@ -341,7 +353,10 @@ function LiveWikipediaExample() {
         );
         setLoading(false);
       } catch (err) {
-        if ((err as Error).name !== 'AbortError') setLoading(false);
+        if ((err as Error).name === 'AbortError') return;
+        if (abortRef.current !== ac) return;
+        setItems([]);
+        setLoading(false);
       }
     }, 250);
   };

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -78,7 +78,8 @@ import { Autocomplete } from '@mieweb/ui';
 
 **2. Remote / async source** — the list lives behind an API. **Omit \`filter\`**, listen
 to \`onValueChange\`, fetch, and re-render with the new \`items\`. Whatever you pass is
-shown as-is. (See *Async Source* story.)
+shown as-is. (See *Async Source* for the shape, and *Live Wikipedia* for a real
+third-party API with debounce + abort.)
 
 \`\`\`tsx
 const [items, setItems] = useState<Patient[]>([]);
@@ -283,6 +284,114 @@ export const AsyncSource: Story = {
       description: {
         story:
           'Pattern 2 — **remote/async source**. Omit `filter`; use `onValueChange` to query your API (debounce it in a real app) and re-render with the results as `items`. A loading state can be surfaced through `emptyMessage` while the request is in flight.',
+      },
+    },
+  },
+};
+
+interface WikiArticle {
+  title: string;
+  description: string;
+  url: string;
+}
+
+/**
+ * Pattern 2 against a real third-party API: Wikipedia's opensearch endpoint
+ * (CORS-enabled via `origin=*`). Debounced 250ms, previous request aborted on
+ * each keystroke.
+ */
+function LiveWikipediaExample() {
+  const [items, setItems] = useState<WikiArticle[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<WikiArticle | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const abortRef = useRef<AbortController | undefined>(undefined);
+
+  const search = (q: string) => {
+    clearTimeout(debounceTimer.current);
+    abortRef.current?.abort();
+    if (!q) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    debounceTimer.current = setTimeout(async () => {
+      const ac = new AbortController();
+      abortRef.current = ac;
+      try {
+        const res = await fetch(
+          `https://en.wikipedia.org/w/api.php?action=opensearch&search=${encodeURIComponent(q)}&limit=8&format=json&origin=*`,
+          { signal: ac.signal }
+        );
+        const [, titles, descriptions, urls] = (await res.json()) as [
+          string,
+          string[],
+          string[],
+          string[],
+        ];
+        setItems(
+          titles.map((title, i) => ({
+            title,
+            description: descriptions[i],
+            url: urls[i],
+          }))
+        );
+        setLoading(false);
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') setLoading(false);
+      }
+    }, 250);
+  };
+
+  return (
+    <div className="max-w-md space-y-3">
+      <Autocomplete<WikiArticle>
+        items={items}
+        getItemKey={(a) => a.url}
+        renderItem={(a) => (
+          <div className="flex flex-col">
+            <span className="font-medium">{a.title}</span>
+            {a.description && (
+              <span className="text-muted-foreground line-clamp-1 text-xs">
+                {a.description}
+              </span>
+            )}
+          </div>
+        )}
+        onSelect={setSelected}
+        onValueChange={search}
+        clearOnSelect={false}
+        placeholder="Search Wikipedia articles…"
+        emptyMessage={loading ? 'Searching Wikipedia…' : 'No articles found.'}
+        aria-label="Search Wikipedia articles"
+      />
+      {selected && (
+        <p className="text-muted-foreground text-sm">
+          Selected:{' '}
+          <a
+            href={selected.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline"
+          >
+            {selected.title}
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const LiveWikipedia: Story = {
+  render: () => <LiveWikipediaExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pattern 2 against a **real third-party API** — Wikipedia's [opensearch endpoint](https://www.mediawiki.org/wiki/API:Opensearch) (CORS-enabled via `origin=*`). Shows the full production recipe: **debounce** (250 ms) + **AbortController** so stale responses never land, loading state through `emptyMessage`. Requires internet access.",
       },
     },
   },


### PR DESCRIPTION
## Summary

Follow-up to #381. The Async Source story demonstrates the remote wiring pattern with a simulated `setTimeout` backend — this adds a **Live Wikipedia** story that hits a real third-party API, proving the pattern works cross-origin against production infrastructure and demonstrating the full production recipe.

## What changed

Docs-only change to `src/components/Autocomplete/Autocomplete.stories.tsx` (+110):

- **New `Live Wikipedia` story** — type-ahead against Wikipedia's [opensearch endpoint](https://www.mediawiki.org/wiki/API:Opensearch) (CORS-enabled via `origin=*`):
  - **250 ms debounce** before each request
  - **`AbortController`** cancels the in-flight request per keystroke, so stale responses never land
  - Loading state via `emptyMessage` ("Searching Wikipedia…")
  - Selected article renders as a working external link; `clearOnSelect={false}` keeps the query
- Wiring-patterns docs section cross-references the new story

## Notes

- Story requires internet access; it is **not** in the curated visual-regression list (`tests/visual/components.spec.ts`), so no snapshot flakiness
- No component code touched

## Verification

- `pnpm typecheck` ✅ / eslint ✅ / prettier ✅ / `pnpm vitest run src/components/Autocomplete` 7/7 ✅
- Verified live in Storybook: "electronic health rec" → debounced fetch → 8 real Wikipedia articles → selection renders link to https://en.wikipedia.org/wiki/Electronic_health_record