### PR TITLE
feat(KeyboardShortcutsOverlay): shortcuts help dialog + Kbd chip

### DIFF
--- a/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.stories.tsx
+++ b/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.stories.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../Button';
+import { Kbd, KeyboardShortcutsOverlay } from './KeyboardShortcutsOverlay';
+
+const meta: Meta<typeof KeyboardShortcutsOverlay> = {
+  title: 'Components/Overlays & Popups/KeyboardShortcutsOverlay',
+  component: KeyboardShortcutsOverlay,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The `?` keyboard-shortcuts help dialog: shortcut rows with `Kbd` chips, optionally ' +
+          'grouped into sections. Composes the library `Modal` (focus trap, Escape, overlay ' +
+          'click) and pairs with `useKeyboardShortcut`, which owns the actual bindings. The ' +
+          '`Kbd` chip is exported on its own for inline shortcut references in docs and menus.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    shortcuts: { description: 'Flat list of shortcuts.', control: false },
+    groups: {
+      description: 'Sectioned shortcuts with headings.',
+      control: false,
+    },
+    title: { description: 'Dialog heading.', control: 'text' },
+    hint: { description: 'Footer hint (null hides it).', control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const NAVIGATION = [
+  { keys: ['j', '↓'], description: 'Next record' },
+  { keys: ['k', '↑'], description: 'Previous record' },
+  { keys: 'Enter', description: 'Open selected record' },
+  { keys: 'Esc', description: 'Close panel' },
+];
+
+const ACTIONS = [
+  { keys: '⌘K', description: 'Command palette' },
+  { keys: 'c', description: 'Compose note' },
+  { keys: 'e / a', description: 'Archive record' },
+];
+
+export const Default: Story = {
+  render: (args) => <OverlayExample {...args} />,
+  args: { shortcuts: [...NAVIGATION, ...ACTIONS.slice(0, 1)] },
+};
+
+export const Grouped: Story = {
+  render: (args) => <OverlayExample {...args} />,
+  args: {
+    groups: [
+      { title: 'Navigation', shortcuts: NAVIGATION },
+      { title: 'Actions', shortcuts: ACTIONS },
+    ],
+  },
+};
+
+function OverlayExample(
+  args: React.ComponentProps<typeof KeyboardShortcutsOverlay>
+) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        Show shortcuts
+      </Button>
+      <KeyboardShortcutsOverlay
+        {...args}
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+export const KbdChip: Story = {
+  render: () => (
+    <p className="text-foreground text-sm">
+      Press <Kbd>⌘K</Kbd> to open the command palette, or <Kbd>?</Kbd> for help.
+    </p>
+  ),
+  parameters: {
+    docs: {
+      description: { story: 'The `Kbd` chip used inline in prose and menus.' },
+    },
+  },
+};

--- a/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.test.tsx
+++ b/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { Kbd, KeyboardShortcutsOverlay } from './KeyboardShortcutsOverlay';
+
+const SHORTCUTS = [
+  { keys: ['j', '↓'], description: 'Next record' },
+  { keys: '⌘K', description: 'Command palette' },
+];
+
+describe('Kbd', () => {
+  it('renders a kbd element', () => {
+    renderWithTheme(<Kbd>⌘K</Kbd>);
+    const kbd = screen.getByText('⌘K');
+    expect(kbd.tagName).toBe('KBD');
+  });
+});
+
+describe('KeyboardShortcutsOverlay', () => {
+  it('renders nothing while closed', () => {
+    renderWithTheme(
+      <KeyboardShortcutsOverlay
+        open={false}
+        onClose={() => {}}
+        shortcuts={SHORTCUTS}
+      />
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('lists shortcuts with key chips and alternatives', () => {
+    renderWithTheme(
+      <KeyboardShortcutsOverlay open onClose={() => {}} shortcuts={SHORTCUTS} />
+    );
+    expect(
+      screen.getByRole('dialog', { name: 'Keyboard shortcuts' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Next record')).toBeInTheDocument();
+    expect(screen.getByText('j')).toBeInTheDocument();
+    expect(screen.getByText('↓')).toBeInTheDocument();
+    expect(screen.getByText('or')).toBeInTheDocument();
+    expect(screen.getByText('⌘K')).toBeInTheDocument();
+  });
+
+  it('splits legacy "a / b" key strings into chips', () => {
+    renderWithTheme(
+      <KeyboardShortcutsOverlay
+        open
+        onClose={() => {}}
+        shortcuts={[{ keys: 'e / a', description: 'Archive' }]}
+      />
+    );
+    expect(screen.getByText('e')).toBeInTheDocument();
+    expect(screen.getByText('a')).toBeInTheDocument();
+  });
+
+  it('renders grouped sections with headings', () => {
+    renderWithTheme(
+      <KeyboardShortcutsOverlay
+        open
+        onClose={() => {}}
+        groups={[
+          { title: 'Navigation', shortcuts: [SHORTCUTS[0]] },
+          { title: 'Actions', shortcuts: [SHORTCUTS[1]] },
+        ]}
+      />
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Navigation', level: 3 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Actions', level: 3 })
+    ).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    renderWithTheme(
+      <KeyboardShortcutsOverlay open onClose={onClose} shortcuts={SHORTCUTS} />
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the default hint and can hide it', () => {
+    const { rerender } = renderWithTheme(
+      <KeyboardShortcutsOverlay open onClose={() => {}} shortcuts={SHORTCUTS} />
+    );
+    expect(
+      screen.getByText(/anytime to toggle this help/i)
+    ).toBeInTheDocument();
+
+    rerender(
+      <KeyboardShortcutsOverlay
+        open
+        onClose={() => {}}
+        shortcuts={SHORTCUTS}
+        hint={null}
+      />
+    );
+    expect(
+      screen.queryByText(/anytime to toggle this help/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import * as React from 'react';
+import { Keyboard } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalClose,
+  ModalBody,
+  ModalFooter,
+} from '../Modal';
+
+// =============================================================================
+// Kbd
+// =============================================================================
+
+export type KbdProps = React.HTMLAttributes<HTMLElement>;
+
+/** A keyboard-key chip: `<Kbd>⌘K</Kbd>`. */
+export const Kbd = React.forwardRef<HTMLElement, KbdProps>(function Kbd(
+  { className, ...props },
+  ref
+) {
+  return (
+    <kbd
+      ref={ref}
+      className={cn(
+        'border-border bg-muted text-foreground rounded border px-1.5 py-0.5 font-mono text-[11px]',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+// =============================================================================
+// KeyboardShortcutsOverlay
+// =============================================================================
+
+export interface ShortcutDef {
+  /** Key or alternatives — `"j"`, `["j", "↓"]`, `"⌘K"`. */
+  keys: string | string[];
+  description: string;
+}
+
+export interface ShortcutGroup {
+  title: string;
+  shortcuts: ShortcutDef[];
+}
+
+export interface KeyboardShortcutsOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  /** Flat list of shortcuts, or use `groups` for sectioned help. */
+  shortcuts?: ShortcutDef[];
+  /** Sectioned shortcuts with group headings. */
+  groups?: ShortcutGroup[];
+  title?: string;
+  /** Footer hint. Pass `null` to hide it. */
+  hint?: React.ReactNode | null;
+  /** Joins key alternatives (default "or"), overridable for i18n. */
+  alternativesLabel?: string;
+}
+
+function Keys({
+  keys,
+  alternativesLabel,
+}: {
+  keys: string | string[];
+  alternativesLabel: string;
+}) {
+  const list = Array.isArray(keys) ? keys : keys.split(' / ');
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {list.map((k, i) => (
+        <React.Fragment key={`${k}-${i}`}>
+          <Kbd>{k}</Kbd>
+          {i < list.length - 1 && (
+            <span className="text-muted-foreground mx-0.5 text-xs">
+              {alternativesLabel}
+            </span>
+          )}
+        </React.Fragment>
+      ))}
+    </span>
+  );
+}
+
+function ShortcutList({
+  shortcuts,
+  alternativesLabel,
+}: {
+  shortcuts: ShortcutDef[];
+  alternativesLabel: string;
+}) {
+  return (
+    <ul className="flex list-none flex-col gap-2 p-0">
+      {shortcuts.map((s) => (
+        <li
+          key={`${s.description}-${String(s.keys)}`}
+          className="text-foreground flex items-center justify-between gap-4 text-sm"
+        >
+          <span className="min-w-0">{s.description}</span>
+          <Keys keys={s.keys} alternativesLabel={alternativesLabel} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The `?` keyboard-shortcuts help dialog: a list of shortcut rows
+ * (optionally grouped) with `Kbd` chips for each key. Pairs with the
+ * `useKeyboardShortcut` hook, which handles the binding — this component
+ * only renders the help.
+ *
+ * @example
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ * useKeyboardShortcut({ key: '?', shift: true }, () => setOpen((v) => !v));
+ *
+ * <KeyboardShortcutsOverlay
+ *   open={open}
+ *   onClose={() => setOpen(false)}
+ *   shortcuts={[
+ *     { keys: ['j', '↓'], description: 'Next record' },
+ *     { keys: '⌘K', description: 'Command palette' },
+ *   ]}
+ * />
+ * ```
+ */
+export function KeyboardShortcutsOverlay({
+  open,
+  onClose,
+  shortcuts,
+  groups,
+  title = 'Keyboard shortcuts',
+  hint,
+  alternativesLabel = 'or',
+}: KeyboardShortcutsOverlayProps) {
+  const defaultHint = (
+    <>
+      Press <Kbd>?</Kbd> anytime to toggle this help
+    </>
+  );
+  const footer = hint === null ? null : (hint ?? defaultHint);
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+      size="sm"
+      aria-label={title}
+    >
+      <ModalHeader>
+        <ModalTitle className="flex items-center gap-2 text-sm">
+          <Keyboard aria-hidden="true" className="text-primary-500 h-4 w-4" />
+          {title}
+        </ModalTitle>
+        <ModalClose />
+      </ModalHeader>
+      <ModalBody className="flex flex-col gap-4">
+        {shortcuts && (
+          <ShortcutList
+            shortcuts={shortcuts}
+            alternativesLabel={alternativesLabel}
+          />
+        )}
+        {groups?.map((group) => (
+          <div key={group.title} className="flex flex-col gap-2">
+            <h3 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+              {group.title}
+            </h3>
+            <ShortcutList
+              shortcuts={group.shortcuts}
+              alternativesLabel={alternativesLabel}
+            />
+          </div>
+        ))}
+      </ModalBody>
+      {footer && (
+        <ModalFooter className="text-muted-foreground justify-center text-[11px]">
+          <span>{footer}</span>
+        </ModalFooter>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcutsOverlay/KeyboardShortcutsOverlay.tsx
@@ -119,7 +119,9 @@ function ShortcutList({
  * @example
  * ```tsx
  * const [open, setOpen] = useState(false);
- * useKeyboardShortcut({ key: '?', shift: true }, () => setOpen((v) => !v));
+ * useKeyboardShortcut('?', () => setOpen((v) => !v), {
+ *   modifiers: { shift: true },
+ * });
  *
  * <KeyboardShortcutsOverlay
  *   open={open}

--- a/src/components/KeyboardShortcutsOverlay/index.ts
+++ b/src/components/KeyboardShortcutsOverlay/index.ts
@@ -1,0 +1,8 @@
+export {
+  Kbd,
+  KeyboardShortcutsOverlay,
+  type KbdProps,
+  type KeyboardShortcutsOverlayProps,
+  type ShortcutDef,
+  type ShortcutGroup,
+} from './KeyboardShortcutsOverlay';

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export * from './components/InventoryManager';
 export * from './components/Label';
 export * from './components/InviteUserModal';
 export * from './components/InvoiceList';
+export * from './components/KeyboardShortcutsOverlay';
 export * from './components/InvoicePaymentPage';
 // InvoiceView exports InvoiceLineItem which conflicts with InvoicePaymentPage
 export { InvoiceView, type InvoiceViewProps } from './components/InvoiceView';

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -125,6 +125,12 @@ module.exports = {
     'overflow-auto',
     // Select component
     'truncate',
+    // Kbd / KeyboardShortcutsOverlay — key chips and shortcut rows
+    'px-1.5',
+    'py-0.5',
+    'font-mono',
+    'text-[11px]',
+    'min-w-0',
   ],
   theme: {
     extend: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -599,6 +599,12 @@ export const miewebUISafelist = [
   'dark:border-primary-800',
   'dark:text-primary-300',
   'opacity-60',
+  // Kbd / KeyboardShortcutsOverlay — key chips and shortcut rows
+  'px-1.5',
+  'py-0.5',
+  'font-mono',
+  'text-[11px]',
+  'min-w-0',
 ];
 
 export interface MiewebUIPreset {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
     'components/Dropdown/index': 'src/components/Dropdown/index.ts',
     'components/FloatingWindow/index': 'src/components/FloatingWindow/index.ts',
     'components/Input/index': 'src/components/Input/index.ts',
+    'components/KeyboardShortcutsOverlay/index':
+      'src/components/KeyboardShortcutsOverlay/index.ts',
     'components/Label/index': 'src/components/Label/index.ts',
     'components/Markdown/index': 'src/components/Markdown/index.ts',
     'components/MediaEditor/index': 'src/components/MediaEditor/index.ts',


### PR DESCRIPTION
Ports waggleline's `?` shortcuts help modal into the design system, recomposed on the library `Modal`, and exports the `Kbd` chip as its own primitive.

## What it does

- **`KeyboardShortcutsOverlay`** — shortcut rows with key chips, either a flat `shortcuts` list or `groups` with section headings; footer hint (default "Press ? anytime…", `hint={null}` hides it)
- **`Kbd`** — the keyboard-key chip, exported standalone for inline shortcut references in prose, menus, and docs
- Key alternatives (`keys: ['j', '↓']` or legacy `"e / a"` strings) render as chips joined by an i18n-able "or"
- Composes the library **`Modal`** — focus trap, Escape, overlay click, and consistent chrome for free — and pairs with the existing `useKeyboardShortcut` hook, which owns the actual bindings

## Screenshots

Grouped sections with key chips:

| Light | Dark |
|---|---|
| ![KeyboardShortcutsOverlay light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr11-keyboard-shortcuts-light.png) | ![KeyboardShortcutsOverlay dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr11-keyboard-shortcuts-dark.png) |

## Provenance

Port of `waggleline/app/imports/ui/components/KeyboardShortcutsOverlay.tsx`; the hand-rolled fixed-position dialog becomes a `Modal` composition, FontAwesome → lucide `Keyboard`, purple accent → primary token, plus grouped sections.

## Testing

- 7 unit tests (closed renders nothing, chips + alternatives, legacy string splitting, grouped headings, Escape, hint default/hide, Kbd element)
- 3 stories (flat, grouped, inline Kbd chip)
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 651/651