### PR TITLE
feat(FreshnessBadge): recency chip + dot with configurable thresholds

### DIFF
--- a/src/components/FreshnessBadge/FreshnessBadge.stories.tsx
+++ b/src/components/FreshnessBadge/FreshnessBadge.stories.tsx
@@ -36,6 +36,17 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: { date: daysAgo(12) },
+  // Storybook's date control emits a numeric timestamp; normalize it back
+  // to a Date so the component's string | Date contract holds.
+  render: (args) => {
+    const raw = args.date as string | number | Date;
+    return (
+      <FreshnessBadge
+        {...args}
+        date={typeof raw === 'number' ? new Date(raw) : raw}
+      />
+    );
+  },
 };
 
 export const Levels: Story = {

--- a/src/components/FreshnessBadge/FreshnessBadge.stories.tsx
+++ b/src/components/FreshnessBadge/FreshnessBadge.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DateTime } from 'luxon';
+import { FreshnessBadge, FreshnessDot } from './FreshnessBadge';
+
+const daysAgo = (n: number) => DateTime.now().minus({ days: n }).toISODate()!;
+
+const meta: Meta<typeof FreshnessBadge> = {
+  title: 'Components/Data Display/FreshnessBadge',
+  component: FreshnessBadge,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A recency chip that ages from success through warning to destructive — "Reviewed ' +
+          '12d ago". Thresholds are configurable per use (default 90/180 days), so the same ' +
+          'component covers source-registry review ages, sync statuses, and data-quality ' +
+          'freshness. `FreshnessDot` is the compact variant for table cells; `freshnessLevel` ' +
+          'and `daysSince` are exported for host logic.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    date: { description: 'The date being aged.', control: 'date' },
+    thresholds: {
+      description: 'Day cutoffs for fresh/aging (default 90/180).',
+      control: false,
+    },
+    label: { description: 'Verb before the age.', control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { date: daysAgo(12) },
+};
+
+export const Levels: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <FreshnessBadge date={daysAgo(0)} />
+      <FreshnessBadge date={daysAgo(120)} />
+      <FreshnessBadge date={daysAgo(400)} />
+    </div>
+  ),
+};
+
+export const SyncStatus: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <FreshnessBadge
+        date={daysAgo(0)}
+        label="Synced"
+        thresholds={{ fresh: 1, aging: 7 }}
+      />
+      <FreshnessBadge
+        date={daysAgo(3)}
+        label="Synced"
+        thresholds={{ fresh: 1, aging: 7 }}
+      />
+      <FreshnessBadge
+        date={daysAgo(30)}
+        label="Synced"
+        thresholds={{ fresh: 1, aging: 7 }}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tighter thresholds turn the same chip into a sync-status indicator.',
+      },
+    },
+  },
+};
+
+export const Dots: Story = {
+  render: () => (
+    <table className="border-border w-72 border-collapse border text-sm">
+      <tbody>
+        {[
+          { source: 'BLS SOII 2025', d: 20 },
+          { source: 'State plan table', d: 150 },
+          { source: 'Legacy import', d: 500 },
+        ].map((row) => (
+          <tr key={row.source}>
+            <td className="border-border text-foreground border px-3 py-2">
+              {row.source}
+            </td>
+            <td className="border-border border px-3 py-2 text-center">
+              <FreshnessDot date={daysAgo(row.d)} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'The dot variant carries the same signal in table cells.',
+      },
+    },
+  },
+};

--- a/src/components/FreshnessBadge/FreshnessBadge.test.tsx
+++ b/src/components/FreshnessBadge/FreshnessBadge.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import {
+  FreshnessBadge,
+  FreshnessDot,
+  freshnessLevel,
+  daysSince,
+} from './FreshnessBadge';
+
+const NOW = new Date('2026-08-22T12:00:00Z');
+
+describe('FreshnessBadge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('buckets dates by the default thresholds', () => {
+    expect(freshnessLevel('2026-08-01')).toBe('fresh');
+    expect(freshnessLevel('2026-04-01')).toBe('aging');
+    expect(freshnessLevel('2025-08-01')).toBe('stale');
+  });
+
+  it('respects custom thresholds', () => {
+    const t = { fresh: 1, aging: 7 };
+    expect(freshnessLevel('2026-08-22', t)).toBe('fresh');
+    expect(freshnessLevel('2026-08-19', t)).toBe('aging');
+    expect(freshnessLevel('2026-08-01', t)).toBe('stale');
+  });
+
+  it('computes whole days since, clamped at zero', () => {
+    expect(daysSince('2026-08-20')).toBe(2);
+    expect(daysSince('2026-09-01')).toBe(0);
+  });
+
+  it('renders today / yesterday / Nd ago text', () => {
+    const { rerender } = renderWithTheme(<FreshnessBadge date="2026-08-22" />);
+    expect(screen.getByText(/reviewed today/i)).toBeInTheDocument();
+    rerender(<FreshnessBadge date="2026-08-21" />);
+    expect(screen.getByText(/reviewed yesterday/i)).toBeInTheDocument();
+    rerender(<FreshnessBadge date="2026-08-10" />);
+    expect(screen.getByText(/reviewed 12d ago/i)).toBeInTheDocument();
+  });
+
+  it('uses a custom label verb', () => {
+    renderWithTheme(<FreshnessBadge date="2026-08-20" label="Synced" />);
+    expect(screen.getByText(/synced 2d ago/i)).toBeInTheDocument();
+  });
+
+  it('accepts Date objects', () => {
+    renderWithTheme(<FreshnessBadge date={new Date('2026-08-15T00:00:00Z')} />);
+    expect(screen.getByText(/reviewed 7d ago/i)).toBeInTheDocument();
+  });
+
+  it('dot exposes level and age to assistive tech', () => {
+    renderWithTheme(<FreshnessDot date="2025-01-01" />);
+    const dot = screen.getByRole('img');
+    expect(dot).toHaveAccessibleName(/stale — reviewed \d+d ago/i);
+  });
+});

