### PR TITLE
feat(storybook): add configurable LiveDataExplorer story for Autocomplete

### DIFF
--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -411,3 +411,280 @@ export const LiveWikipedia: Story = {
     },
   },
 };
+
+// ---------------------------------------------------------------------------
+// Live Data Explorer — a configurable remote-source harness. Mirrors the
+// `autocomplete` field type in mieweb/eSheet (see mieweb/eSheet#162): the same
+// knobs (data source URL, results path, label/value keys, capture attributes)
+// are exposed here as Storybook controls so any JSON API can be tried live.
+// ---------------------------------------------------------------------------
+
+interface ExplorerItem {
+  label: string;
+  value: string;
+  raw?: Record<string, unknown>;
+}
+
+/** Walk a dot-path (e.g. `suggestionGroup.suggestionList.suggestion`) into an enveloped response. */
+function resolveResultsPath(data: unknown, path: string): unknown {
+  if (!path) return data;
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (acc, key) =>
+        acc && typeof acc === 'object'
+          ? (acc as Record<string, unknown>)[key]
+          : undefined,
+      data
+    );
+}
+
+/**
+ * Normalize the three common response shapes into `ExplorerItem`s:
+ * OpenSearch arrays (`[term, titles[], …]`), bare string arrays, and object
+ * arrays (using `labelKey`/`valueKey`, keeping the raw object for capture).
+ */
+function parseExplorerItems(
+  data: unknown,
+  labelKey: string,
+  valueKey: string
+): ExplorerItem[] {
+  if (
+    Array.isArray(data) &&
+    typeof data[0] === 'string' &&
+    Array.isArray(data[1])
+  ) {
+    // OpenSearch envelope: [query, titles[], descriptions[], urls[]]
+    return (data[1] as unknown[])
+      .filter((t): t is string => typeof t === 'string')
+      .map((t) => ({ label: t, value: t }));
+  }
+  if (!Array.isArray(data)) return [];
+  return data.flatMap((entry): ExplorerItem[] => {
+    if (typeof entry === 'string') return [{ label: entry, value: entry }];
+    if (entry && typeof entry === 'object') {
+      const obj = entry as Record<string, unknown>;
+      const label = obj[labelKey || 'label'];
+      if (label == null) return [];
+      const value = obj[valueKey || labelKey || 'label'] ?? label;
+      return [{ label: String(label), value: String(value), raw: obj }];
+    }
+    return [];
+  });
+}
+
+/** Copy the requested comma-separated keys from the selected raw object. */
+function captureAttributesFrom(
+  raw: Record<string, unknown> | undefined,
+  captureAttributes: string
+): Record<string, string> {
+  const captured: Record<string, string> = {};
+  if (!raw) return captured;
+  for (const key of captureAttributes
+    .split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)) {
+    const value = raw[key];
+    if (value != null) captured[key] = String(value);
+  }
+  return captured;
+}
+
+interface ExplorerArgs {
+  dataSourceUrl: string;
+  resultsPath: string;
+  labelKey: string;
+  valueKey: string;
+  captureAttributes: string;
+  minQueryLength: number;
+}
+
+function LiveExplorerExample({
+  dataSourceUrl,
+  resultsPath,
+  labelKey,
+  valueKey,
+  captureAttributes,
+  minQueryLength,
+}: ExplorerArgs) {
+  const [items, setItems] = useState<ExplorerItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<ExplorerItem | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const abortRef = useRef<AbortController | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(debounceTimer.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const search = (q: string) => {
+    clearTimeout(debounceTimer.current);
+    abortRef.current?.abort();
+    setError(null);
+    if (!dataSourceUrl.includes('{query}') || q.length < minQueryLength) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    debounceTimer.current = setTimeout(async () => {
+      const ac = new AbortController();
+      abortRef.current = ac;
+      try {
+        const res = await fetch(
+          dataSourceUrl.replace('{query}', encodeURIComponent(q)),
+          { signal: ac.signal }
+        );
+        if (!res.ok) throw new Error(`Server responded ${res.status}`);
+        const data: unknown = await res.json();
+        // Ignore stale responses: only the latest request may update state.
+        if (abortRef.current !== ac) return;
+        setItems(
+          parseExplorerItems(
+            resolveResultsPath(data, resultsPath.trim()),
+            labelKey.trim(),
+            valueKey.trim()
+          )
+        );
+        setLoading(false);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        if (abortRef.current !== ac) return;
+        setItems([]);
+        setError((err as Error).message);
+        setLoading(false);
+      }
+    }, 250);
+  };
+
+  const captured = captureAttributesFrom(selected?.raw, captureAttributes);
+
+  return (
+    <div className="max-w-md space-y-3">
+      <Autocomplete<ExplorerItem>
+        items={items}
+        getItemKey={(item) => `${item.value}::${item.label}`}
+        renderItem={(item) => (
+          <div className="flex flex-col">
+            <span className="font-medium">{item.label}</span>
+            {item.value !== item.label && (
+              <span className="text-muted-foreground line-clamp-1 text-xs">
+                {item.value}
+              </span>
+            )}
+          </div>
+        )}
+        onSelect={setSelected}
+        onValueChange={search}
+        clearOnSelect={false}
+        minQueryLength={minQueryLength}
+        placeholder="Start typing to search…"
+        emptyMessage={
+          error
+            ? `Request failed: ${error}`
+            : loading
+              ? 'Searching…'
+              : 'No results.'
+        }
+        aria-label="Live data explorer search"
+      />
+      {selected && (
+        <div className="text-muted-foreground space-y-1 text-sm">
+          <p>
+            Selected: <span className="text-foreground">{selected.label}</span>{' '}
+            <span className="text-xs">(value: {selected.value})</span>
+          </p>
+          {Object.keys(captured).length > 0 && (
+            <pre className="bg-muted overflow-auto rounded-lg p-2 text-xs">
+              {JSON.stringify({ attributes: captured }, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const LiveDataExplorer: StoryObj<ExplorerArgs> = {
+  args: {
+    dataSourceUrl:
+      'https://en.wikipedia.org/w/rest.php/v1/search/title?q={query}&limit=8',
+    resultsPath: 'pages',
+    labelKey: 'title',
+    valueKey: 'key',
+    captureAttributes: 'id, description',
+    minQueryLength: 2,
+  },
+  argTypes: {
+    dataSourceUrl: {
+      control: 'text',
+      description:
+        'Remote endpoint; `{query}` is replaced with the typed text.',
+    },
+    resultsPath: {
+      control: 'text',
+      description:
+        'Dot-path to the array inside an enveloped response. Empty when the response is the array itself.',
+    },
+    labelKey: {
+      control: 'text',
+      description: 'For object responses: key shown to the user.',
+    },
+    valueKey: {
+      control: 'text',
+      description:
+        'For object responses: key stored as the value. Defaults to the label key.',
+    },
+    captureAttributes: {
+      control: 'text',
+      description:
+        'Comma-separated keys copied from the selected object into the result.',
+    },
+    minQueryLength: {
+      control: { type: 'number', min: 0, max: 10 },
+      description: 'Minimum characters before fetching.',
+    },
+  },
+  render: (args) => <LiveExplorerExample {...args} />,
+  parameters: {
+    controls: {
+      include: [
+        'dataSourceUrl',
+        'resultsPath',
+        'labelKey',
+        'valueKey',
+        'captureAttributes',
+        'minQueryLength',
+      ],
+    },
+    docs: {
+      description: {
+        story: `
+A **configurable remote-source harness** — point it at any CORS-enabled JSON API from the
+Controls panel, no code changes. It mirrors the \`autocomplete\` field type in
+[mieweb/eSheet](https://github.com/mieweb/eSheet/pull/162) and handles the same response
+shapes: OpenSearch arrays, bare string arrays, and object arrays (with envelope unwrap via
+**results path** and per-selection **capture attributes**).
+
+Verified presets to paste into the controls:
+
+| Source | Data source URL | Results path | Label key | Value key | Capture attributes |
+| --- | --- | --- | --- | --- | --- |
+| Wikipedia REST *(default)* | \`https://en.wikipedia.org/w/rest.php/v1/search/title?q={query}&limit=8\` | \`pages\` | \`title\` | \`key\` | \`id, description\` |
+| Wikipedia OpenSearch | \`https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*\` | — | — | — | — |
+| RxNorm (NIH) | \`https://rxnav.nlm.nih.gov/REST/spellingsuggestions.json?name={query}\` | \`suggestionGroup.suggestionList.suggestion\` | — | — | — |
+| Datamuse | \`https://api.datamuse.com/sug?s={query}\` | — | \`word\` | — | — |
+| OpenLibrary | \`https://openlibrary.org/search.json?q={query}&limit=8\` | \`docs\` | \`title\` | \`key\` | \`first_publish_year, author_name\` |
+
+All presets are CORS-open and need no API key. Requires internet access.
+        `,
+      },
+    },
+  },
+};

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { Autocomplete } from './Autocomplete';
+import { Button } from '../Button/Button';
 
 interface Employee {
   id: string;
@@ -499,6 +501,89 @@ interface ExplorerArgs {
   minQueryLength: number;
 }
 
+interface ExplorerPreset {
+  name: string;
+  hint: string;
+  args: Omit<ExplorerArgs, 'minQueryLength'>;
+}
+
+/**
+ * Public, CORS-open, key-free APIs verified against this parser (and against
+ * the matching eSheet field — see mieweb/eSheet#162). Single source of truth
+ * for both the on-canvas preset table and the docs table below.
+ */
+const EXPLORER_PRESETS: ExplorerPreset[] = [
+  {
+    name: 'Wikipedia REST',
+    hint: 'Envelope + captured attributes. Try “toledo”.',
+    args: {
+      dataSourceUrl:
+        'https://en.wikipedia.org/w/rest.php/v1/search/title?q={query}&limit=8',
+      resultsPath: 'pages',
+      labelKey: 'title',
+      valueKey: 'key',
+      captureAttributes: 'id, description',
+    },
+  },
+  {
+    name: 'Wikipedia OpenSearch',
+    hint: 'OpenSearch array format, no keys needed. Try “hypertension”.',
+    args: {
+      dataSourceUrl:
+        'https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*',
+      resultsPath: '',
+      labelKey: '',
+      valueKey: '',
+      captureAttributes: '',
+    },
+  },
+  {
+    name: 'RxNorm (NIH)',
+    hint: 'Deep results path into a string array. Try “metformi”.',
+    args: {
+      dataSourceUrl:
+        'https://rxnav.nlm.nih.gov/REST/spellingsuggestions.json?name={query}',
+      resultsPath: 'suggestionGroup.suggestionList.suggestion',
+      labelKey: '',
+      valueKey: '',
+      captureAttributes: '',
+    },
+  },
+  {
+    name: 'Datamuse',
+    hint: 'Bare object array. Try “hyperten”.',
+    args: {
+      dataSourceUrl: 'https://api.datamuse.com/sug?s={query}',
+      resultsPath: '',
+      labelKey: 'word',
+      valueKey: '',
+      captureAttributes: '',
+    },
+  },
+  {
+    name: 'OpenLibrary',
+    hint: 'Envelope + captured attributes (incl. arrays). Try “dune”.',
+    args: {
+      dataSourceUrl: 'https://openlibrary.org/search.json?q={query}&limit=8',
+      resultsPath: 'docs',
+      labelKey: 'title',
+      valueKey: 'key',
+      captureAttributes: 'first_publish_year, author_name',
+    },
+  },
+];
+
+const mdCell = (value: string) => (value ? `\`${value}\`` : '—');
+
+const presetTableMarkdown = [
+  '| Source | Data source URL | Results path | Label key | Value key | Capture attributes |',
+  '| --- | --- | --- | --- | --- | --- |',
+  ...EXPLORER_PRESETS.map(
+    ({ name, args }) =>
+      `| ${name} | ${mdCell(args.dataSourceUrl)} | ${mdCell(args.resultsPath)} | ${mdCell(args.labelKey)} | ${mdCell(args.valueKey)} | ${mdCell(args.captureAttributes)} |`
+  ),
+].join('\n');
+
 function LiveExplorerExample({
   dataSourceUrl,
   resultsPath,
@@ -613,12 +698,7 @@ function LiveExplorerExample({
 
 export const LiveDataExplorer: StoryObj<ExplorerArgs> = {
   args: {
-    dataSourceUrl:
-      'https://en.wikipedia.org/w/rest.php/v1/search/title?q={query}&limit=8',
-    resultsPath: 'pages',
-    labelKey: 'title',
-    valueKey: 'key',
-    captureAttributes: 'id, description',
+    ...EXPLORER_PRESETS[0].args,
     minQueryLength: 2,
   },
   argTypes: {
@@ -651,7 +731,95 @@ export const LiveDataExplorer: StoryObj<ExplorerArgs> = {
       description: 'Minimum characters before fetching.',
     },
   },
-  render: (args) => <LiveExplorerExample {...args} />,
+  render: function LiveDataExplorerStory(args) {
+    const [, updateArgs] = useArgs<ExplorerArgs>();
+    const isActive = (preset: ExplorerPreset) =>
+      preset.args.dataSourceUrl === args.dataSourceUrl;
+    // Remount the example when the source config changes so stale
+    // items/selection from the previous API never linger.
+    const configKey = `${args.dataSourceUrl}|${args.resultsPath}|${args.labelKey}|${args.valueKey}|${args.captureAttributes}`;
+    return (
+      <div className="space-y-6">
+        <LiveExplorerExample key={configKey} {...args} />
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-xs">
+            <caption className="text-muted-foreground mb-2 text-left text-sm">
+              Verified public data sources — load one, then type to search.
+              Every column maps to a control in the Controls panel.
+            </caption>
+            <thead>
+              <tr className="border-border text-muted-foreground border-b">
+                <th scope="col" className="py-1.5 pr-3 font-semibold">
+                  Source
+                </th>
+                <th scope="col" className="py-1.5 pr-3 font-semibold">
+                  Data source URL
+                </th>
+                <th scope="col" className="py-1.5 pr-3 font-semibold">
+                  Results path
+                </th>
+                <th scope="col" className="py-1.5 pr-3 font-semibold">
+                  Label key
+                </th>
+                <th scope="col" className="py-1.5 pr-3 font-semibold">
+                  Value key
+                </th>
+                <th scope="col" className="py-1.5 pr-3 font-semibold">
+                  Capture attributes
+                </th>
+                <th scope="col" className="py-1.5">
+                  <span className="sr-only">Load preset</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {EXPLORER_PRESETS.map((preset) => (
+                <tr
+                  key={preset.name}
+                  className="border-border/50 border-b align-top"
+                >
+                  <th
+                    scope="row"
+                    className="py-2 pr-3 font-medium whitespace-nowrap"
+                  >
+                    {preset.name}
+                    <span className="text-muted-foreground block max-w-[12rem] text-[11px] font-normal whitespace-normal">
+                      {preset.hint}
+                    </span>
+                  </th>
+                  <td className="text-muted-foreground max-w-[18rem] py-2 pr-3 font-mono break-all">
+                    {preset.args.dataSourceUrl}
+                  </td>
+                  <td className="text-muted-foreground py-2 pr-3 font-mono break-all">
+                    {preset.args.resultsPath || '—'}
+                  </td>
+                  <td className="text-muted-foreground py-2 pr-3 font-mono">
+                    {preset.args.labelKey || '—'}
+                  </td>
+                  <td className="text-muted-foreground py-2 pr-3 font-mono">
+                    {preset.args.valueKey || '—'}
+                  </td>
+                  <td className="text-muted-foreground py-2 pr-3 font-mono break-all">
+                    {preset.args.captureAttributes || '—'}
+                  </td>
+                  <td className="py-2">
+                    <Button
+                      size="sm"
+                      variant={isActive(preset) ? 'primary' : 'outline'}
+                      onClick={() => updateArgs({ ...preset.args })}
+                      aria-label={`Load ${preset.name} preset`}
+                    >
+                      {isActive(preset) ? 'Loaded' : 'Load'}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  },
   parameters: {
     controls: {
       include: [
@@ -672,15 +840,9 @@ Controls panel, no code changes. It mirrors the \`autocomplete\` field type in
 shapes: OpenSearch arrays, bare string arrays, and object arrays (with envelope unwrap via
 **results path** and per-selection **capture attributes**).
 
-Verified presets to paste into the controls:
+Verified presets — use the **Load** buttons on the story canvas, or paste into the controls:
 
-| Source | Data source URL | Results path | Label key | Value key | Capture attributes |
-| --- | --- | --- | --- | --- | --- |
-| Wikipedia REST *(default)* | \`https://en.wikipedia.org/w/rest.php/v1/search/title?q={query}&limit=8\` | \`pages\` | \`title\` | \`key\` | \`id, description\` |
-| Wikipedia OpenSearch | \`https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*\` | — | — | — | — |
-| RxNorm (NIH) | \`https://rxnav.nlm.nih.gov/REST/spellingsuggestions.json?name={query}\` | \`suggestionGroup.suggestionList.suggestion\` | — | — | — |
-| Datamuse | \`https://api.datamuse.com/sug?s={query}\` | — | \`word\` | — | — |
-| OpenLibrary | \`https://openlibrary.org/search.json?q={query}&limit=8\` | \`docs\` | \`title\` | \`key\` | \`first_publish_year, author_name\` |
+${presetTableMarkdown}
 
 All presets are CORS-open and need no API key. Requires internet access.
         `,

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -612,7 +612,14 @@ function LiveExplorerExample({
     clearTimeout(debounceTimer.current);
     abortRef.current?.abort();
     setError(null);
-    if (!dataSourceUrl.includes('{query}') || q.length < minQueryLength) {
+    if (!dataSourceUrl.includes('{query}')) {
+      // Misconfiguration, not an empty result: say so in the popover.
+      setItems([]);
+      setLoading(false);
+      setError('Data source URL must contain a {query} token.');
+      return;
+    }
+    if (q.length < minQueryLength) {
       setItems([]);
       setLoading(false);
       return;
@@ -642,7 +649,7 @@ function LiveExplorerExample({
         if ((err as Error).name === 'AbortError') return;
         if (abortRef.current !== ac) return;
         setItems([]);
-        setError((err as Error).message);
+        setError(`Request failed: ${(err as Error).message}`);
         setLoading(false);
       }
     }, 250);
@@ -670,13 +677,7 @@ function LiveExplorerExample({
         clearOnSelect={false}
         minQueryLength={minQueryLength}
         placeholder="Start typing to search…"
-        emptyMessage={
-          error
-            ? `Request failed: ${error}`
-            : loading
-              ? 'Searching…'
-              : 'No results.'
-        }
+        emptyMessage={error ?? (loading ? 'Searching…' : 'No results.')}
         aria-label="Live data explorer search"
       />
       {selected && (


### PR DESCRIPTION
## Summary

Adds a **`LiveDataExplorer`** story to the Autocomplete component that mirrors the configurable `autocomplete` field type shipped in mieweb/eSheet#162. The Storybook Controls panel exposes the same knobs as the eSheet builder edit panel, so any CORS-enabled JSON API can be tried live without code changes:

- **Data source URL** — `{query}` token replaced with the typed text
- **Results path** — dot-path envelope unwrap (e.g. `suggestionGroup.suggestionList.suggestion`)
- **Label key / Value key** — for object-array responses
- **Capture attributes** — comma-separated keys copied from the selected object
- **Min query length**

## Implementation

- Small story-local helpers normalize the three common response shapes: OpenSearch arrays, bare string arrays, and object arrays (raw object retained for attribute capture).
- Same production fetch recipe as the existing *Live Wikipedia* story: 250 ms debounce, `AbortController`, stale-response guard, error surfaced via `emptyMessage`.
- Selection + captured attributes rendered below the input so the capture behavior is visible.
- Docs tab includes a table of **verified presets** (all CORS-open, no API key): Wikipedia REST (default), Wikipedia OpenSearch, RxNorm (NIH), Datamuse, OpenLibrary — the same sources live-tested in mieweb/eSheet#162.

## Testing

- `pnpm exec prettier` / `pnpm exec eslint` / `pnpm typecheck` all pass
- Verified live in Storybook: default Wikipedia REST config returns options for "toledo"; selecting one shows captured `{ id, description }` attributes