### PR TITLE
feat(CopyButton): inline copy-to-clipboard button with success flash

### DIFF
--- a/src/components/CopyButton/CopyButton.stories.tsx
+++ b/src/components/CopyButton/CopyButton.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CopyButton } from './CopyButton';
+
+const meta: Meta<typeof CopyButton> = {
+  title: 'Components/Buttons & Actions/CopyButton',
+  component: CopyButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'An inline copy-to-clipboard icon button with a brief success check. Click events ' +
+          'are stopped so it is safe inside clickable rows and links. Each instance keeps ' +
+          'its own state — drop it next to IDs, emails, phone numbers, and API keys.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    value: { description: 'Text written to the clipboard.', control: 'text' },
+    label: { description: 'Accessible label / tooltip.', control: 'text' },
+    copiedLabel: {
+      description: 'Label while the copied state shows.',
+      control: 'text',
+    },
+    timeout: { description: 'Copied-state duration in ms.', control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { value: 'WC-10382', label: 'Copy MRN' },
+  render: (args) => (
+    <span className="text-foreground flex items-center gap-1 text-sm">
+      MRN <span className="font-mono font-medium">WC-10382</span>
+      <CopyButton {...args} />
+    </span>
+  ),
+};
+
+export const InDetailFields: Story = {
+  render: () => (
+    <dl className="grid w-80 grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+      {[
+        { label: 'Email', value: 'w.hart@example.com' },
+        { label: 'Phone', value: '+1 (260) 555-0184' },
+        { label: 'Waggle ID', value: 'wgl_8f3k2m' },
+      ].map((row) => (
+        <div key={row.label} className="contents">
+          <dt className="text-muted-foreground">{row.label}</dt>
+          <dd className="text-foreground flex items-center gap-1">
+            <span className="truncate">{row.value}</span>
+            <CopyButton
+              value={row.value}
+              label={`Copy ${row.label.toLowerCase()}`}
+            />
+          </dd>
+        </div>
+      ))}
+    </dl>
+  ),
+};

--- a/src/components/CopyButton/CopyButton.test.tsx
+++ b/src/components/CopyButton/CopyButton.test.tsx
@@ -9,10 +9,15 @@ describe('CopyButton', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     writeText.mockReset().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText } });
+    // Stub (rather than mutate) the global so it is restored after each test
+    vi.stubGlobal('navigator', {
+      ...window.navigator,
+      clipboard: { writeText },
+    });
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 

