### PR TITLE
feat(Sparkline): compact activity bar sparkline

### DIFF
--- a/src/components/Sparkline/Sparkline.stories.tsx
+++ b/src/components/Sparkline/Sparkline.stories.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DateTime } from 'luxon';
+import { Sparkline, type SparklinePoint } from './Sparkline';
+
+// Deterministic pseudo-random activity so visual baselines stay stable
+function thirtyDays(seed = 7): SparklinePoint[] {
+  let s = seed;
+  const rand = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  return Array.from({ length: 30 }, (_, i) => {
+    const d = DateTime.now().minus({ days: 29 - i });
+    const quiet = rand() < 0.3;
+    return {
+      key: d.toISODate()!,
+      label: d.toFormat('MMM d'),
+      value: quiet ? 0 : Math.ceil(rand() * 12),
+    };
+  });
+}
+
+const meta: Meta<typeof Sparkline> = {
+  title: 'Components/Data Display/Sparkline',
+  component: Sparkline,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A compact bar sparkline for activity-over-time strips. Bars scale to the series ' +
+          'maximum with a baseline stub for zero values; with `onSelect`, bars become toggle ' +
+          'buttons for filtering to one bucket. Data arrives pre-bucketed — the host owns ' +
+          'date math — keeping the component pure. For full charting, use DataVis.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    data: {
+      description: 'Pre-bucketed points in display order.',
+      control: false,
+    },
+    selectedKey: { description: 'Highlighted point key.', control: false },
+    onSelect: { description: 'Makes bars clickable toggles.', control: false },
+    label: { description: 'Track label before the bars.', control: 'text' },
+    height: { description: 'Bar track height in px.', control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { data: thirtyDays(), label: 'All activity' },
+};
+
+export const Selectable: Story = {
+  render: (args) => <SelectableExample {...args} />,
+  args: { data: thirtyDays(11), label: 'Calls' },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Click a bar to filter to that day; click again to clear.',
+      },
+    },
+  },
+};
+
+function SelectableExample(args: React.ComponentProps<typeof Sparkline>) {
+  const [day, setDay] = useState<string | null>(null);
+  return (
+    <div className="flex flex-col gap-2">
+      <Sparkline {...args} selectedKey={day} onSelect={setDay} />
+      <p className="text-muted-foreground text-xs">
+        {day ? `Filtered to ${day}` : 'Showing all days'}
+      </p>
+    </div>
+  );
+}
+
+export const MultipleTracks: Story = {
+  render: () => (
+    <div className="border-border bg-card flex w-[36rem] flex-col gap-3 rounded-lg border p-4">
+      <Sparkline data={thirtyDays(3)} label="Calls" height={24} />
+      <Sparkline data={thirtyDays(19)} label="Emails" height={24} />
+      <Sparkline data={thirtyDays(42)} label="Meetings" height={24} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Stacked read-only tracks make a compact activity overview.',
+      },
+    },
+  },
+};

--- a/src/components/Sparkline/Sparkline.stories.tsx
+++ b/src/components/Sparkline/Sparkline.stories.tsx
@@ -3,7 +3,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DateTime } from 'luxon';
 import { Sparkline, type SparklinePoint } from './Sparkline';
 
