### PR TITLE
fix(DateInput): emit Input density slots so condensed mode applies

### DIFF
--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -9,6 +9,28 @@ describe('DateInput', () => {
     vi.useRealTimers();
   });
 
+  it('exposes the Input density slots when it renders its own markup', () => {
+    renderWithTheme(
+      <DateInput label="Service date" helperText="MM/DD/YYYY" showCalendar />
+    );
+
+    expect(screen.getByLabelText('Service date')).toHaveAttribute(
+      'data-slot',
+      'input'
+    );
+    expect(screen.getByText('Service date')).toHaveAttribute(
+      'data-slot',
+      'input-label'
+    );
+    expect(screen.getByText('MM/DD/YYYY')).toHaveAttribute(
+      'data-slot',
+      'input-helper'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Open calendar' })
+    ).toHaveAttribute('data-slot', 'date-input-trigger');
+  });
+
   it('shows only calendar years within its date bounds', async () => {
     const user = userEvent.setup();
 

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -954,9 +954,13 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       const errorMessage = error || localError;
 
       return (
-        <div className={cn('flex flex-col gap-1.5', widthClasses[width])}>
+        <div
+          data-slot="input-wrapper"
+          className={cn('flex flex-col gap-1.5', widthClasses[width])}
+        >
           {label && (
             <label
+              data-slot="input-label"
               htmlFor={inputId}
               className={cn(
                 'text-foreground text-sm font-medium',
@@ -977,6 +981,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           )}
           <div className="relative">
             <input
+              data-slot="input"
               ref={ref}
               id={inputId}
               type="text"
@@ -1023,6 +1028,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
               {...inputProps}
             />
             <button
+              data-slot="date-input-trigger"
               ref={buttonRef}
               type="button"
               onClick={() => setIsCalendarOpen(!isCalendarOpen)}
@@ -1049,6 +1055,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           {errorMessage && (
             <p
               id={errorId}
+              data-slot="input-error"
               className="text-sm"
               style={{ color: '#ef4444' }}
               role="alert"
@@ -1057,7 +1064,11 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
             </p>
           )}
           {helperText && !errorMessage && (
-            <p id={helperId} className="text-muted-foreground text-sm">
+            <p
+              id={helperId}
+              data-slot="input-helper"
+              className="text-muted-foreground text-sm"
+            >
               {helperText}
             </p>
           )}

--- a/src/styles/condensed-view.css
+++ b/src/styles/condensed-view.css
@@ -1398,6 +1398,14 @@ body.condensed [data-slot='input-helper'] {
   line-height: 0.875rem !important;
 }
 
+/* ── DateInput ── */
+
+/* Shares the Input slots; only the calendar/clock trigger needs scaling down. */
+body.condensed [data-slot='date-input-trigger'] svg {
+  width: 0.875rem !important;
+  height: 0.875rem !important;
+}
+
 /* ── Textarea ── */
 
 /* Wrapper: tighter gap between label/textarea/footer */


### PR DESCRIPTION
## Problem

In `body.condensed`, a `DateInput` stays at the comfortable size while the `Input` fields next to it shrink:

| field | markup | computed |
|---|---|---|
| `Input` | `input[data-slot=input]` in `div[data-slot=input-wrapper]` | 28px / 12px, label 11px |
| `DateInput` | `input` with no `data-slot` | 40px / 16px, label 14px |

Both inputs emit the same classes (`h-10 text-base`) — the neighbours are shrunk by `condensed-view.css`, which keys density **only** off `data-slot`:

```css
body.condensed [data-slot='input']       { height: 1.75rem !important; font-size: .75rem !important; … }
body.condensed [data-slot='input-label'] { font-size: .6875rem !important; }
```

When `showCalendar` is set (or `inputType !== 'date'`), `DateInput` builds its own markup instead of composing `Input`, and that markup carries no slots, so none of those rules ever match. Spotted in eCase, where an eSheet `inputType: date` field rendered noticeably taller than the text fields around it.

## Change

- Tag `DateInput`'s hand-rolled wrapper / label / input / error / helper with the shared `input-*` slots.
- Give the calendar/clock trigger `data-slot="date-input-trigger"` and scale its icon down in condensed mode so it fits the 1.75rem field.
- Test asserting the slots are present.

No class or API changes — the comfortable rendering is byte-identical.

## Checks

`pnpm typecheck`, `pnpm lint`, `pnpm format:fix`, `pnpm exec vitest run src/components/DateInput` (11 passed).