--- a/src/components/CopyButton/CopyButton.test.tsx
+++ b/src/components/CopyButton/CopyButton.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, fireEvent, act } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { CopyButton } from './CopyButton';
+
+describe('CopyButton', () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText.mockReset().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('copies the value and flashes the copied state', async () => {
+    const onCopied = vi.fn();
+    renderWithTheme(<CopyButton value="WC-10382" onCopied={onCopied} />);
+    const btn = screen.getByRole('button', { name: 'Copy' });
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('WC-10382');
+    expect(onCopied).toHaveBeenCalledWith('WC-10382');
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1300);
+    });
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('uses custom labels', async () => {
+    renderWithTheme(
+      <CopyButton value="x" label="Copy MRN" copiedLabel="MRN copied" />
+    );
+    const btn = screen.getByRole('button', { name: 'Copy MRN' });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    expect(
+      screen.getByRole('button', { name: 'MRN copied' })
+    ).toBeInTheDocument();
+  });
+
+  it('stops propagation so row clicks do not fire', async () => {
+    const onRowClick = vi.fn();
+    renderWithTheme(
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- simulates a clickable grid row
+      <div onClick={onRowClick}>
+        <CopyButton value="x" />
+      </div>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when clipboard access is denied', async () => {
+    writeText.mockRejectedValue(new Error('denied'));
+    renderWithTheme(<CopyButton value="x" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+});

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import * as React from 'react';
+import { Check, Copy } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+export interface CopyButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'value'
+> {
+  /** Text written to the clipboard. */
+  value: string;
+  /** Accessible label / tooltip (default "Copy"). */
+  label?: string;
+  /** Label while the copied state shows (default "Copied"). */
+  copiedLabel?: string;
+  /** How long the copied state shows, in ms (default 1200). */
+  timeout?: number;
+  /** Called after a successful copy. */
+  onCopied?: (value: string) => void;
+}
+
+/**
+ * An inline copy-to-clipboard icon button with a brief success check.
+ * Stateless across instances — safe to drop into table rows, ID chips,
+ * and detail fields.
+ *
+ * @example
+ * ```tsx
+ * <span className="flex items-center gap-1">
+ *   MRN WC-10382 <CopyButton value="WC-10382" label="Copy MRN" />
+ * </span>
+ * ```
+ */
+export const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
+  function CopyButton(
+    {
+      value,
+      label = 'Copy',
+      copiedLabel = 'Copied',
+      timeout = 1200,
+      onCopied,
+      className,
+      onClick,
+      ...props
+    },
+    ref
+  ) {
+    const [copied, setCopied] = React.useState(false);
+    const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    React.useEffect(
+      () => () => {
+        if (timer.current) clearTimeout(timer.current);
+      },
+      []
+    );
+
+    const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+      // Inside clickable rows/links the copy must not trigger the row action
+      e.stopPropagation();
+      e.preventDefault();
+      onClick?.(e);
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        onCopied?.(value);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), timeout);
+      } catch {
+        /* clipboard access denied — silent */
+      }
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={handleClick}
+        title={copied ? copiedLabel : label}
+        aria-label={copied ? copiedLabel : label}
+        className={cn(
+          'inline-flex shrink-0 items-center justify-center rounded p-1 transition-colors',
+          'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+          copied
+            ? 'text-success'
+            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+          className
+        )}
+        {...props}
+      >
+        {copied ? (
+          <Check aria-hidden="true" className="h-3.5 w-3.5" />
+        ) : (
+          <Copy aria-hidden="true" className="h-3.5 w-3.5" />
+        )}
+      </button>
+    );
+  }
+);

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -98,3 +98,5 @@ export const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
     );
   }
 );
+
+CopyButton.displayName = 'CopyButton';

--- a/src/components/CopyButton/index.ts
+++ b/src/components/CopyButton/index.ts
@@ -1,0 +1,1 @@
+export { CopyButton, type CopyButtonProps } from './CopyButton';

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export * from './components/CountBadge';
 export * from './components/CountryCodeDropdown';
 export * from './components/CountryDropdown';
 export * from './components/CookieConsent';
+export * from './components/CopyButton';
 export * from './components/CSVColumnMapper';
 export * from './components/DashboardWidget';
 export * from './components/DateInput';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     'components/Checkbox/index': 'src/components/Checkbox/index.ts',
     'components/CollabStatus/index': 'src/components/CollabStatus/index.ts',
     'components/Collapsible/index': 'src/components/Collapsible/index.ts',
+    'components/CopyButton/index': 'src/components/CopyButton/index.ts',
     'components/CountryCodeDropdown/index': 'src/components/CountryCodeDropdown/index.ts',
     'components/DateInput/index': 'src/components/DateInput/index.ts',
     'components/Dropdown/index': 'src/components/Dropdown/index.ts',


### PR DESCRIPTION
Ports waggleline's row-level copy affordance into the design system — the inline copy-to-clipboard button the library has been missing next to IDs, emails, phone numbers, and API keys.

## What it does

- Writes `value` to the clipboard and flashes a success check (`copiedLabel`, configurable `timeout`), then reverts
- **Stops propagation and prevents default**, so it is safe inside clickable rows, links, and grid cells
- Silent when clipboard access is denied; `onCopied` callback for toasts/analytics
- Per-instance state — drop any number into a table

## Screenshots

Detail fields with the email just copied (success check showing):

| Light | Dark |
|---|---|
| ![CopyButton light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr9-copy-button-light.png) | ![CopyButton dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr9-copy-button-dark.png) |

## Provenance

Port of `waggleline/app/imports/ui/components/CopyButton.tsx`; FontAwesome → lucide `Copy`/`Check`, hardcoded grays → semantic tokens, plus a `success`-token flash, configurable labels, and an `onCopied` hook.

## Testing

- 4 unit tests (copy + flash + revert under fake timers, custom labels, propagation stop, denied clipboard)
- 2 stories (inline usage, detail-field rows)
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 651/651