-// Deterministic pseudo-random activity so visual baselines stay stable
+// Deterministic pseudo-random activity so visual baselines stay stable —
+// values AND dates are fixed (anchored, not DateTime.now()) so labels and
+// keys never drift between snapshot runs.
+const ANCHOR = DateTime.fromISO('2026-08-22');
+
 function thirtyDays(seed = 7): SparklinePoint[] {
   let s = seed;
   const rand = () => {
@@ -11,7 +15,7 @@ function thirtyDays(seed = 7): SparklinePoint[] {
     return s / 2147483647;
   };
   return Array.from({ length: 30 }, (_, i) => {
-    const d = DateTime.now().minus({ days: 29 - i });
+    const d = ANCHOR.minus({ days: 29 - i });
     const quiet = rand() < 0.3;
     return {
       key: d.toISODate()!,

--- a/src/components/Sparkline/Sparkline.test.tsx
+++ b/src/components/Sparkline/Sparkline.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithTheme } from '../../test/test-utils';
+import { Sparkline, type SparklinePoint } from './Sparkline';
+
+const DATA: SparklinePoint[] = [
+  { key: '2026-08-20', label: 'Aug 20', value: 4 },
+  { key: '2026-08-21', label: 'Aug 21', value: 0 },
+  { key: '2026-08-22', label: 'Aug 22', value: 12 },
+];
+
+describe('Sparkline', () => {
+  it('renders read-only bars with accessible names', () => {
+    renderWithTheme(<Sparkline data={DATA} />);
+    expect(
+      screen.getByRole('group', { name: 'Activity over time' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'Aug 22 — 12' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('scales bars to the series maximum with a stub for zero', () => {
+    renderWithTheme(<Sparkline data={DATA} />);
+    expect(screen.getByRole('img', { name: 'Aug 22 — 12' })).toHaveStyle({
+      height: '100%',
+    });
+    expect(screen.getByRole('img', { name: 'Aug 21 — 0' })).toHaveStyle({
+      height: '6%',
+    });
+    // 4/12 = 33%
+    expect(screen.getByRole('img', { name: 'Aug 20 — 4' })).toHaveStyle({
+      height: '33%',
+    });
+  });
+
+  it('toggles selection when interactive', () => {
+    const onSelect = vi.fn();
+    renderWithTheme(
+      <Sparkline data={DATA} selectedKey="2026-08-22" onSelect={onSelect} />
+    );
+    const selected = screen.getByRole('button', { name: 'Aug 22 — 12' });
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(selected);
+    expect(onSelect).toHaveBeenCalledWith(null);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Aug 20 — 4' }));
+    expect(onSelect).toHaveBeenCalledWith('2026-08-20');
+  });
+
+  it('renders the track label', () => {
+    renderWithTheme(<Sparkline data={DATA} label="Calls" />);
+    expect(screen.getByText('Calls')).toBeInTheDocument();
+  });
+
+  it('formats values for accessible names', () => {
+    renderWithTheme(
+      <Sparkline data={DATA} formatValue={(p) => `${p.value} events`} />
+    );
+    expect(
+      screen.getByRole('img', { name: 'Aug 22 — 12 events' })
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the key when label is omitted', () => {
+    renderWithTheme(<Sparkline data={[{ key: 'wk-34', value: 2 }]} />);
+    expect(screen.getByRole('img', { name: 'wk-34 — 2' })).toBeInTheDocument();
+  });
+});

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -129,7 +129,10 @@ export const Sparkline = React.forwardRef<HTMLDivElement, SparklineProps>(
                 aria-pressed={isSelected}
                 title={title}
                 aria-label={title}
-                className={cn(barClasses, 'cursor-pointer')}
+                className={cn(
+                  barClasses,
+                  'focus-visible:ring-ring cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none'
+                )}
                 style={{ height: `${heightPct}%` }}
               />
             ) : (

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SparklinePoint {
+  /** Stable key for selection (e.g. a day key like "2026-08-22"). */
+  key: string;
+  /** Human label for tooltips and accessible names (defaults to key). */
+  label?: string;
+  value: number;
+}
+
+export interface SparklineProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  /** Pre-bucketed points in display order (e.g. one per day). */
+  data: SparklinePoint[];
+  /** Selected point key — that bar is highlighted. */
+  selectedKey?: string | null;
+  /**
+   * Makes bars clickable; clicking the selected bar reports `null`
+   * (deselect). Omit for a read-only sparkline.
+   */
+  onSelect?: (key: string | null) => void;
+  /** Track label rendered before the bars (e.g. "All activity"). */
+  label?: string;
+  /** Accessible name for the bar group (default "Activity over time"). */
+  ariaLabel?: string;
+  /** Bar track height in px (default 32). */
+  height?: number;
+  /** Formats the value for tooltips/accessible names (default `String`). */
+  formatValue?: (point: SparklinePoint) => string;
+}
+
+// =============================================================================
+// Sparkline
+// =============================================================================
+
+/**
+ * A compact bar sparkline for activity-over-time strips — timelines,
+ * table rows, dashboard headers. Bars scale to the series maximum;
+ * zero-value bars render as a low baseline stub. With `onSelect`, bars
+ * become toggle buttons for filtering the view to one bucket.
+ *
+ * Data arrives pre-bucketed (the host owns date math), keeping the
+ * component pure. For full charting, reach for DataVis instead.
+ *
+ * @example
+ * ```tsx
+ * <Sparkline
+ *   label="All activity"
+ *   data={days.map((d) => ({ key: d.iso, label: d.pretty, value: d.count }))}
+ *   selectedKey={day}
+ *   onSelect={setDay}
+ * />
+ * ```
+ */
+export const Sparkline = React.forwardRef<HTMLDivElement, SparklineProps>(
+  function Sparkline(
+    {
+      data,
+      selectedKey,
+      onSelect,
+      label,
+      ariaLabel = 'Activity over time',
+      height = 32,
+      formatValue,
+      className,
+      ...props
+    },
+    ref
+  ) {
+    const max = React.useMemo(
+      () => Math.max(1, ...data.map((d) => d.value)),
+      [data]
+    );
+
+    const interactive = Boolean(onSelect);
+
+    return (
+      <div
+        ref={ref}
+        className={cn('flex items-end gap-3', className)}
+        {...props}
+      >
+        {label && (
+          <span className="text-muted-foreground w-16 shrink-0 pb-0.5 text-[10px] leading-tight font-medium tracking-wider uppercase">
+            {label}
+          </span>
+        )}
+        <div
+          className="flex flex-1 items-end gap-[2px]"
+          style={{ height }}
+          role="group"
+          aria-label={ariaLabel}
+        >
+          {data.map((point) => {
+            const heightPct =
+              point.value === 0
+                ? 6
+                : Math.max(12, Math.round((point.value / max) * 100));
+            const isSelected = selectedKey === point.key;
+            const display = point.label ?? point.key;
+            const valueText = formatValue
+              ? formatValue(point)
+              : String(point.value);
+            const title = `${display} — ${valueText}`;
+
+            const barClasses = cn(
+              'min-w-[3px] flex-1 rounded-sm transition-colors',
+              isSelected
+                ? 'bg-primary-500 hover:bg-primary-500/90'
+                : point.value > 0
+                  ? 'bg-primary-500/40 hover:bg-primary-500/70'
+                  : 'bg-muted hover:bg-muted-foreground/20'
+            );
+
+            return interactive ? (
+              <button
+                key={point.key}
+                type="button"
+                onClick={() => onSelect?.(isSelected ? null : point.key)}
+                aria-pressed={isSelected}
+                title={title}
+                aria-label={title}
+                className={cn(barClasses, 'cursor-pointer')}
+                style={{ height: `${heightPct}%` }}
+              />
+            ) : (
+              <span
+                key={point.key}
+                role="img"
+                title={title}
+                aria-label={title}
+                className={barClasses}
+                style={{ height: `${heightPct}%` }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);

--- a/src/components/Sparkline/index.ts
+++ b/src/components/Sparkline/index.ts
@@ -1,0 +1,5 @@
+export {
+  Sparkline,
+  type SparklineProps,
+  type SparklinePoint,
+} from './Sparkline';

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,7 @@ export * from './components/ServicePricingManager';
 export * from './components/ServiceShippingSettings';
 export * from './components/Separator';
 export * from './components/Sheet';
+export * from './components/Sparkline';
 // SetupServiceModal exports ServiceCategory which conflicts with ServiceAccordion
 export {
   SetupServiceModal,

--- a/src/tailwind-preset.cjs
+++ b/src/tailwind-preset.cjs
@@ -125,6 +125,14 @@ module.exports = {
     'overflow-auto',
     // Select component
     'truncate',
+    // Sparkline — bar sizing, gaps, and hover tints
+    'min-w-[3px]',
+    'gap-[2px]',
+    'bg-primary-500/40',
+    'hover:bg-primary-500/70',
+    'hover:bg-primary-500/90',
+    'hover:bg-muted-foreground/20',
+    'focus-visible:ring-offset-1',
   ],
   theme: {
     extend: {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -599,14 +599,13 @@ export const miewebUISafelist = [
   'dark:border-primary-800',
   'dark:text-primary-300',
   'opacity-60',
-  // Sparkline — bar sizing, gaps, and hover tints
+  // Sparkline — bar sizing, gaps, and hover tints (bg-primary-500/40 and
+  // focus-visible:ring-offset-1 are already safelisted above)
   'min-w-[3px]',
   'gap-[2px]',
-  'bg-primary-500/40',
   'hover:bg-primary-500/70',
   'hover:bg-primary-500/90',
   'hover:bg-muted-foreground/20',
-  'focus-visible:ring-offset-1',
 ];
 
 export interface MiewebUIPreset {

--- a/src/tailwind-preset.ts
+++ b/src/tailwind-preset.ts
@@ -599,6 +599,14 @@ export const miewebUISafelist = [
   'dark:border-primary-800',
   'dark:text-primary-300',
   'opacity-60',
+  // Sparkline — bar sizing, gaps, and hover tints
+  'min-w-[3px]',
+  'gap-[2px]',
+  'bg-primary-500/40',
+  'hover:bg-primary-500/70',
+  'hover:bg-primary-500/90',
+  'hover:bg-muted-foreground/20',
+  'focus-visible:ring-offset-1',
 ];
 
 export interface MiewebUIPreset {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
     'components/Sheet/index': 'src/components/Sheet/index.ts',
     'components/Skeleton/index': 'src/components/Skeleton/index.ts',
     'components/Slider/index': 'src/components/Slider/index.ts',
+    'components/Sparkline/index': 'src/components/Sparkline/index.ts',
     'components/Spinner/index': 'src/components/Spinner/index.ts',
     'components/SuperChat/index': 'src/components/SuperChat/index.ts',
     'components/SuperChat/plugins/index': 'src/components/SuperChat/plugins/index.ts',


### PR DESCRIPTION
Generalizes waggleline's activity-timeline sparkline into the design system's lightweight charting primitive — the "too small for DataVis" gap.

## What it does

- **Compact bar sparkline** for activity-over-time strips: bars scale to the series maximum, zero values render as a low baseline stub, tooltips + accessible names per bar (`formatValue` for units)
- **Optional selection**: with `onSelect`, bars become `aria-pressed` toggle buttons for filtering the view to one bucket (click again to clear); omit it for a read-only strip
- **Pure by design**: data arrives pre-bucketed (`{ key, label?, value }[]`) — the host owns date math, so weeks/hours/anything works, not just days
- Track `label`, adjustable `height`, primary-token colors; stacked tracks make a compact multi-metric overview

## Screenshots

Stacked read-only tracks (Calls / Emails / Meetings, 30 days):

| Light | Dark |
|---|---|
| ![Sparkline light](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr13-sparkline-light.png) | ![Sparkline dark](https://raw.githubusercontent.com/mieweb/ui/assets/pr-screenshots-2026-08/docs/pr-screenshots/pr13-sparkline-dark.png) |

## Provenance

Generalized from `waggleline/app/imports/ui/components/activity-timeline/TimelineSparkline.tsx`: the `TimelineItem` coupling and 30-day bucketing move to the host, brand-orange hardcodes become primary tokens, and the "hide when too little signal" heuristic is left to hosts (it was a product decision, not a component one).

## Testing

- 6 unit tests (read-only accessible names, max scaling + zero stubs, selection toggling with `aria-pressed`, track label, `formatValue`, key fallback)
- 3 stories (default, selectable filter demo, stacked tracks) with deterministic seeded data for stable visual baselines
- `typecheck` / `lint` / `format` / `rtl:scan` clean; combined batch suite 651/651