### PR TITLE
feat(FilterSummaryBar): active-filter summary bar for data grids

### DIFF
--- a/src/components/FilterSummaryBar/FilterSummaryBar.stories.tsx
+++ b/src/components/FilterSummaryBar/FilterSummaryBar.stories.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../Button';
+import { FilterSummaryBar } from './FilterSummaryBar';
+
+const meta: Meta<typeof FilterSummaryBar> = {
+  title: 'Components/Data Display/FilterSummaryBar',
+  component: FilterSummaryBar,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The bar that anchors a filtered grid: "1,204 of 8,911 records — 3 filters active ' +
+          '· Clear all". Hidden while idle unless `showWhenIdle`; tinted with the primary ' +
+          'accent whenever filters or search narrow the view. All visible strings are ' +
+          'overridable for i18n.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    filteredCount: {
+      description: 'Rows visible after filtering.',
+      control: 'number',
+    },
+    totalCount: {
+      description: 'Total records before filtering.',
+      control: 'number',
+    },
+    activeFilterCount: {
+      description: 'Active filter conditions.',
+      control: 'number',
+    },
+    hasSearchText: {
+      description: 'Whether a search query is active.',
+      control: 'boolean',
+    },
+    showWhenIdle: {
+      description: 'Show even with nothing active.',
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    filteredCount: 1204,
+    totalCount: 8911,
+    activeFilterCount: 3,
+    onClearAll: () => {},
+  },
+};
+
+export const FiltersPlusSearch: Story = {
+  args: {
+    filteredCount: 42,
+    totalCount: 8911,
+    activeFilterCount: 2,
+    hasSearchText: true,
+    onClearAll: () => {},
+  },
+};
+
+export const SearchOnly: Story = {
+  args: {
+    filteredCount: 310,
+    totalCount: 8911,
+    activeFilterCount: 0,
+    hasSearchText: true,
+    onClearAll: () => {},
+  },
+};
+
+export const Idle: Story = {
+  args: {
+    filteredCount: 8911,
+    totalCount: 8911,
+    activeFilterCount: 0,
+    showWhenIdle: true,
+    onClearAll: () => {},
+  },
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveExample />,
+};
+
+function InteractiveExample() {
+  const [filters, setFilters] = useState(3);
+  const filtered = Math.max(120, 8911 - filters * 2600);
+  return (
+    <div className="flex flex-col gap-3">
+      <FilterSummaryBar
+        filteredCount={filters > 0 ? filtered : 8911}
+        totalCount={8911}
+        activeFilterCount={filters}
+        showWhenIdle
+        onClearAll={() => setFilters(0)}
+      />
+      <Button
+        variant="outline"
+        size="sm"
+        className="self-start"
+        onClick={() => setFilters((f) => f + 1)}
+      >
+        Add a filter
+      </Button>
+    </div>
+  );
+}

