### PR TITLE
feat(ClampedText): N-line clamp with fade and Show more toggle

### DIFF
--- a/src/components/ClampedText/ClampedText.stories.tsx
+++ b/src/components/ClampedText/ClampedText.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof ClampedText> = {
     lines: {
       description: 'Lines visible while collapsed.',
       control: 'select',
-      options: [2, 3, 4, 5, 6, 8],
+      options: [2, 3, 4, 5, 6, 7, 8],
     },
     threshold: {
       description: 'Skip the clamp below this character count.',

--- a/src/components/ClampedText/ClampedText.stories.tsx
+++ b/src/components/ClampedText/ClampedText.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ClampedText } from './ClampedText';
+
+const LONG_TEXT = `Patient called regarding ongoing wrist discomfort following the workstation assessment on 6/12. Reports the new keyboard tray helped initially but symptoms returned after the quarterly reporting crunch. Discussed splint usage compliance — wearing it overnight but not during data entry, which is when symptoms peak.
+
+Recommended: resume PT exercises twice daily, schedule ergonomic re-evaluation, and follow up with occupational health if numbness spreads past the second digit. Employee agreed to a two-week check-in and asked whether the standing desk request from March was still in the approval queue — confirmed it cleared facilities on Monday and installation is scheduled for the 28th.`;
+
+const meta: Meta<typeof ClampedText> = {
+  title: 'Components/Data Display/ClampedText',
+  component: ClampedText,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Clamps long text to N lines with a fade-out gradient and a Show more / Show less ' +
+          'toggle. Text under the character threshold renders inline with no toggle. Match ' +
+          '`fadeClassName` to the surface behind the text (default `from-card`).',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    text: { description: 'The long text to clamp.', control: 'text' },
+    lines: {
+      description: 'Lines visible while collapsed.',
+      control: 'select',
+      options: [2, 3, 4, 5, 6, 8],
+    },
+    threshold: {
+      description: 'Skip the clamp below this character count.',
+      control: 'number',
+    },
+    fadeClassName: {
+      description: 'Gradient start matching the surface behind the text.',
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { text: LONG_TEXT, lines: 4 },
+  render: (args) => (
+    <div className="border-border bg-card text-foreground w-96 rounded-lg border p-4 text-sm leading-relaxed">
+      <h3 className="text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase">
+        Call note
+      </h3>
+      <ClampedText {...args} />
+    </div>
+  ),
+};
+
+export const ShortTextStaysFlat: Story = {
+  args: { text: 'Left voicemail; will retry Thursday.' },
+  render: (args) => (
+    <div className="border-border bg-card text-foreground w-96 rounded-lg border p-4 text-sm">
+      <ClampedText {...args} />
+    </div>
+  ),
+};
+
+export const OnPageBackground: Story = {
+  args: { text: LONG_TEXT, lines: 3, fadeClassName: 'from-background' },
+  render: (args) => (
+    <div className="text-foreground w-96 p-4 text-sm leading-relaxed">
+      <ClampedText {...args} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'On the page background, pass `fadeClassName="from-background"` so the fade matches.',
+      },
+    },
+  },
+};

