### PR TITLE
feat(ReadingProgressBar): scroll-progress bar for long-form pages

### DIFF
--- a/src/components/ReadingProgressBar/ReadingProgressBar.stories.tsx
+++ b/src/components/ReadingProgressBar/ReadingProgressBar.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ReadingProgressBar } from './ReadingProgressBar';
+
+const meta: Meta<typeof ReadingProgressBar> = {
+  title: 'Components/Feedback/ReadingProgressBar',
+  component: ReadingProgressBar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A thin progress bar pinned to the top of the viewport, tracking how far the reader ' +
+          'has scrolled through the document. Decorative (`aria-hidden`), rAF-throttled, and ' +
+          'token-colored — pair it with long-form articles, guides, and reports.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    barClassName: {
+      description: 'Class for the filled bar (default bg-primary-500).',
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function LongArticle() {
+  return (
+    <main className="mx-auto flex max-w-xl flex-col gap-6 px-6 py-10">
+      <h1 className="text-foreground text-2xl font-bold">
+        Scroll to see the bar fill
+      </h1>
+      {Array.from({ length: 14 }, (_, i) => (
+        <p key={i} className="text-muted-foreground text-sm leading-relaxed">
+          Section {i + 1} — placeholder prose standing in for a long-form
+          article. The bar at the very top of the viewport tracks overall
+          document progress as you scroll, updating at most once per frame.
+        </p>
+      ))}
+    </main>
+  );
+}
+
+export const Default: Story = {
+  render: (args) => (
+    <div>
+      <ReadingProgressBar {...args} />
+      <LongArticle />
+    </div>
+  ),
+};
+
+export const CustomBar: Story = {
+  args: { barClassName: 'bg-warning', className: 'h-0.5' },
+  render: (args) => (
+    <div>
+      <ReadingProgressBar {...args} />
+      <LongArticle />
+    </div>
+  ),
+};

--- a/src/components/ReadingProgressBar/ReadingProgressBar.test.tsx
+++ b/src/components/ReadingProgressBar/ReadingProgressBar.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { ReadingProgressBar } from './ReadingProgressBar';
+
+function mockScrollMetrics({
+  scrollTop = 0,
+  scrollHeight = 2000,
+  clientHeight = 1000,
+}) {
+  Object.defineProperty(document.documentElement, 'scrollTop', {
+    configurable: true,
+    value: scrollTop,
+  });
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    configurable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(document.documentElement, 'clientHeight', {
+    configurable: true,
+    value: clientHeight,
+  });
+}
+
+function fill(container: HTMLElement): HTMLElement {
+  return container.querySelector(
+    '[data-slot="reading-progress-fill"]'
+  ) as HTMLElement;
+}
+
+describe('ReadingProgressBar', () => {
+  beforeEach(() => {
+    // rAF fires synchronously so scroll-driven updates apply immediately
+    vi.stubGlobal('requestAnimationFrame', (cb: (time: number) => void) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts at 0% at the top of the document', () => {
+    mockScrollMetrics({ scrollTop: 0 });
+    const { container } = renderWithTheme(<ReadingProgressBar />);
+    expect(fill(container).style.width).toBe('0%');
+  });
+
+  it('tracks scroll position', () => {
+    mockScrollMetrics({ scrollTop: 0 });
+    const { container } = renderWithTheme(<ReadingProgressBar />);
+
+    mockScrollMetrics({ scrollTop: 500 });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(fill(container).style.width).toBe('50%');
+
+    mockScrollMetrics({ scrollTop: 1000 });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(fill(container).style.width).toBe('100%');
+  });
+
+  it('clamps to 100% and handles unscrollable documents', () => {
+    mockScrollMetrics({ scrollTop: 5000 });
+    const { container, rerender } = renderWithTheme(<ReadingProgressBar />);
+    expect(fill(container).style.width).toBe('100%');
+
+    mockScrollMetrics({ scrollTop: 0, scrollHeight: 800, clientHeight: 1000 });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    rerender(<ReadingProgressBar />);
+    expect(fill(container).style.width).toBe('0%');
+  });
+
+  it('is hidden from assistive tech and accepts a custom bar class', () => {
+    mockScrollMetrics({ scrollTop: 0 });
+    const { container } = renderWithTheme(
+      <ReadingProgressBar barClassName="bg-warning" />
+    );
+    expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true');
+    expect(fill(container)).toHaveClass('bg-warning');
+  });
+});

--- a/src/components/ReadingProgressBar/ReadingProgressBar.tsx
+++ b/src/components/ReadingProgressBar/ReadingProgressBar.tsx
@@ -31,7 +31,9 @@ export const ReadingProgressBar = React.forwardRef<
     const update = () => {
       const el = document.documentElement;
       const max = el.scrollHeight - el.clientHeight;
-      setPct(max > 0 ? Math.min(100, (el.scrollTop / max) * 100) : 0);
+      setPct(
+        max > 0 ? Math.min(100, Math.max(0, (el.scrollTop / max) * 100)) : 0
+      );
     };
 
     // Coalesce bursty scroll events to one state update per frame
@@ -54,7 +56,10 @@ export const ReadingProgressBar = React.forwardRef<
     <div
       ref={ref}
       aria-hidden="true"
-      className={cn('fixed inset-x-0 top-0 z-50 h-1 bg-transparent', className)}
+      className={cn(
+        'pointer-events-none fixed inset-x-0 top-0 z-50 h-1 bg-transparent',
+        className
+      )}
       {...props}
     >
       <div

--- a/src/components/ReadingProgressBar/ReadingProgressBar.tsx
+++ b/src/components/ReadingProgressBar/ReadingProgressBar.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface ReadingProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Class for the filled bar (default `bg-primary-500`). */
+  barClassName?: string;
+}
+
+/**
+ * A thin progress bar pinned to the top of the viewport, tracking how far
+ * the reader has scrolled through the document. Purely decorative
+ * (`aria-hidden`) — long-form articles, guides, reports.
+ *
+ * @example
+ * ```tsx
+ * <ReadingProgressBar />
+ * <ReadingProgressBar barClassName="bg-warning" className="h-0.5" />
+ * ```
+ */
+export const ReadingProgressBar = React.forwardRef<
+  HTMLDivElement,
+  ReadingProgressBarProps
+>(function ReadingProgressBar({ className, barClassName, ...props }, ref) {
+  const [pct, setPct] = React.useState(0);
+
+  React.useEffect(() => {
+    let rafId = 0;
+
+    const update = () => {
+      const el = document.documentElement;
+      const max = el.scrollHeight - el.clientHeight;
+      setPct(max > 0 ? Math.min(100, (el.scrollTop / max) * 100) : 0);
+    };
+
+    // Coalesce bursty scroll events to one state update per frame
+    const schedule = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={cn('fixed inset-x-0 top-0 z-50 h-1 bg-transparent', className)}
+      {...props}
+    >
+      <div
+        data-slot="reading-progress-fill"
+        className={cn(
+          'h-full transition-[width] duration-150',
+          barClassName ?? 'bg-primary-500'
+        )}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+});

--- a/src/components/ReadingProgressBar/index.ts
+++ b/src/components/ReadingProgressBar/index.ts
@@ -1,0 +1,4 @@
+export {
+  ReadingProgressBar,
+  type ReadingProgressBarProps,
+} from './ReadingProgressBar';

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ export * from './components/ProviderUsersTable';
 export * from './components/QuickAction';
 export * from './components/QuickLinksCard';
 export * from './components/Radio';
+export * from './components/ReadingProgressBar';
 export * from './components/RecordButton';
 export * from './components/RecurringServiceCard';
 export * from './components/RejectionModal';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
     'components/Q/index': 'src/components/Q/index.ts',
     'components/QuickAction/index': 'src/components/QuickAction/index.ts',
     'components/Radio/index': 'src/components/Radio/index.ts',
+    'components/ReadingProgressBar/index':
+      'src/components/ReadingProgressBar/index.ts',
     'components/RecordButton/index': 'src/components/RecordButton/index.ts',
     'components/RichTextEditor/index': 'src/components/RichTextEditor/index.ts',
     'components/SchedulePicker/index': 'src/components/SchedulePicker/index.ts',


### PR DESCRIPTION
Ports the Enterprise Health frontdoor's reading-progress bar — the thin bar pinned to the viewport top that fills as the reader scrolls a long-form page.

## What it does

- Tracks document scroll and fills 0–100%, clamped, with unscrollable documents handled
- **rAF-coalesced** scroll handler (one state update per frame — an upgrade over the source's per-event updates), passive listener, resize-aware
- Decorative by design (`aria-hidden`); token-colored with `bg-primary-500` default and `barClassName`/`className` overrides for color and thickness
- Pairs with `TableOfContents` and `SectionSpyNav` (#392) as the third piece of long-form wayfinding

## Screenshots

Mid-article, ~55% read:

| Light | Dark |
|---|---|
| ![ReadingProgressBar light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr8-reading-progress-bar-light.png) | ![ReadingProgressBar dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr8-reading-progress-bar-dark.png) |

## Provenance

Port of `enterprise-health-frontdoor/components/ui/ReadingProgressBar.tsx`, retokened from the EH gilt to the primary scale.

## Testing

- 4 unit tests (0% at top, scroll tracking, 100% clamp + unscrollable documents, aria-hidden + custom bar class) with mocked scroll metrics and synchronous rAF
- 2 stories: default and custom color/thickness over a long article
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 622/622