### PR TITLE
fix(storybook): import eSheet compiled CSS explicitly in stories

### DIFF
--- a/src/components/ESheet/EsheetBuilder.stories.tsx
+++ b/src/components/ESheet/EsheetBuilder.stories.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-// eSheet ≥0.0.6 no longer self-imports its compiled CSS (see eSheet PR #145);
+// eSheet no longer self-imports its compiled CSS (see mieweb/eSheet#145);
 // consumers load it explicitly. Path is relative because the @esheet aliases
 // in .storybook/main.ts only cover bare package specifiers.
 import '../../../packages/esheet/packages/builder/src/index.output.css';

--- a/src/components/ESheet/EsheetBuilder.stories.tsx
+++ b/src/components/ESheet/EsheetBuilder.stories.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+// eSheet ≥0.0.6 no longer self-imports its compiled CSS (see eSheet PR #145);
+// consumers load it explicitly. Path is relative because the @esheet aliases
+// in .storybook/main.ts only cover bare package specifiers.
+import '../../../packages/esheet/packages/builder/src/index.output.css';
 import {
   EsheetBuilder,
   registerMieEsheetFields,

--- a/src/components/ESheet/EsheetRenderer.stories.tsx
+++ b/src/components/ESheet/EsheetRenderer.stories.tsx
@@ -1,5 +1,9 @@
 import { useRef, useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+// eSheet ≥0.0.6 no longer self-imports its compiled CSS (see eSheet PR #145);
+// consumers load it explicitly. Path is relative because the @esheet aliases
+// in .storybook/main.ts only cover bare package specifiers.
+import '../../../packages/esheet/packages/renderer/src/index.output.css';
 import {
   EsheetRenderer,
   registerMieEsheetFields,

--- a/src/components/ESheet/EsheetRenderer.stories.tsx
+++ b/src/components/ESheet/EsheetRenderer.stories.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-// eSheet ≥0.0.6 no longer self-imports its compiled CSS (see eSheet PR #145);
+// eSheet no longer self-imports its compiled CSS (see mieweb/eSheet#145);
 // consumers load it explicitly. Path is relative because the @esheet aliases
 // in .storybook/main.ts only cover bare package specifiers.
 import '../../../packages/esheet/packages/renderer/src/index.output.css';


### PR DESCRIPTION
## Problem

The eSheet Builder/Renderer Storybook stories render completely unstyled when the `packages/esheet` submodule checkout is on a commit newer than the currently-pinned pointer.

## Root cause

- Storybook aliases `@esheet/*` to **submodule source** (`.storybook/main.ts`), so it never consumed the built packages.
- eSheet's Tailwind classes are `ms:`-prefixed and only exist in eSheet's compiled artifact (`src/index.output.css`) — this repo's Tailwind build cannot generate them.
- At the pinned submodule commit, every eSheet entrypoint side-effect-imported that CSS (`import './index.output.css'`), so styles came along for free.
- Upstream **eSheet PR mieweb/eSheet#145** (Nx→pnpm migration) removed those side-effect imports and changed the contract: consumers load the compiled CSS explicitly. Any submodule bump past that commit silently drops every `ms:` rule from Storybook.

## Fix

Import the compiled CSS explicitly in the two story files (with a comment documenting the contract). On the currently-pinned submodule commit this is a harmless duplicate import; once the pointer moves past #145 it is required.

## Verification

- `pnpm typecheck`, `eslint`, `prettier` — clean
- Verified live in Storybook with the submodule on latest `origin/main`: builder story fully styled again (2 stylesheets with `ms:` rules loaded, palette/canvas/edit panel render correctly)