--- a/src/components/ClampedText/ClampedText.test.tsx
+++ b/src/components/ClampedText/ClampedText.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { ClampedText } from './ClampedText';
+
+const LONG = 'lorem '.repeat(100).trim();
+
+describe('ClampedText', () => {
+  it('renders short text inline without a toggle', () => {
+    renderWithTheme(<ClampedText text="Short note" />);
+    expect(screen.getByText('Short note')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('clamps long text and toggles open/closed', () => {
+    const { container } = renderWithTheme(
+      <ClampedText text={LONG} lines={4} />
+    );
+    const clamped = container.querySelector('.line-clamp-4');
+    expect(clamped).not.toBeNull();
+
+    const toggle = screen.getByRole('button', { name: 'Show more' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggle);
+    expect(container.querySelector('.line-clamp-4')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Show less' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+    expect(container.querySelector('.line-clamp-4')).not.toBeNull();
+  });
+
+  it('respects a custom threshold', () => {
+    renderWithTheme(<ClampedText text="0123456789" threshold={5} />);
+    expect(
+      screen.getByRole('button', { name: 'Show more' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses custom toggle labels', () => {
+    renderWithTheme(
+      <ClampedText
+        text={LONG}
+        showMoreLabel="Expand"
+        showLessLabel="Collapse"
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+    expect(
+      screen.getByRole('button', { name: 'Collapse' })
+    ).toBeInTheDocument();
+  });
+
+  it('applies the fade class while collapsed', () => {
+    const { container } = renderWithTheme(
+      <ClampedText text={LONG} fadeClassName="from-background" />
+    );
+    expect(container.querySelector('.from-background')).not.toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+    expect(container.querySelector('.from-background')).toBeNull();
+  });
+});

--- a/src/components/ClampedText/ClampedText.tsx
+++ b/src/components/ClampedText/ClampedText.tsx
@@ -3,11 +3,11 @@
 import * as React from 'react';
 import { cn } from '../../utils/cn';
 
-export interface ClampedTextProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ClampedTextProps extends React.HTMLAttributes<HTMLElement> {
   /** The long text to clamp. */
   text: string;
   /** Lines visible while collapsed (2–8, default 6). */
-  lines?: 2 | 3 | 4 | 5 | 6 | 8;
+  lines?: 2 | 3 | 4 | 5 | 6 | 7 | 8;
   /** Skip the clamp entirely below this character count (default 280). */
   threshold?: number;
   /** Toggle labels, overridable for i18n. */
@@ -20,13 +20,17 @@ export interface ClampedTextProps extends React.HTMLAttributes<HTMLDivElement> {
   fadeClassName?: string;
 }
 
-// Static map so Tailwind sees every clamp utility it must generate
+// Static map so Tailwind sees every clamp utility it must generate.
+// 7/8 are beyond Tailwind 3's core 1–6 scale — the preset extends
+// theme.lineClamp so TW3 consumers generate them too (TW4 accepts any
+// integer as a bare value).
 const LINE_CLAMP: Record<number, string> = {
   2: 'line-clamp-2',
   3: 'line-clamp-3',
   4: 'line-clamp-4',
   5: 'line-clamp-5',
   6: 'line-clamp-6',
+  7: 'line-clamp-7',
   8: 'line-clamp-8',
 };
 
@@ -42,7 +46,7 @@ const LINE_CLAMP: Record<number, string> = {
  * <ClampedText text={note.body} lines={4} />
  * ```
  */
-export const ClampedText = React.forwardRef<HTMLDivElement, ClampedTextProps>(
+export const ClampedText = React.forwardRef<HTMLElement, ClampedTextProps>(
   function ClampedText(
     {
       text,
@@ -60,14 +64,22 @@ export const ClampedText = React.forwardRef<HTMLDivElement, ClampedTextProps>(
 
     if (text.length <= threshold) {
       return (
-        <span className={cn('break-words whitespace-pre-wrap', className)}>
+        <span
+          ref={ref as React.ForwardedRef<HTMLSpanElement>}
+          className={cn('break-words whitespace-pre-wrap', className)}
+          {...props}
+        >
           {text}
         </span>
       );
     }
 
     return (
-      <div ref={ref} className={className} {...props}>
+      <div
+        ref={ref as React.ForwardedRef<HTMLDivElement>}
+        className={className}
+        {...props}
+      >
         <div
           className={cn(
             'relative break-words whitespace-pre-wrap',

--- a/src/components/ClampedText/ClampedText.tsx
+++ b/src/components/ClampedText/ClampedText.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+export interface ClampedTextProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The long text to clamp. */
+  text: string;
+  /** Lines visible while collapsed (2–8, default 6). */
+  lines?: 2 | 3 | 4 | 5 | 6 | 8;
+  /** Skip the clamp entirely below this character count (default 280). */
+  threshold?: number;
+  /** Toggle labels, overridable for i18n. */
+  showMoreLabel?: string;
+  showLessLabel?: string;
+  /**
+   * Gradient start for the fade at the clamp edge — match it to the
+   * surface behind the text (default `from-card`).
+   */
+  fadeClassName?: string;
+}
+
+// Static map so Tailwind sees every clamp utility it must generate
+const LINE_CLAMP: Record<number, string> = {
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+  4: 'line-clamp-4',
+  5: 'line-clamp-5',
+  6: 'line-clamp-6',
+  8: 'line-clamp-8',
+};
+
+/**
+ * Clamps long text to N lines with a fade-out gradient and a
+ * Show more / Show less toggle. Short text renders inline with no
+ * toggle, so brief values stay flat. Pure presentation — ideal for
+ * free-text fields (messages, notes, descriptions) inside detail
+ * panels and modals.
+ *
+ * @example
+ * ```tsx
+ * <ClampedText text={note.body} lines={4} />
+ * ```
+ */
+export const ClampedText = React.forwardRef<HTMLDivElement, ClampedTextProps>(
+  function ClampedText(
+    {
+      text,
+      lines = 6,
+      threshold = 280,
+      showMoreLabel = 'Show more',
+      showLessLabel = 'Show less',
+      fadeClassName = 'from-card',
+      className,
+      ...props
+    },
+    ref
+  ) {
+    const [open, setOpen] = React.useState(false);
+
+    if (text.length <= threshold) {
+      return (
+        <span className={cn('break-words whitespace-pre-wrap', className)}>
+          {text}
+        </span>
+      );
+    }
+
+    return (
+      <div ref={ref} className={className} {...props}>
+        <div
+          className={cn(
+            'relative break-words whitespace-pre-wrap',
+            !open && (LINE_CLAMP[lines] ?? 'line-clamp-6')
+          )}
+        >
+          {text}
+          {!open && (
+            <span
+              aria-hidden="true"
+              className={cn(
+                'pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t to-transparent',
+                fadeClassName
+              )}
+            />
+          )}
+        </div>
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpen((v) => !v);
+          }}
+          className="text-primary-600 dark:text-primary-400 mt-1 text-[11px] font-medium hover:underline"
+        >
+          {open ? showLessLabel : showMoreLabel}
+        </button>
+      </div>
+    );
+  }
+);

--- a/src/components/ClampedText/index.ts
+++ b/src/components/ClampedText/index.ts
@@ -1,0 +1,1 @@
+export { ClampedText, type ClampedTextProps } from './ClampedText';

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export * from './components/Checkbox';
 export * from './components/CodeLookup/context';
 export * from './components/ConditionEditor';
 export * from './components/CheckrIntegration';
+export * from './components/ClampedText';
 export * from './components/CollabStatus';
 export * from './components/Collapsible';
 export * from './components/CommandPalette';

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -125,6 +125,17 @@ module.exports = {
     'overflow-auto',
     // Select component
     'truncate',
+    // ClampedText — collapsed clamp levels and fade gradient
+    'line-clamp-2',
+    'line-clamp-3',
+    'line-clamp-4',
+    'line-clamp-5',
+    'line-clamp-6',
+    'line-clamp-7',
+    'line-clamp-8',
+    'bg-gradient-to-t',
+    'from-card',
+    'to-transparent',
   ],
   theme: {
     extend: {
@@ -234,6 +245,11 @@ module.exports = {
         'slide-in-from-bottom': 'slide-in-from-bottom 150ms ease-out',
         'scale-in': 'scale-in 150ms ease-out',
         'ozwell-message-flare': 'ozwell-message-flare 1.8s ease-out',
+      },
+      // ClampedText supports 7/8-line clamps beyond Tailwind 3's core 1–6 scale
+      lineClamp: {
+        7: '7',
+        8: '8',
       },
     },
   },

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -135,6 +135,7 @@ module.exports = {
     'line-clamp-8',
     'bg-gradient-to-t',
     'from-card',
+    'from-background',
     'to-transparent',
   ],
   theme: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -599,6 +599,17 @@ export const miewebUISafelist = [
   'dark:border-primary-800',
   'dark:text-primary-300',
   'opacity-60',
+  // ClampedText — collapsed clamp levels and fade gradient
+  'line-clamp-2',
+  'line-clamp-3',
+  'line-clamp-4',
+  'line-clamp-5',
+  'line-clamp-6',
+  'line-clamp-7',
+  'line-clamp-8',
+  'bg-gradient-to-t',
+  'from-card',
+  'to-transparent',
 ];
 
 export interface MiewebUIPreset {
@@ -826,6 +837,11 @@ export const miewebUIPreset: MiewebUIPreset = {
         'slide-in-left': 'slide-in-left 300ms ease-out',
         'scale-in': 'scale-in 150ms ease-out',
         'ozwell-message-flare': 'ozwell-message-flare 1.8s ease-out',
+      },
+      // ClampedText supports 7/8-line clamps beyond Tailwind 3's core 1–6 scale
+      lineClamp: {
+        7: '7',
+        8: '8',
       },
     },
   },

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -609,6 +609,7 @@ export const miewebUISafelist = [
   'line-clamp-8',
   'bg-gradient-to-t',
   'from-card',
+  'from-background',
   'to-transparent',
 ];
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     'components/Button/index': 'src/components/Button/index.ts',
     'components/Card/index': 'src/components/Card/index.ts',
     'components/Checkbox/index': 'src/components/Checkbox/index.ts',
+    'components/ClampedText/index': 'src/components/ClampedText/index.ts',
     'components/CollabStatus/index': 'src/components/CollabStatus/index.ts',
     'components/Collapsible/index': 'src/components/Collapsible/index.ts',
     'components/CountryCodeDropdown/index': 'src/components/CountryCodeDropdown/index.ts',


### PR DESCRIPTION
Ports waggleline's free-text clamp into the design system — long messages, notes, and descriptions collapse to N lines instead of pushing a detail panel's scroll a mile down.

## What it does

- Clamps to **2–8 lines** with a fade-out gradient at the clamp edge and a **Show more / Show less** toggle (`aria-expanded`)
- **Short text stays flat**: under the `threshold` character count (default 280) it renders inline with no toggle
- `fadeClassName` matches the fade to the surface behind the text (`from-card` default, `from-background` for page surfaces)
- Toggle labels overridable for i18n; toggle clicks stop propagation for use inside clickable containers

## Screenshots

A long call note clamped to four lines inside a card:

| Light | Dark |
|---|---|
| ![ClampedText light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr10-clamped-text-light.png) | ![ClampedText dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr10-clamped-text-dark.png) |

## Provenance

Port of `waggleline/app/imports/ui/components/ClampedText.tsx` (used by its form-details renderer for 2,000-character free-text fields); hardcoded gray/cyan → semantic tokens, static `line-clamp-*` map kept literal for Tailwind scanning.

## Testing

- 5 unit tests (short-text passthrough, clamp + toggle round-trip, custom threshold, i18n labels, fade class lifecycle)
- 3 stories (card usage, short text, page-background fade)
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 651/651