--- a/src/components/FilterSummaryBar/FilterSummaryBar.test.tsx
+++ b/src/components/FilterSummaryBar/FilterSummaryBar.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { FilterSummaryBar } from './FilterSummaryBar';
+
+describe('FilterSummaryBar', () => {
+  it('hides while idle by default', () => {
+    renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={100}
+        totalCount={100}
+        activeFilterCount={0}
+        onClearAll={() => {}}
+      />
+    );
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('shows idle summary with showWhenIdle', () => {
+    renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={100}
+        totalCount={100}
+        activeFilterCount={0}
+        showWhenIdle
+        onClearAll={() => {}}
+      />
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('all records visible');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('summarizes counts and pluralizes filters', () => {
+    renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={1204}
+        totalCount={8911}
+        activeFilterCount={3}
+        onClearAll={() => {}}
+      />
+    );
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('1,204 of 8,911 records');
+    expect(status).toHaveTextContent('3 filters active');
+  });
+
+  it('uses the singular filter label', () => {
+    renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={10}
+        activeFilterCount={1}
+        onClearAll={() => {}}
+      />
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('1 filter active');
+  });
+
+  it('describes search-only and search+filters states', () => {
+    const { rerender } = renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={310}
+        activeFilterCount={0}
+        hasSearchText
+        onClearAll={() => {}}
+      />
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('search active');
+
+    rerender(
+      <FilterSummaryBar
+        filteredCount={42}
+        activeFilterCount={2}
+        hasSearchText
+        onClearAll={() => {}}
+      />
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '2 filters active + search'
+    );
+  });
+
+  it('clears all filters', () => {
+    const onClearAll = vi.fn();
+    renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={10}
+        activeFilterCount={2}
+        onClearAll={onClearAll}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+    expect(onClearAll).toHaveBeenCalled();
+  });
+
+  it('supports i18n label overrides', () => {
+    renderWithTheme(
+      <FilterSummaryBar
+        filteredCount={5}
+        activeFilterCount={1}
+        onClearAll={() => {}}
+        recordsLabel="contacts"
+        filterLabel="condition"
+        clearLabel="Reset"
+      />
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('5 contacts');
+    expect(screen.getByRole('status')).toHaveTextContent('1 condition active');
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/FilterSummaryBar/FilterSummaryBar.tsx
+++ b/src/components/FilterSummaryBar/FilterSummaryBar.tsx
@@ -25,6 +25,10 @@ export interface FilterSummaryBarProps extends React.HTMLAttributes<HTMLDivEleme
   searchActiveLabel?: string;
   allVisibleLabel?: string;
   clearLabel?: string;
+  /** Joiner between filtered and total counts (default "of"). */
+  ofLabel?: string;
+  /** Suffix appended when search narrows on top of filters (default "+ search"). */
+  plusSearchLabel?: string;
 }
 
 /**
@@ -63,6 +67,8 @@ export const FilterSummaryBar = React.forwardRef<
     searchActiveLabel = 'search active',
     allVisibleLabel = 'all records visible',
     clearLabel = 'Clear all',
+    ofLabel = 'of',
+    plusSearchLabel = '+ search',
     className,
     ...props
   },
@@ -102,7 +108,7 @@ export const FilterSummaryBar = React.forwardRef<
         {totalCount ? (
           <>
             {' '}
-            of{' '}
+            {ofLabel}{' '}
             <span className="font-semibold">{totalCount.toLocaleString()}</span>
           </>
         ) : null}{' '}
@@ -121,7 +127,7 @@ export const FilterSummaryBar = React.forwardRef<
         {hasSearchText && activeFilterCount === 0 && (
           <> &mdash; {searchActiveLabel}</>
         )}
-        {hasSearchText && activeFilterCount > 0 && <> + search</>}
+        {hasSearchText && activeFilterCount > 0 && <> {plusSearchLabel}</>}
         {!isFiltering && showWhenIdle && <> &mdash; {allVisibleLabel}</>}
       </span>
       {isFiltering && (

--- a/src/components/FilterSummaryBar/FilterSummaryBar.tsx
+++ b/src/components/FilterSummaryBar/FilterSummaryBar.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import * as React from 'react';
+import { Filter, X } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+export interface FilterSummaryBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Rows currently visible after filtering. */
+  filteredCount: number;
+  /** Total records before filtering. Omit (or pass 0) when unknown. */
+  totalCount?: number;
+  /** Number of active filter conditions. */
+  activeFilterCount: number;
+  /** Whether a search query is also active. */
+  hasSearchText?: boolean;
+  /** Keep the summary visible even when no filters/search are active. */
+  showWhenIdle?: boolean;
+  /** Called when the clear action is clicked. */
+  onClearAll: () => void;
+  /** Visible strings, overridable for i18n. */
+  recordsLabel?: string;
+  filterLabel?: string;
+  filtersLabel?: string;
+  activeLabel?: string;
+  searchActiveLabel?: string;
+  allVisibleLabel?: string;
+  clearLabel?: string;
+}
+
+/**
+ * The bar that anchors a filtered grid: "1,204 of 8,911 records — 3
+ * filters active · Clear all". Hidden while idle unless `showWhenIdle`,
+ * and tinted with the primary accent whenever filters or search narrow
+ * the view. Pair with any data grid or list whose filter state lives in
+ * the host.
+ *
+ * @example
+ * ```tsx
+ * <FilterSummaryBar
+ *   filteredCount={rows.length}
+ *   totalCount={total}
+ *   activeFilterCount={filters.length}
+ *   hasSearchText={query.length > 0}
+ *   onClearAll={resetFilters}
+ * />
+ * ```
+ */
+export const FilterSummaryBar = React.forwardRef<
+  HTMLDivElement,
+  FilterSummaryBarProps
+>(function FilterSummaryBar(
+  {
+    filteredCount,
+    totalCount,
+    activeFilterCount,
+    hasSearchText = false,
+    showWhenIdle = false,
+    onClearAll,
+    recordsLabel = 'records',
+    filterLabel = 'filter',
+    filtersLabel = 'filters',
+    activeLabel = 'active',
+    searchActiveLabel = 'search active',
+    allVisibleLabel = 'all records visible',
+    clearLabel = 'Clear all',
+    className,
+    ...props
+  },
+  ref
+) {
+  const isFiltering = activeFilterCount > 0 || hasSearchText;
+  if (!isFiltering && !showWhenIdle) return null;
+
+  return (
+    <div
+      ref={ref}
+      role="status"
+      className={cn(
+        'flex items-center gap-3 rounded-lg border px-4 py-2 text-xs transition-colors',
+        isFiltering
+          ? 'border-primary-300 bg-primary-500/10 dark:border-primary-700'
+          : 'border-border bg-muted/60',
+        className
+      )}
+      {...props}
+    >
+      <Filter
+        aria-hidden="true"
+        className={cn(
+          'h-3 w-3 shrink-0',
+          isFiltering ? 'text-primary-500' : 'text-muted-foreground'
+        )}
+      />
+      <span
+        className={cn(
+          isFiltering
+            ? 'text-primary-800 dark:text-primary-200'
+            : 'text-muted-foreground'
+        )}
+      >
+        <span className="font-semibold">{filteredCount.toLocaleString()}</span>
+        {totalCount ? (
+          <>
+            {' '}
+            of{' '}
+            <span className="font-semibold">{totalCount.toLocaleString()}</span>
+          </>
+        ) : null}{' '}
+        {recordsLabel}
+        {activeFilterCount > 0 && (
+          <>
+            {' '}
+            &mdash;{' '}
+            <span className="font-semibold">
+              {activeFilterCount}{' '}
+              {activeFilterCount === 1 ? filterLabel : filtersLabel}
+            </span>{' '}
+            {activeLabel}
+          </>
+        )}
+        {hasSearchText && activeFilterCount === 0 && (
+          <> &mdash; {searchActiveLabel}</>
+        )}
+        {hasSearchText && activeFilterCount > 0 && <> + search</>}
+        {!isFiltering && showWhenIdle && <> &mdash; {allVisibleLabel}</>}
+      </span>
+      {isFiltering && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className={cn(
+            'ms-auto flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+            'text-primary-700 hover:bg-primary-500/15 dark:text-primary-300'
+          )}
+        >
+          <X aria-hidden="true" className="h-2.5 w-2.5" />
+          {clearLabel}
+        </button>
+      )}
+    </div>
+  );
+});

--- a/src/components/FilterSummaryBar/index.ts
+++ b/src/components/FilterSummaryBar/index.ts
@@ -1,0 +1,4 @@
+export {
+  FilterSummaryBar,
+  type FilterSummaryBarProps,
+} from './FilterSummaryBar';

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export * from './components/EmployerView';
 export * from './components/EmployerServiceModal';
 export * from './components/ErrorPage';
 export * from './components/FileManager';
+export * from './components/FilterSummaryBar';
 export * from './components/FloatingWindow';
 export * from './components/HealthSurveillance';
 export * from './components/HelpSupportPanel';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
     'components/CountryCodeDropdown/index': 'src/components/CountryCodeDropdown/index.ts',
     'components/DateInput/index': 'src/components/DateInput/index.ts',
     'components/Dropdown/index': 'src/components/Dropdown/index.ts',
+    'components/FilterSummaryBar/index':
+      'src/components/FilterSummaryBar/index.ts',
     'components/FloatingWindow/index': 'src/components/FloatingWindow/index.ts',
     'components/Input/index': 'src/components/Input/index.ts',
     'components/Label/index': 'src/components/Label/index.ts',


### PR DESCRIPTION
Ports the bar that anchors every filtered waggleline grid into the design system: "**1,204** of **8,911** records — **3 filters** active · Clear all".

## What it does

- Summarizes `filteredCount` / `totalCount` / `activeFilterCount` with correct pluralization, plus search-only and filters-plus-search states
- **Hidden while idle** unless `showWhenIdle` (then reads "all records visible" with no clear action)
- Tinted with the primary accent whenever the view is narrowed; `role="status"` announces changes to assistive tech
- Every visible string overridable for i18n (`recordsLabel`, `filterLabel`/`filtersLabel`, `clearLabel`, …)
- Framework-agnostic: filter state lives in the host — pairs with AG Grid, DataVis, or any list

## Screenshots

| Light | Dark |
|---|---|
| ![FilterSummaryBar light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr12-filter-summary-bar-light.png) | ![FilterSummaryBar dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr12-filter-summary-bar-dark.png) |

## Provenance

Port of `waggleline/app/imports/ui/components/filters/FilterSummaryBar.tsx` (used across its AG Grid pages); teal hardcodes → primary tokens, FontAwesome → lucide `Filter`/`X`, `ml-auto` → logical `ms-auto`.

## Testing

- 7 unit tests (idle hide/show, count formatting + pluralization, search states, clear action, i18n overrides)
- 5 stories incl. an interactive add-a-filter demo
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 651/651