--- a/src/components/FreshnessBadge/FreshnessBadge.test.tsx
+++ b/src/components/FreshnessBadge/FreshnessBadge.test.tsx
@@ -62,4 +62,13 @@ describe('FreshnessBadge', () => {
     const dot = screen.getByRole('img');
     expect(dot).toHaveAccessibleName(/stale — reviewed \d+d ago/i);
   });
+
+  it('treats unparseable dates as unknown instead of fresh or stale', () => {
+    expect(freshnessLevel('not-a-date')).toBe('unknown');
+    expect(freshnessLevel(new Date('invalid'))).toBe('unknown');
+    expect(daysSince('not-a-date')).toBeNull();
+
+    renderWithTheme(<FreshnessBadge date="not-a-date" />);
+    expect(screen.getByText(/reviewed date unknown/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/FreshnessBadge/FreshnessBadge.tsx
+++ b/src/components/FreshnessBadge/FreshnessBadge.tsx
@@ -2,14 +2,19 @@
 
 import * as React from 'react';
 import { DateTime } from 'luxon';
-import { CircleAlert, CircleCheck, CircleMinus } from 'lucide-react';
+import {
+  CircleAlert,
+  CircleCheck,
+  CircleHelp,
+  CircleMinus,
+} from 'lucide-react';
 import { cn } from '../../utils/cn';
 
 // =============================================================================
 // Types & helpers
 // =============================================================================
 
-export type FreshnessLevel = 'fresh' | 'aging' | 'stale';
+export type FreshnessLevel = 'fresh' | 'aging' | 'stale' | 'unknown';
 
 export interface FreshnessThresholds {
   /** Days within which a date counts as fresh (default 90). */
@@ -26,24 +31,34 @@ function toDateTime(date: string | Date): DateTime {
     : DateTime.fromJSDate(date);
 }
 
-/** Whole days elapsed since the given date (0 for today/future). */
-export function daysSince(date: string | Date): number {
-  const days = Math.floor(DateTime.now().diff(toDateTime(date), 'days').days);
+/**
+ * Whole days elapsed since the given date (0 for today/future), or `null`
+ * when the date cannot be parsed.
+ */
+export function daysSince(date: string | Date): number | null {
+  const dt = toDateTime(date);
+  if (!dt.isValid) return null;
+  const days = Math.floor(DateTime.now().diff(dt, 'days').days);
   return Math.max(0, days);
 }
 
-/** Bucket a date into fresh / aging / stale by day thresholds. */
+/**
+ * Bucket a date into fresh / aging / stale by day thresholds. Unparseable
+ * dates return `unknown` rather than masquerading as fresh or stale.
+ */
 export function freshnessLevel(
   date: string | Date,
   thresholds: FreshnessThresholds = DEFAULT_THRESHOLDS
 ): FreshnessLevel {
   const days = daysSince(date);
+  if (days === null) return 'unknown';
   if (days < thresholds.fresh) return 'fresh';
   if (days < thresholds.aging) return 'aging';
   return 'stale';
 }
 
-function ageText(days: number): string {
+function ageText(days: number | null): string {
+  if (days === null) return 'date unknown';
   return days === 0 ? 'today' : days === 1 ? 'yesterday' : `${days}d ago`;
 }
 
@@ -68,6 +83,12 @@ const META: Record<
     chip: 'bg-destructive/10 text-destructive dark:bg-destructive/20',
     dot: 'bg-destructive',
     label: 'Stale',
+  },
+  unknown: {
+    Icon: CircleHelp,
+    chip: 'bg-muted text-muted-foreground',
+    dot: 'bg-muted-foreground/50',
+    label: 'Unknown',
   },
 };
 

--- a/src/components/FreshnessBadge/FreshnessBadge.tsx
+++ b/src/components/FreshnessBadge/FreshnessBadge.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import * as React from 'react';
+import { DateTime } from 'luxon';
+import { CircleAlert, CircleCheck, CircleMinus } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+// =============================================================================
+// Types & helpers
+// =============================================================================
+
+export type FreshnessLevel = 'fresh' | 'aging' | 'stale';
+
+export interface FreshnessThresholds {
+  /** Days within which a date counts as fresh (default 90). */
+  fresh: number;
+  /** Days within which a date counts as aging; beyond is stale (default 180). */
+  aging: number;
+}
+
+const DEFAULT_THRESHOLDS: FreshnessThresholds = { fresh: 90, aging: 180 };
+
+function toDateTime(date: string | Date): DateTime {
+  return typeof date === 'string'
+    ? DateTime.fromISO(date)
+    : DateTime.fromJSDate(date);
+}
+
+/** Whole days elapsed since the given date (0 for today/future). */
+export function daysSince(date: string | Date): number {
+  const days = Math.floor(DateTime.now().diff(toDateTime(date), 'days').days);
+  return Math.max(0, days);
+}
+
+/** Bucket a date into fresh / aging / stale by day thresholds. */
+export function freshnessLevel(
+  date: string | Date,
+  thresholds: FreshnessThresholds = DEFAULT_THRESHOLDS
+): FreshnessLevel {
+  const days = daysSince(date);
+  if (days < thresholds.fresh) return 'fresh';
+  if (days < thresholds.aging) return 'aging';
+  return 'stale';
+}
+
+function ageText(days: number): string {
+  return days === 0 ? 'today' : days === 1 ? 'yesterday' : `${days}d ago`;
+}
+
+const META: Record<
+  FreshnessLevel,
+  { Icon: typeof CircleCheck; chip: string; dot: string; label: string }
+> = {
+  fresh: {
+    Icon: CircleCheck,
+    chip: 'bg-success/10 text-success dark:bg-success/20',
+    dot: 'bg-success',
+    label: 'Fresh',
+  },
+  aging: {
+    Icon: CircleMinus,
+    chip: 'bg-warning/15 text-warning-700 dark:bg-warning/20 dark:text-warning',
+    dot: 'bg-warning',
+    label: 'Aging',
+  },
+  stale: {
+    Icon: CircleAlert,
+    chip: 'bg-destructive/10 text-destructive dark:bg-destructive/20',
+    dot: 'bg-destructive',
+    label: 'Stale',
+  },
+};
+
+// =============================================================================
+// Components
+// =============================================================================
+
+export interface FreshnessBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** The date being aged — last review, last sync, last update. */
+  date: string | Date;
+  /** Day cutoffs for fresh/aging (default 90/180). */
+  thresholds?: FreshnessThresholds;
+  /** Verb before the age (default "Reviewed"). */
+  label?: string;
+}
+
+/**
+ * A recency chip that ages from success through warning to destructive:
+ * "Reviewed 12d ago". Suits source registries, sync statuses, data-quality
+ * dashboards — anywhere staleness is a signal.
+ *
+ * @example
+ * ```tsx
+ * <FreshnessBadge date="2026-07-01" />
+ * <FreshnessBadge date={lastSync} label="Synced" thresholds={{ fresh: 1, aging: 7 }} />
+ * ```
+ */
+export const FreshnessBadge = React.forwardRef<
+  HTMLSpanElement,
+  FreshnessBadgeProps
+>(function FreshnessBadge(
+  {
+    date,
+    thresholds = DEFAULT_THRESHOLDS,
+    label = 'Reviewed',
+    className,
+    ...props
+  },
+  ref
+) {
+  const level = freshnessLevel(date, thresholds);
+  const days = daysSince(date);
+  const { Icon, chip } = META[level];
+  return (
+    <span
+      ref={ref}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold',
+        chip,
+        className
+      )}
+      {...props}
+    >
+      <Icon aria-hidden="true" className="h-3 w-3 shrink-0" />
+      {label} {ageText(days)}
+    </span>
+  );
+});
+
+export interface FreshnessDotProps extends React.HTMLAttributes<HTMLSpanElement> {
+  date: string | Date;
+  thresholds?: FreshnessThresholds;
+  /** Verb used in the accessible label and tooltip (default "Reviewed"). */
+  label?: string;
+}
+
+/** Colored dot for tight spots — table cells, tooltip source rows. */
+export const FreshnessDot = React.forwardRef<
+  HTMLSpanElement,
+  FreshnessDotProps
+>(function FreshnessDot(
+  {
+    date,
+    thresholds = DEFAULT_THRESHOLDS,
+    label = 'Reviewed',
+    className,
+    ...props
+  },
+  ref
+) {
+  const level = freshnessLevel(date, thresholds);
+  const days = daysSince(date);
+  const description = `${META[level].label} — ${label.toLowerCase()} ${ageText(days)}`;
+  return (
+    <span
+      ref={ref}
+      role="img"
+      aria-label={description}
+      title={description}
+      className={cn(
+        'inline-block h-2 w-2 shrink-0 rounded-full',
+        META[level].dot,
+        className
+      )}
+      {...props}
+    />
+  );
+});

--- a/src/components/FreshnessBadge/index.ts
+++ b/src/components/FreshnessBadge/index.ts
@@ -1,0 +1,10 @@
+export {
+  FreshnessBadge,
+  FreshnessDot,
+  freshnessLevel,
+  daysSince,
+  type FreshnessBadgeProps,
+  type FreshnessDotProps,
+  type FreshnessLevel,
+  type FreshnessThresholds,
+} from './FreshnessBadge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export * from './components/EmployerServiceModal';
 export * from './components/ErrorPage';
 export * from './components/FileManager';
 export * from './components/FloatingWindow';
+export * from './components/FreshnessBadge';
 export * from './components/HealthSurveillance';
 export * from './components/HelpSupportPanel';
 export * from './components/HRISProviderSelector';

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -125,6 +125,17 @@ module.exports = {
     'overflow-auto',
     // Select component
     'truncate',
+    // FreshnessBadge / FreshnessDot — tinted level chips and dots
+    'bg-success/10',
+    'dark:bg-success/20',
+    'bg-warning/15',
+    'dark:bg-warning/20',
+    'text-warning-700',
+    'dark:text-warning',
+    'bg-destructive/10',
+    'dark:bg-destructive/20',
+    'bg-muted-foreground/50',
+    'text-[11px]',
   ],
   theme: {
     extend: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -599,6 +599,17 @@ export const miewebUISafelist = [
   'dark:border-primary-800',
   'dark:text-primary-300',
   'opacity-60',
+  // FreshnessBadge / FreshnessDot — tinted level chips and dots
+  'bg-success/10',
+  'dark:bg-success/20',
+  'bg-warning/15',
+  'dark:bg-warning/20',
+  'text-warning-700',
+  'dark:text-warning',
+  'bg-destructive/10',
+  'dark:bg-destructive/20',
+  'bg-muted-foreground/50',
+  'text-[11px]',
 ];
 
 export interface MiewebUIPreset {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     'components/DateInput/index': 'src/components/DateInput/index.ts',
     'components/Dropdown/index': 'src/components/Dropdown/index.ts',
     'components/FloatingWindow/index': 'src/components/FloatingWindow/index.ts',
+    'components/FreshnessBadge/index': 'src/components/FreshnessBadge/index.ts',
     'components/Input/index': 'src/components/Input/index.ts',
     'components/Label/index': 'src/components/Label/index.ts',
     'components/Markdown/index': 'src/components/Markdown/index.ts',


### PR DESCRIPTION
Ports the Observatory's source-registry freshness chip into the design system as a general recency indicator.

## What it does

- **`FreshnessBadge`** — a chip that ages from success through warning to destructive: "Reviewed 12d ago" / "today" / "yesterday". `label` swaps the verb ("Synced", "Updated"…)
- **`FreshnessDot`** — the compact variant for table cells and tooltip rows, with the level + age exposed via `aria-label`/`title`
- **Configurable thresholds** (default 90/180 days) — tight thresholds (`{ fresh: 1, aging: 7 }`) turn the same chip into a sync-status indicator for HubSpot/Intacct-style integrations
- **`freshnessLevel`/`daysSince` exported** for host logic (sorting, filtering, alerts); day math on luxon per house convention

## Screenshots

All three levels:

| Light | Dark |
|---|---|
| ![FreshnessBadge light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr7-freshness-badge-light.png) | ![FreshnessBadge dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr7-freshness-badge-dark.png) |

## Provenance

Port of `enterprise-health-observatory/src/components/Freshness.tsx`, decoupled from its sources registry (`sourceFreshness`/`daysSince` now live in the component with thresholds as props) and retokened from teal/gilt/rose to the `success`/`warning`/`destructive` scales.

## Testing

- 7 unit tests (default + custom threshold bucketing, day math with clamping, today/yesterday/Nd text, custom verb, Date object input, dot accessibility) under a fixed system clock
- 4 stories: default, all levels, sync-status thresholds, table-cell dots
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 622/622