### PR TITLE
feat(Accordion): expandable panel list

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Accordion, type AccordionItem } from './Accordion';
+
+const meta: Meta<typeof Accordion> = {
+  title: 'Components/Layout & Structure/Accordion',
+  component: Accordion,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A vertically stacked set of expandable panels for FAQ lists, settings groups, and ' +
+          'progressive disclosure. Panels animate to their natural height (CSS grid rows — no ' +
+          'max-height clipping), headers are real buttons inside headings with full ' +
+          '`aria-expanded`/`aria-controls` wiring, and open state can be single or multiple, ' +
+          'uncontrolled or controlled.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    items: { description: 'Panels to render.', control: false },
+    type: {
+      description:
+        'single keeps at most one panel open; multiple allows any number.',
+      control: 'select',
+      options: ['single', 'multiple'],
+    },
+    variant: {
+      description: 'separated cards or one joined bordered list.',
+      control: 'select',
+      options: ['separated', 'joined'],
+    },
+    collapsible: {
+      description: 'In single mode, allow closing the open panel.',
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const FAQ_ITEMS: AccordionItem[] = [
+  {
+    id: 'what-is-recordable',
+    title: 'What makes an injury OSHA recordable?',
+    content: (
+      <p>
+        A work-related injury or illness is recordable when it results in death,
+        days away from work, restricted work or job transfer, medical treatment
+        beyond first aid, or loss of consciousness (29 CFR 1904.7).
+      </p>
+    ),
+  },
+  {
+    id: 'when-to-report',
+    title: 'How quickly must a fatality be reported?',
+    content: (
+      <p>
+        Employers must report a work-related fatality to OSHA within 8 hours,
+        and any in-patient hospitalization, amputation, or loss of an eye within
+        24 hours (29 CFR 1904.39).
+      </p>
+    ),
+  },
+  {
+    id: 'who-keeps-logs',
+    title: 'Which employers must keep OSHA 300 logs?',
+    content: (
+      <p>
+        Employers with more than 10 employees keep injury and illness records
+        unless their industry is classified as low-hazard and specifically
+        exempted from routine recordkeeping.
+      </p>
+    ),
+  },
+  {
+    id: 'disabled-example',
+    title: 'Coming soon: state-plan differences',
+    content: <p>Placeholder.</p>,
+    disabled: true,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    items: FAQ_ITEMS,
+    type: 'single',
+    defaultOpenIds: ['what-is-recordable'],
+  },
+};
+
+export const Joined: Story = {
+  args: {
+    items: FAQ_ITEMS,
+    variant: 'joined',
+    type: 'single',
+    defaultOpenIds: ['when-to-report'],
+  },
+};
+
+export const Multiple: Story = {
+  args: {
+    items: FAQ_ITEMS.slice(0, 3),
+    type: 'multiple',
+    defaultOpenIds: ['what-is-recordable', 'who-keeps-logs'],
+  },
+};
+
+export const Controlled: Story = {
+  render: (args) => <ControlledExample {...args} />,
+  args: { items: FAQ_ITEMS.slice(0, 3), type: 'single' },
+};
+
+function ControlledExample(args: React.ComponentProps<typeof Accordion>) {
+  const [openIds, setOpenIds] = useState<string[]>([]);
+  return (
+    <div className="flex flex-col gap-3">
+      <Accordion {...args} openIds={openIds} onOpenChange={setOpenIds} />
+      <pre className="bg-muted text-muted-foreground rounded-md p-2 text-xs">
+        open: {JSON.stringify(openIds)}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { Accordion, type AccordionItem } from './Accordion';
+
+const ITEMS: AccordionItem[] = [
+  { id: 'a', title: 'Question A', content: 'Answer A' },
+  { id: 'b', title: 'Question B', content: 'Answer B' },
+  { id: 'c', title: 'Question C', content: 'Answer C', disabled: true },
+];
+
+describe('Accordion', () => {
+  it('renders all triggers collapsed by default', () => {
+    renderWithTheme(<Accordion items={ITEMS} />);
+    for (const name of ['Question A', 'Question B']) {
+      expect(screen.getByRole('button', { name })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    }
+  });
+
+  it('opens defaultOpenIds and wires aria-controls to the panel', () => {
+    renderWithTheme(<Accordion items={ITEMS} defaultOpenIds={['a']} />);
+    const trigger = screen.getByRole('button', { name: 'Question A' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const panel = screen.getByRole('region', { name: 'Question A' });
+    expect(panel.id).toBe(trigger.getAttribute('aria-controls'));
+  });
+
+  it('single mode closes the previous panel', () => {
+    renderWithTheme(
+      <Accordion items={ITEMS} type="single" defaultOpenIds={['a']} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Question B' }));
+    expect(screen.getByRole('button', { name: 'Question A' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    expect(screen.getByRole('button', { name: 'Question B' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('single non-collapsible keeps one panel open', () => {
+    renderWithTheme(
+      <Accordion
+        items={ITEMS}
+        type="single"
+        collapsible={false}
+        defaultOpenIds={['a']}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Question A' }));
+    expect(screen.getByRole('button', { name: 'Question A' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('multiple mode opens panels independently', () => {
+    renderWithTheme(<Accordion items={ITEMS} type="multiple" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Question A' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Question B' }));
+    expect(screen.getByRole('button', { name: 'Question A' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Question B' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('supports controlled open state', () => {
+    const onOpenChange = vi.fn();
+    renderWithTheme(
+      <Accordion items={ITEMS} openIds={['b']} onOpenChange={onOpenChange} />
+    );
+    expect(screen.getByRole('button', { name: 'Question B' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Question A' }));
+    expect(onOpenChange).toHaveBeenCalledWith(['a']);
+    // Controlled: state does not change without the parent updating props
+    expect(screen.getByRole('button', { name: 'Question A' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
+  it('disables items', () => {
+    renderWithTheme(<Accordion items={ITEMS} />);
+    expect(screen.getByRole('button', { name: 'Question C' })).toBeDisabled();
+  });
+});

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -95,4 +95,36 @@ describe('Accordion', () => {
     renderWithTheme(<Accordion items={ITEMS} />);
     expect(screen.getByRole('button', { name: 'Question C' })).toBeDisabled();
   });
+
+  it('hides collapsed panels from AT and keyboard via aria-hidden + inert', () => {
+    renderWithTheme(<Accordion items={ITEMS} defaultOpenIds={['a']} />);
+    const openPanel = document.getElementById(
+      screen
+        .getByRole('button', { name: 'Question A' })
+        .getAttribute('aria-controls')!
+    )!;
+    const closedPanel = document.getElementById(
+      screen
+        .getByRole('button', { name: 'Question B' })
+        .getAttribute('aria-controls')!
+    )!;
+    expect(openPanel).toHaveAttribute('aria-hidden', 'false');
+    expect(openPanel).not.toHaveAttribute('inert');
+    expect(closedPanel).toHaveAttribute('aria-hidden', 'true');
+    expect(closedPanel).toHaveAttribute('inert');
+  });
+
+  it('normalizes single mode to at most one open panel', () => {
+    renderWithTheme(
+      <Accordion type="single" items={ITEMS} defaultOpenIds={['a', 'b']} />
+    );
+    expect(screen.getByRole('button', { name: 'Question A' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Question B' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
 });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import * as React from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../utils/cn';
+
+// =============================================================================
+// Variants
+// =============================================================================
+
+const accordionVariants = cva('', {
+  variants: {
+    variant: {
+      // Each item is its own card with spacing between
+      separated: 'flex flex-col gap-3',
+      // One bordered list with dividers
+      joined: 'border-border divide-border divide-y rounded-lg border',
+    },
+  },
+  defaultVariants: {
+    variant: 'separated',
+  },
+});
+
+const itemVariants = cva('overflow-hidden', {
+  variants: {
+    variant: {
+      separated: 'border-border bg-card rounded-lg border',
+      joined: 'bg-card first:rounded-t-lg last:rounded-b-lg',
+    },
+  },
+  defaultVariants: {
+    variant: 'separated',
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface AccordionItem {
+  /** Stable id used for open state and aria wiring. */
+  id: string;
+  /** Header label (e.g. an FAQ question). */
+  title: React.ReactNode;
+  /** Panel content (e.g. the answer). */
+  content: React.ReactNode;
+  disabled?: boolean;
+}
+
+export interface AccordionProps
+  extends
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+    VariantProps<typeof accordionVariants> {
+  items: AccordionItem[];
+  /** `single` keeps at most one panel open; `multiple` allows any number. */
+  type?: 'single' | 'multiple';
+  /** Ids open initially (uncontrolled). */
+  defaultOpenIds?: string[];
+  /** Controlled open ids. Changes reported via `onOpenChange`. */
+  openIds?: string[];
+  onOpenChange?: (openIds: string[]) => void;
+  /** In `single` mode, allow closing the open panel (default true). */
+  collapsible?: boolean;
+  /** Heading level wrapping each trigger for document outline (default h3). */
+  headingLevel?: 'h2' | 'h3' | 'h4';
+}
+
+// =============================================================================
+// Accordion
+// =============================================================================
+
+/**
+ * A vertically stacked set of expandable panels — FAQ lists, settings
+ * groups, progressive disclosure. Panels animate open to their natural
+ * height (CSS grid rows, no max-height clipping), and headers are real
+ * buttons inside headings with full `aria-expanded`/`aria-controls` wiring.
+ *
+ * @example
+ * ```tsx
+ * <Accordion
+ *   type="single"
+ *   items={[
+ *     { id: 'pricing', title: 'How is pricing calculated?', content: <p>…</p> },
+ *     { id: 'billing', title: 'When am I billed?', content: <p>…</p> },
+ *   ]}
+ * />
+ * ```
+ */
+export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
+  function Accordion(
+    {
+      items,
+      type = 'single',
+      defaultOpenIds,
+      openIds: controlledOpen,
+      onOpenChange,
+      collapsible = true,
+      headingLevel: Heading = 'h3',
+      variant,
+      className,
+      ...props
+    },
+    ref
+  ) {
+    const baseId = React.useId();
+    const [internalOpen, setInternalOpen] = React.useState<string[]>(
+      () => defaultOpenIds ?? []
+    );
+    const open = controlledOpen ?? internalOpen;
+    const openSet = React.useMemo(() => new Set(open), [open]);
+
+    const toggle = (id: string) => {
+      let next: string[];
+      if (openSet.has(id)) {
+        if (type === 'single' && !collapsible) return;
+        next = open.filter((o) => o !== id);
+      } else {
+        next = type === 'single' ? [id] : [...open, id];
+      }
+      if (controlledOpen === undefined) setInternalOpen(next);
+      onOpenChange?.(next);
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(accordionVariants({ variant }), className)}
+        {...props}
+      >
+        {items.map((item) => {
+          const isOpen = openSet.has(item.id);
+          const triggerId = `${baseId}-${item.id}-trigger`;
+          const panelId = `${baseId}-${item.id}-panel`;
+          return (
+            <div key={item.id} className={cn(itemVariants({ variant }))}>
+              <Heading className="m-0">
+                <button
+                  type="button"
+                  id={triggerId}
+                  aria-expanded={isOpen}
+                  aria-controls={panelId}
+                  disabled={item.disabled}
+                  onClick={() => toggle(item.id)}
+                  className={cn(
+                    'hover:bg-muted/60 flex w-full items-center justify-between gap-4 px-5 py-4 text-start transition-colors',
+                    'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+                    'disabled:pointer-events-none disabled:opacity-50'
+                  )}
+                >
+                  <span className="text-foreground min-w-0 text-sm font-semibold">
+                    {item.title}
+                  </span>
+                  <ChevronDown
+                    aria-hidden="true"
+                    className={cn(
+                      'text-muted-foreground h-5 w-5 shrink-0 transition-transform duration-200',
+                      isOpen && 'rotate-180'
+                    )}
+                  />
+                </button>
+              </Heading>
+              {/* grid-rows 0fr→1fr animates to natural height without a max-height clip */}
+              <div
+                id={panelId}
+                role="region"
+                aria-labelledby={triggerId}
+                className={cn(
+                  'grid transition-[grid-template-rows] duration-200 ease-out',
+                  isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                )}
+              >
+                <div className="overflow-hidden">
+                  <div className="text-muted-foreground px-5 pb-4 text-sm leading-relaxed">
+                    {item.content}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+);

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -108,7 +108,13 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
     const [internalOpen, setInternalOpen] = React.useState<string[]>(
       () => defaultOpenIds ?? []
     );
-    const open = controlledOpen ?? internalOpen;
+    const rawOpen = controlledOpen ?? internalOpen;
+    // Single mode keeps at most one panel open, even if defaultOpenIds or a
+    // controlled openIds array hands us several.
+    const open = React.useMemo(
+      () => (type === 'single' ? rawOpen.slice(0, 1) : rawOpen),
+      [type, rawOpen]
+    );
     const openSet = React.useMemo(() => new Set(open), [open]);
 
     const toggle = (id: string) => {
@@ -161,11 +167,14 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
                   />
                 </button>
               </Heading>
-              {/* grid-rows 0fr→1fr animates to natural height without a max-height clip */}
+              {/* grid-rows 0fr→1fr animates to natural height without a max-height clip;
+                  collapsed panels are hidden from AT and unfocusable via aria-hidden + inert */}
               <div
                 id={panelId}
                 role="region"
                 aria-labelledby={triggerId}
+                aria-hidden={!isOpen}
+                inert={!isOpen || undefined}
                 className={cn(
                   'grid transition-[grid-template-rows] duration-200 ease-out',
                   isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,0 +1,5 @@
+export {
+  Accordion,
+  type AccordionProps,
+  type AccordionItem,
+} from './Accordion';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Components
 export * from './components/AddContactModal';
+export * from './components/Accordion';
 export * from './components/AdditionalFields';
 export * from './components/Address';
 // AG Grid is exported via a separate entry point: @mieweb/ui/ag-grid

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -125,6 +125,10 @@ module.exports = {
     'overflow-auto',
     // Select component
     'truncate',
+    // Accordion — grid-rows height animation (arbitrary values TW3 won't scan)
+    'transition-[grid-template-rows]',
+    'grid-rows-[0fr]',
+    'grid-rows-[1fr]',
   ],
   theme: {
     extend: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -599,6 +599,10 @@ export const miewebUISafelist = [
   'dark:border-primary-800',
   'dark:text-primary-300',
   'opacity-60',
+  // Accordion — grid-rows height animation (arbitrary values TW3 won't scan)
+  'transition-[grid-template-rows]',
+  'grid-rows-[0fr]',
+  'grid-rows-[1fr]',
 ];
 
 export interface MiewebUIPreset {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'utils/index': 'src/utils/index.ts',
     'tailwind-preset': 'src/tailwind-preset.ts',
     // Individual component entries for tree-shaking
+    'components/Accordion/index': 'src/components/Accordion/index.ts',
     'components/Alert/index': 'src/components/Alert/index.ts',
     'components/AlertDialog/index': 'src/components/AlertDialog/index.ts',
     'components/AudioPlayer/index': 'src/components/AudioPlayer/index.ts',


### PR DESCRIPTION
Adds the generic expandable-panel primitive the library was missing — `ServiceAccordion` is domain-specific, and consumers (bluehive-marketing's FAQ lists among them) have been hand-rolling this pattern.

## What it does

- **`single` / `multiple`** open modes, uncontrolled (`defaultOpenIds`) or controlled (`openIds`/`onOpenChange`), with `collapsible` for single mode
- **Animates to natural height** using the CSS grid-rows trick (`0fr → 1fr`) — no `max-height` clipping of long answers (the bug lurking in the hand-rolled versions)
- **Real a11y wiring**: triggers are buttons inside configurable headings (`headingLevel`), with `aria-expanded`/`aria-controls` and labelled panel regions; per-item `disabled`
- **Two variants**: `separated` cards with gaps, or a `joined` bordered list with dividers

## Screenshots

| Light | Dark |
|---|---|
| ![Accordion light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr6-accordion-light.png) | ![Accordion dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr6-accordion-dark.png) |

## Provenance

Generalizes `bluehive-marketing/src/components/ui/FAQAccordion.tsx` (FAQ lists on the marketing site) into a data-driven primitive with modes, variants, and controlled state.

## Testing

- 7 unit tests (aria wiring, single closes previous, non-collapsible floor, multiple independence, controlled state, disabled items)
- 4 stories: FAQ default, joined variant, multiple mode, controlled
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 622/622