### PR TITLE
feat(GlossaryTooltip): rich term-definition hover card

### DIFF
--- a/src/components/GlossaryTooltip/GlossaryTooltip.stories.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { GlossaryTooltip } from './GlossaryTooltip';
+
+const meta: Meta<typeof GlossaryTooltip> = {
+  title: 'Components/Overlays & Popups/GlossaryTooltip',
+  component: GlossaryTooltip,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A rich "what does this term mean?" hover card: category badge, canonical term, ' +
+          'truncated definition, optional key fact, source link, and related-term chips. ' +
+          'The sibling of `SourceTip` ("what backs this claim?") — same interaction grammar: ' +
+          'hover previews, touch taps pin, Escape/outside-tap closes. Phrasing-content markup ' +
+          'keeps it valid inside prose; the card portals to body and stays in the viewport.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    term: {
+      description: 'Canonical term name — the card heading.',
+      control: 'text',
+    },
+    definition: {
+      description: 'Definition text (truncated in-card).',
+      control: 'text',
+    },
+    category: { description: 'Category badge label.', control: 'text' },
+    keyFact: {
+      description: 'Single key fact with a diamond marker.',
+      control: 'text',
+    },
+    source: { description: 'Authoritative source link.', control: false },
+    related: { description: 'Sibling terms shown as chips.', control: false },
+    href: {
+      description:
+        'Full glossary page — desktop clicks navigate, hover previews.',
+      control: 'text',
+    },
+    underline: {
+      description: 'Dashed underline on the trigger.',
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    term: 'OSHA recordable',
+    definition:
+      'A work-related injury or illness that must be entered on the OSHA 300 log: one involving death, days away from work, restricted work or job transfer, medical treatment beyond first aid, or loss of consciousness.',
+    category: 'Compliance',
+    href: '#osha-recordable',
+    children: 'OSHA recordables',
+  },
+  render: (args) => (
+    <p className="text-foreground max-w-md text-sm leading-relaxed">
+      Clinics that manage <GlossaryTooltip {...args} /> for employers need a
+      defensible audit trail from intake to the 300A summary.
+    </p>
+  ),
+};
+
+export const FullCard: Story = {
+  args: {
+    term: 'DOT physical',
+    definition:
+      'A medical examination required for commercial motor vehicle drivers, performed by a certified medical examiner listed on the FMCSA National Registry. Certification is valid for up to 24 months.',
+    category: 'Occupational Health',
+    keyFact: 'Examiners must be listed on the FMCSA National Registry.',
+    source: {
+      label: '49 CFR 391.43',
+      url: 'https://www.ecfr.gov/current/title-49/section-391.43',
+    },
+    related: [
+      { term: 'FMCSA', href: '#fmcsa' },
+      { term: 'Medical certificate', href: '#medical-certificate' },
+      { term: 'CDL' },
+    ],
+    href: '#dot-physical',
+    children: 'DOT physicals',
+  },
+  render: (args) => (
+    <p className="text-foreground max-w-md text-sm leading-relaxed">
+      Scheduling <GlossaryTooltip {...args} /> alongside drug screens cuts
+      driver downtime to a single visit.
+    </p>
+  ),
+};
+
+export const WithoutLink: Story = {
+  args: {
+    term: 'Momentum score',
+    definition:
+      'A composite 0–100 index summarizing how an account is trending, computed from engagement, friction, and readiness signals over a rolling window.',
+    category: 'Waggleline',
+    children: 'momentum score',
+  },
+  render: (args) => (
+    <p className="text-foreground max-w-md text-sm leading-relaxed">
+      An account&apos;s <GlossaryTooltip {...args} /> drops when meetings go
+      dark — Enter or Space pins the card for keyboard users.
+    </p>
+  ),
+};

--- a/src/components/GlossaryTooltip/GlossaryTooltip.test.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.test.tsx
@@ -40,7 +40,7 @@ describe('GlossaryTooltip', () => {
     renderWithTheme(<GlossaryTooltip {...BASE}>DOT physicals</GlossaryTooltip>);
     fireEvent.mouseEnter(screen.getByRole('button'));
 
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Occupational Health')).toBeInTheDocument();
     expect(screen.getByText('DOT physical')).toBeInTheDocument();
     expect(
@@ -99,7 +99,7 @@ describe('GlossaryTooltip', () => {
     act(() => {
       vi.advanceTimersByTime(200);
     });
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('pins via keyboard and shows the close button', () => {
@@ -107,17 +107,35 @@ describe('GlossaryTooltip', () => {
     const trigger = screen.getByRole('button');
     fireEvent.keyDown(trigger, { key: 'Enter' });
 
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     const closeBtn = screen.getByRole('button', { name: /close definition/i });
     fireEvent.click(closeBtn);
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('closes on Escape', () => {
     renderWithTheme(<GlossaryTooltip {...BASE}>trigger</GlossaryTooltip>);
     fireEvent.focus(screen.getByRole('button'));
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders a real button element when the term has no href', () => {
+    renderWithTheme(<GlossaryTooltip {...BASE}>trigger</GlossaryTooltip>);
+    const trigger = screen.getByRole('button', { name: /show definition/i });
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('type', 'button');
+  });
+
+  it('clamps maxDefinitionLength so tiny values cannot break truncation', () => {
+    renderWithTheme(
+      <GlossaryTooltip {...BASE} maxDefinitionLength={0}>
+        trigger
+      </GlossaryTooltip>
+    );
+    fireEvent.focus(screen.getByRole('button'));
+    // limit is clamped to 1 → nothing before the ellipsis, but no crash
+    expect(screen.getByText(/…$/)).toBeInTheDocument();
   });
 });

--- a/src/components/GlossaryTooltip/GlossaryTooltip.test.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, fireEvent, act } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { GlossaryTooltip } from './GlossaryTooltip';
+
+const BASE = {
+  term: 'DOT physical',
+  definition: 'A medical examination required for commercial drivers.',
+  category: 'Occupational Health',
+};
+
+describe('GlossaryTooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders a link trigger when href is set', () => {
+    renderWithTheme(
+      <GlossaryTooltip {...BASE} href="/glossary/dot-physical">
+        DOT physicals
+      </GlossaryTooltip>
+    );
+    const link = screen.getByRole('link', { name: 'DOT physicals' });
+    expect(link).toHaveAttribute('href', '/glossary/dot-physical');
+    expect(link).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('renders a button trigger without href', () => {
+    renderWithTheme(<GlossaryTooltip {...BASE}>DOT physicals</GlossaryTooltip>);
+    expect(
+      screen.getByRole('button', { name: /dot physical — show definition/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows category, term, and definition on hover', () => {
+    renderWithTheme(<GlossaryTooltip {...BASE}>DOT physicals</GlossaryTooltip>);
+    fireEvent.mouseEnter(screen.getByRole('button'));
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByText('Occupational Health')).toBeInTheDocument();
+    expect(screen.getByText('DOT physical')).toBeInTheDocument();
+    expect(
+      screen.getByText(/medical examination required/i)
+    ).toBeInTheDocument();
+  });
+
+  it('truncates long definitions', () => {
+    renderWithTheme(
+      <GlossaryTooltip
+        {...BASE}
+        definition={'x'.repeat(300)}
+        maxDefinitionLength={50}
+      >
+        trigger
+      </GlossaryTooltip>
+    );
+    fireEvent.mouseEnter(screen.getByRole('button'));
+    expect(screen.getByText(/^x{49}…$/)).toBeInTheDocument();
+  });
+
+  it('renders key fact, source, related chips, and full-definition link', () => {
+    renderWithTheme(
+      <GlossaryTooltip
+        {...BASE}
+        keyFact="Valid up to 24 months."
+        source={{ label: '49 CFR 391.43', url: 'https://www.ecfr.gov/' }}
+        related={[{ term: 'FMCSA', href: '/glossary/fmcsa' }, { term: 'CDL' }]}
+        href="/glossary/dot-physical"
+      >
+        DOT physicals
+      </GlossaryTooltip>
+    );
+    fireEvent.mouseEnter(screen.getByRole('link', { name: 'DOT physicals' }));
+
+    expect(screen.getByText('Valid up to 24 months.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '49 CFR 391.43' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    );
+    expect(screen.getByRole('link', { name: 'FMCSA' })).toHaveAttribute(
+      'href',
+      '/glossary/fmcsa'
+    );
+    expect(screen.getByText('CDL')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /full definition/i })
+    ).toBeInTheDocument();
+  });
+
+  it('closes after the grace period on mouse leave', () => {
+    renderWithTheme(<GlossaryTooltip {...BASE}>trigger</GlossaryTooltip>);
+    const trigger = screen.getByRole('button');
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(trigger);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('pins via keyboard and shows the close button', () => {
+    renderWithTheme(<GlossaryTooltip {...BASE}>trigger</GlossaryTooltip>);
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    const closeBtn = screen.getByRole('button', { name: /close definition/i });
+    fireEvent.click(closeBtn);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    renderWithTheme(<GlossaryTooltip {...BASE}>trigger</GlossaryTooltip>);
+    fireEvent.focus(screen.getByRole('button'));
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/GlossaryTooltip/GlossaryTooltip.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.tsx
@@ -94,6 +94,9 @@ export function GlossaryTooltip({
   const [open, setOpen] = React.useState(false);
   const [pinned, setPinned] = React.useState(false);
   const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True while close() restores focus to the trigger, so the trigger's
+  // focus-show doesn't immediately reopen a card the user just dismissed.
+  const suppressFocusShow = React.useRef(false);
 
   const { anchorRef, floatingRef, style } = useAnchoredPosition<
     HTMLSpanElement,
@@ -128,9 +131,20 @@ export function GlossaryTooltip({
     clearHideTimer();
     setPinned(false);
     setOpen(false);
-  }, []);
+    // Return focus to the trigger if it was inside the card.
+    if (floatingRef.current?.contains(document.activeElement)) {
+      suppressFocusShow.current = true;
+      (anchorRef.current?.querySelector('a,button') as HTMLElement)?.focus();
+    }
+  }, [anchorRef, floatingRef]);
 
   React.useEffect(() => () => clearHideTimer(), []);
+
+  // A pinned card is a non-modal dialog: move focus into it so its links
+  // and close button are reachable by keyboard.
+  React.useEffect(() => {
+    if (pinned) floatingRef.current?.focus();
+  }, [pinned, floatingRef]);
 
   useEscapeKey(close, open);
 
@@ -177,6 +191,14 @@ export function GlossaryTooltip({
     }
   };
 
+  const onTriggerFocus = () => {
+    if (suppressFocusShow.current) {
+      suppressFocusShow.current = false;
+      return;
+    }
+    show();
+  };
+
   const onBlurCapture = (e: React.FocusEvent<HTMLSpanElement>) => {
     const next = e.relatedTarget as Node | null;
     if (
@@ -187,9 +209,10 @@ export function GlossaryTooltip({
     scheduleHide();
   };
 
+  const limit = Math.max(1, maxDefinitionLength);
   const short =
-    definition.length > maxDefinitionLength
-      ? `${definition.slice(0, maxDefinitionLength - 1).trimEnd()}…`
+    definition.length > limit
+      ? `${definition.slice(0, limit - 1).trimEnd()}…`
       : definition;
 
   const triggerClasses = cn(
@@ -213,33 +236,45 @@ export function GlossaryTooltip({
       className="relative inline"
       onMouseEnter={show}
       onMouseLeave={scheduleHide}
-      onFocus={show}
+      onFocus={onTriggerFocus}
       onBlur={onBlurCapture}
     >
       {href ? (
-        <a href={href} aria-expanded={open} {...triggerProps}>
-          {children}
-        </a>
-      ) : (
-        <span
-          role="button"
-          tabIndex={0}
+        <a
+          href={href}
           aria-expanded={open}
-          aria-label={`${term} — show definition`}
-          onKeyDown={onTriggerKeyDown}
+          aria-haspopup="dialog"
           {...triggerProps}
         >
           {children}
-        </span>
+        </a>
+      ) : (
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-haspopup="dialog"
+          aria-label={`${term} — show definition`}
+          onKeyDown={onTriggerKeyDown}
+          {...triggerProps}
+          className={cn(
+            'inline appearance-none border-0 bg-transparent p-0 text-inherit [font:inherit]',
+            triggerProps.className
+          )}
+        >
+          {children}
+        </button>
       )}
       {open &&
         createPortal(
           <span
             ref={floatingRef}
-            role="tooltip"
+            role="dialog"
+            aria-label={term}
+            tabIndex={-1}
             onMouseEnter={show}
             onMouseLeave={scheduleHide}
-            className="z-50 block w-80"
+            onBlurCapture={onBlurCapture}
+            className="z-50 block w-80 outline-none"
             style={style}
           >
             <span className="border-border bg-card block overflow-hidden rounded-lg border text-start font-normal tracking-normal normal-case shadow-xl ring-1 ring-black/5 dark:ring-white/10">

--- a/src/components/GlossaryTooltip/GlossaryTooltip.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.tsx
@@ -173,13 +173,17 @@ export function GlossaryTooltip({
     }
   }, [pinned, close, show]);
 
-  // Desktop clicks on a linked term navigate; coarse pointers pin instead.
+  // Linked terms: desktop clicks navigate, coarse pointers pin instead.
+  // Unlinked (button) terms: any click toggles the pin — hover previews,
+  // click holds the card open.
   const onTriggerClick = (e: React.MouseEvent) => {
     const coarse =
       typeof window !== 'undefined' &&
       window.matchMedia('(hover: none)').matches;
-    if (!coarse) return;
-    if (href) e.preventDefault();
+    if (href) {
+      if (!coarse) return;
+      e.preventDefault();
+    }
     togglePin();
   };
 

--- a/src/components/GlossaryTooltip/GlossaryTooltip.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.tsx
@@ -290,7 +290,7 @@ export function GlossaryTooltip({
             onMouseLeave={scheduleHide}
             onBlurCapture={onBlurCapture}
             onKeyDown={onDialogKeyDown}
-            className="z-50 block w-80 outline-none"
+            className="focus-visible:ring-ring z-50 block w-80 rounded-lg outline-none focus-visible:ring-2"
             style={style}
           >
             <span className="border-border bg-card block overflow-hidden rounded-lg border text-start font-normal tracking-normal normal-case shadow-xl ring-1 ring-black/5 dark:ring-white/10">

--- a/src/components/GlossaryTooltip/GlossaryTooltip.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.tsx
@@ -191,6 +191,16 @@ export function GlossaryTooltip({
     }
   };
 
+  // Focus lives on the dialog container once pinned, so Enter/Space there
+  // (not on a link or the close button inside) must also unpin.
+  const onDialogKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      close();
+    }
+  };
+
   const onTriggerFocus = () => {
     if (suppressFocusShow.current) {
       suppressFocusShow.current = false;
@@ -266,6 +276,7 @@ export function GlossaryTooltip({
       )}
       {open &&
         createPortal(
+          /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- keyboard dismissal on a focused non-modal dialog container is the WAI-ARIA pattern; links inside keep their own semantics */
           <span
             ref={floatingRef}
             role="dialog"
@@ -274,6 +285,7 @@ export function GlossaryTooltip({
             onMouseEnter={show}
             onMouseLeave={scheduleHide}
             onBlurCapture={onBlurCapture}
+            onKeyDown={onDialogKeyDown}
             className="z-50 block w-80 outline-none"
             style={style}
           >

--- a/src/components/GlossaryTooltip/GlossaryTooltip.tsx
+++ b/src/components/GlossaryTooltip/GlossaryTooltip.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowRight, Diamond, X } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { useAnchoredPosition } from '../../hooks/useAnchoredPosition';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Authoritative source link shown in the card footer. */
+export interface GlossarySource {
+  label: string;
+  url: string;
+}
+
+/** Sibling term shown as a lateral "hop" chip. */
+export interface GlossaryRelatedTerm {
+  term: string;
+  href?: string;
+}
+
+export interface GlossaryTooltipProps {
+  /** Visible, in-flow trigger text (may be a plural or abbreviation match). */
+  children: React.ReactNode;
+  /** Canonical term name, shown as the card heading. */
+  term: string;
+  definition: string;
+  /** Human-readable category label, shown as a badge in the header. */
+  category?: string;
+  /** Optional single key fact, shown with a diamond marker. */
+  keyFact?: string;
+  /** Optional authoritative source link, shown in the footer. */
+  source?: GlossarySource;
+  /** Optional sibling terms, shown as chips. */
+  related?: GlossaryRelatedTerm[];
+  /**
+   * Full glossary page for the term. When set, the trigger is a real link —
+   * desktop clicks navigate while hover previews; touch taps pin the card.
+   */
+  href?: string;
+  /** Truncation limit for the in-card definition (default 190 chars). */
+  maxDefinitionLength?: number;
+  /** Dashed underline marking the term as hoverable (default true). */
+  underline?: boolean;
+  className?: string;
+}
+
+const HIDE_GRACE_MS = 180;
+
+// =============================================================================
+// GlossaryTooltip
+// =============================================================================
+
+/**
+ * A rich "what does this term mean?" hover card: category badge, canonical
+ * term, truncated definition, optional key fact, source link, and related
+ * term chips. The provenance sibling is `SourceTip` ("what backs this
+ * claim?") — the two share the same interaction grammar.
+ *
+ * Trigger and card are phrasing content (`span`/`a`/`button` only), so it is
+ * valid inside `<p>` prose. The card portals to `body` with fixed
+ * positioning, flipping and clamping to stay in the viewport. On touch, a
+ * tap pins the card instead of navigating; Escape or an outside tap closes.
+ *
+ * @example
+ * ```tsx
+ * <GlossaryTooltip
+ *   term="OSHA recordable"
+ *   definition="A work-related injury or illness that meets OSHA reporting criteria…"
+ *   category="Compliance"
+ *   href="/glossary/osha-recordable"
+ * >
+ *   OSHA recordables
+ * </GlossaryTooltip>
+ * ```
+ */
+export function GlossaryTooltip({
+  children,
+  term,
+  definition,
+  category,
+  keyFact,
+  source,
+  related,
+  href,
+  maxDefinitionLength = 190,
+  underline = true,
+  className,
+}: GlossaryTooltipProps) {
+  const [open, setOpen] = React.useState(false);
+  const [pinned, setPinned] = React.useState(false);
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { anchorRef, floatingRef, style } = useAnchoredPosition<
+    HTMLSpanElement,
+    HTMLSpanElement
+  >({
+    open,
+    placement: 'top',
+    offset: 10,
+    viewportPadding: 8,
+    allowFlip: true,
+  });
+
+  const clearHideTimer = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+
+  const show = React.useCallback(() => {
+    clearHideTimer();
+    setOpen(true);
+  }, []);
+
+  const scheduleHide = React.useCallback(() => {
+    if (pinned) return;
+    clearHideTimer();
+    timer.current = setTimeout(() => setOpen(false), HIDE_GRACE_MS);
+  }, [pinned]);
+
+  const close = React.useCallback(() => {
+    clearHideTimer();
+    setPinned(false);
+    setOpen(false);
+  }, []);
+
+  React.useEffect(() => () => clearHideTimer(), []);
+
+  useEscapeKey(close, open);
+
+  // Pinned cards close on an outside tap; hover cards close on their own.
+  React.useEffect(() => {
+    if (!open || !pinned) return;
+    const onPointer = (e: Event) => {
+      const t = e.target as Node;
+      if (anchorRef.current?.contains(t) || floatingRef.current?.contains(t))
+        return;
+      close();
+    };
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('touchstart', onPointer);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('touchstart', onPointer);
+    };
+  }, [open, pinned, close, anchorRef, floatingRef]);
+
+  const togglePin = React.useCallback(() => {
+    if (pinned) close();
+    else {
+      setPinned(true);
+      show();
+    }
+  }, [pinned, close, show]);
+
+  // Desktop clicks on a linked term navigate; coarse pointers pin instead.
+  const onTriggerClick = (e: React.MouseEvent) => {
+    const coarse =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(hover: none)').matches;
+    if (!coarse) return;
+    if (href) e.preventDefault();
+    togglePin();
+  };
+
+  const onTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (href) return; // links keep native Enter navigation
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      togglePin();
+    }
+  };
+
+  const onBlurCapture = (e: React.FocusEvent<HTMLSpanElement>) => {
+    const next = e.relatedTarget as Node | null;
+    if (
+      next &&
+      (anchorRef.current?.contains(next) || floatingRef.current?.contains(next))
+    )
+      return;
+    scheduleHide();
+  };
+
+  const short =
+    definition.length > maxDefinitionLength
+      ? `${definition.slice(0, maxDefinitionLength - 1).trimEnd()}…`
+      : definition;
+
+  const triggerClasses = cn(
+    'cursor-help',
+    underline &&
+      'decoration-primary-400/70 underline decoration-dashed underline-offset-4',
+    className
+  );
+
+  const triggerProps = {
+    onClick: onTriggerClick,
+    className: cn(
+      triggerClasses,
+      href && 'text-primary-700 dark:text-primary-400 font-medium'
+    ),
+  };
+
+  return (
+    <span
+      ref={anchorRef}
+      className="relative inline"
+      onMouseEnter={show}
+      onMouseLeave={scheduleHide}
+      onFocus={show}
+      onBlur={onBlurCapture}
+    >
+      {href ? (
+        <a href={href} aria-expanded={open} {...triggerProps}>
+          {children}
+        </a>
+      ) : (
+        <span
+          role="button"
+          tabIndex={0}
+          aria-expanded={open}
+          aria-label={`${term} — show definition`}
+          onKeyDown={onTriggerKeyDown}
+          {...triggerProps}
+        >
+          {children}
+        </span>
+      )}
+      {open &&
+        createPortal(
+          <span
+            ref={floatingRef}
+            role="tooltip"
+            onMouseEnter={show}
+            onMouseLeave={scheduleHide}
+            className="z-50 block w-80"
+            style={style}
+          >
+            <span className="border-border bg-card block overflow-hidden rounded-lg border text-start font-normal tracking-normal normal-case shadow-xl ring-1 ring-black/5 dark:ring-white/10">
+              <span className="from-primary-700 to-primary-600 block bg-gradient-to-br px-3.5 py-2.5">
+                <span className="flex items-start justify-between gap-2">
+                  <span className="block min-w-0">
+                    {category && (
+                      <span className="mb-1 inline-flex rounded-full bg-white/15 px-2 py-0.5 text-[10px] font-bold tracking-wide text-white uppercase">
+                        {category}
+                      </span>
+                    )}
+                    <span className="block text-sm leading-snug font-semibold text-white">
+                      {term}
+                    </span>
+                  </span>
+                  {pinned && (
+                    <button
+                      type="button"
+                      onClick={close}
+                      aria-label="Close definition"
+                      className="shrink-0 rounded p-0.5 text-white/70 hover:bg-white/10 hover:text-white"
+                    >
+                      <X aria-hidden="true" className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </span>
+              </span>
+
+              <span className="block px-3.5 py-2.5">
+                <span className="text-muted-foreground block text-[13px] leading-relaxed">
+                  {short}
+                </span>
+                {keyFact && (
+                  <span className="mt-2 flex items-start gap-1.5">
+                    <Diamond
+                      aria-hidden="true"
+                      className="text-primary-500 mt-0.5 h-3 w-3 shrink-0"
+                    />
+                    <span className="text-foreground min-w-0 text-xs leading-relaxed font-medium">
+                      {keyFact}
+                    </span>
+                  </span>
+                )}
+              </span>
+
+              {(source || (related && related.length > 0) || href) && (
+                <span className="border-border bg-muted/50 block border-t px-3.5 py-2">
+                  {related && related.length > 0 && (
+                    <span className="mb-1.5 flex flex-wrap gap-1">
+                      {related.map((r) =>
+                        r.href ? (
+                          <a
+                            key={r.term}
+                            href={r.href}
+                            className="border-border bg-card text-foreground hover:border-primary-400 hover:text-primary-700 dark:hover:text-primary-400 rounded-full border px-2 py-0.5 text-[11px] font-medium"
+                          >
+                            {r.term}
+                          </a>
+                        ) : (
+                          <span
+                            key={r.term}
+                            className="border-border bg-card text-muted-foreground rounded-full border px-2 py-0.5 text-[11px] font-medium"
+                          >
+                            {r.term}
+                          </span>
+                        )
+                      )}
+                    </span>
+                  )}
+                  <span className="flex items-center justify-between gap-2">
+                    {source ? (
+                      <a
+                        href={source.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary-700 hover:text-primary-600 dark:text-primary-400 dark:hover:text-primary-300 min-w-0 truncate text-[11px] font-semibold"
+                      >
+                        {source.label}
+                      </a>
+                    ) : (
+                      <span />
+                    )}
+                    {href && (
+                      <a
+                        href={href}
+                        className="text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-0.5 text-[11px] font-medium"
+                      >
+                        Full definition
+                        <ArrowRight aria-hidden="true" className="h-3 w-3" />
+                      </a>
+                    )}
+                  </span>
+                </span>
+              )}
+            </span>
+          </span>,
+          document.body
+        )}
+    </span>
+  );
+}

--- a/src/components/GlossaryTooltip/index.ts
+++ b/src/components/GlossaryTooltip/index.ts
@@ -1,0 +1,6 @@
+export {
+  GlossaryTooltip,
+  type GlossaryTooltipProps,
+  type GlossarySource,
+  type GlossaryRelatedTerm,
+} from './GlossaryTooltip';

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export * from './components/EmployerServiceModal';
 export * from './components/ErrorPage';
 export * from './components/FileManager';
 export * from './components/FloatingWindow';
+export * from './components/GlossaryTooltip';
 export * from './components/HealthSurveillance';
 export * from './components/HelpSupportPanel';
 export * from './components/HRISProviderSelector';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     'components/DateInput/index': 'src/components/DateInput/index.ts',
     'components/Dropdown/index': 'src/components/Dropdown/index.ts',
     'components/FloatingWindow/index': 'src/components/FloatingWindow/index.ts',
+    'components/GlossaryTooltip/index': 'src/components/GlossaryTooltip/index.ts',
     'components/Input/index': 'src/components/Input/index.ts',
     'components/Label/index': 'src/components/Label/index.ts',
     'components/Markdown/index': 'src/components/Markdown/index.ts',


### PR DESCRIPTION
Ports the Enterprise Health frontdoor's glossary hover card into the design system — the sibling of `SourceTip` (#391): that one answers *"what backs this claim?"*, this one answers *"what does this term mean?"*. Same interaction grammar, so the two read as one system.

## What it does

- **Full card anatomy**: category badge + canonical term in a branded gradient header, truncated definition (`maxDefinitionLength`), optional key fact with diamond marker, authoritative source link, related-term chips, and a "Full definition" link
- **Fully decoupled from the EH glossary registry** — term/definition/category/keyFact/source/related all flow through props, so any app can drive it from its own data
- **Link-aware trigger**: with `href`, desktop clicks navigate to the full glossary page while hover previews; on touch a tap pins the card instead. Without `href` the trigger is a keyboard button (Enter/Space pins, with a close button on the pinned card)
- **Phrasing-content markup** (`span`/`a`/`button` only) — valid inside `<p>` prose; the card portals to `body`, positioned by `useAnchoredPosition` (flip + clamp + scroll tracking), Escape via `useEscapeKey`

## Screenshots

Full card — category, key fact, source, related chips:

| Light | Dark |
|---|---|
| ![GlossaryTooltip light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr5-glossary-tooltip-light.png) | ![GlossaryTooltip dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr5-glossary-tooltip-dark.png) |

## Provenance

Port of `enterprise-health-frontdoor/components/glossary/GlossaryTooltip.tsx` ("Variant C"), retokened to `--mieweb-*` semantics, Next Link → plain anchors, text arrow → lucide `ArrowRight`. Once #391 and this merge, extracting the shared hover/pin/grace logic into a `useHoverCard` hook is a natural follow-up.

## Testing

- 8 unit tests (link vs button trigger, truncation, full-card anatomy, grace-period close, keyboard pin + close button, Escape)
- 3 stories: inline prose, full card, unlinked term
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 622/622